### PR TITLE
Refactor course content builder into card-based lesson workflow

### DIFF
--- a/src/app/api/admin/courses/[courseId]/modules/route.ts
+++ b/src/app/api/admin/courses/[courseId]/modules/route.ts
@@ -6,8 +6,24 @@ import { getSupabaseAdminClient } from "@/lib/supabase/server";
 
 const paramsSchema = z.object({ courseId: z.string().uuid() });
 
+const optionalDescriptorSchema = z
+  .string()
+  .trim()
+  .max(500)
+  .nullish()
+  .transform((value) => (value && value.length > 0 ? value : null));
+
+const optionalThumbnailSchema = z
+  .string()
+  .trim()
+  .max(2048)
+  .nullish()
+  .transform((value) => (value && value.length > 0 ? value : null));
+
 const createModuleSchema = z.object({
   title: z.string().min(1),
+  descriptor: optionalDescriptorSchema,
+  thumbnailUrl: optionalThumbnailSchema,
   sortOrder: z.number().int().min(0).default(0),
 });
 
@@ -22,9 +38,11 @@ export async function POST(req: Request, ctx: { params: Promise<{ courseId: stri
     .insert({
       course_id: courseId,
       title: payload.title,
+      descriptor: payload.descriptor,
+      thumbnail_url: payload.thumbnailUrl,
       sort_order: payload.sortOrder,
     })
-    .select("id,course_id,title,sort_order")
+    .select("id,course_id,title,descriptor,thumbnail_url,sort_order")
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/app/api/admin/lessons/[lessonId]/route.ts
+++ b/src/app/api/admin/lessons/[lessonId]/route.ts
@@ -6,8 +6,24 @@ import { getSupabaseAdminClient } from "@/lib/supabase/server";
 
 const paramsSchema = z.object({ lessonId: z.string().uuid() });
 
+const optionalDescriptorSchema = z
+  .string()
+  .trim()
+  .max(500)
+  .nullish()
+  .transform((value) => (value && value.length > 0 ? value : null));
+
+const optionalThumbnailSchema = z
+  .string()
+  .trim()
+  .max(2048)
+  .nullish()
+  .transform((value) => (value && value.length > 0 ? value : null));
+
 const updateLessonSchema = z.object({
   title: z.string().min(1),
+  descriptor: optionalDescriptorSchema,
+  thumbnailUrl: optionalThumbnailSchema,
   youtubeVideoId: z.string().min(1),
   sortOrder: z.number().int().min(0),
   passingScore: z.number().int().min(0).max(100),
@@ -23,12 +39,14 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ lessonId: str
     .from("lessons")
     .update({
       title: payload.title,
+      descriptor: payload.descriptor,
+      thumbnail_url: payload.thumbnailUrl,
       youtube_video_id: payload.youtubeVideoId,
       sort_order: payload.sortOrder,
       passing_score: payload.passingScore,
     })
     .eq("id", lessonId)
-    .select("id,module_id,title,youtube_video_id,sort_order,passing_score")
+    .select("id,module_id,title,descriptor,thumbnail_url,youtube_video_id,sort_order,passing_score")
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/app/api/admin/modules/[moduleId]/lessons/route.ts
+++ b/src/app/api/admin/modules/[moduleId]/lessons/route.ts
@@ -6,8 +6,24 @@ import { getSupabaseAdminClient } from "@/lib/supabase/server";
 
 const paramsSchema = z.object({ moduleId: z.string().uuid() });
 
+const optionalDescriptorSchema = z
+  .string()
+  .trim()
+  .max(500)
+  .nullish()
+  .transform((value) => (value && value.length > 0 ? value : null));
+
+const optionalThumbnailSchema = z
+  .string()
+  .trim()
+  .max(2048)
+  .nullish()
+  .transform((value) => (value && value.length > 0 ? value : null));
+
 const createLessonSchema = z.object({
   title: z.string().min(1),
+  descriptor: optionalDescriptorSchema,
+  thumbnailUrl: optionalThumbnailSchema,
   youtubeVideoId: z.string().min(1),
   sortOrder: z.number().int().min(0).default(0),
   passingScore: z.number().int().min(0).max(100).default(80),
@@ -24,11 +40,13 @@ export async function POST(req: Request, ctx: { params: Promise<{ moduleId: stri
     .insert({
       module_id: moduleId,
       title: payload.title,
+      descriptor: payload.descriptor,
+      thumbnail_url: payload.thumbnailUrl,
       youtube_video_id: payload.youtubeVideoId,
       sort_order: payload.sortOrder,
       passing_score: payload.passingScore,
     })
-    .select("id,module_id,title,youtube_video_id,sort_order,passing_score")
+    .select("id,module_id,title,descriptor,thumbnail_url,youtube_video_id,sort_order,passing_score")
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/app/api/admin/modules/[moduleId]/route.ts
+++ b/src/app/api/admin/modules/[moduleId]/route.ts
@@ -6,8 +6,24 @@ import { getSupabaseAdminClient } from "@/lib/supabase/server";
 
 const paramsSchema = z.object({ moduleId: z.string().uuid() });
 
+const optionalDescriptorSchema = z
+  .string()
+  .trim()
+  .max(500)
+  .nullish()
+  .transform((value) => (value && value.length > 0 ? value : null));
+
+const optionalThumbnailSchema = z
+  .string()
+  .trim()
+  .max(2048)
+  .nullish()
+  .transform((value) => (value && value.length > 0 ? value : null));
+
 const updateModuleSchema = z.object({
   title: z.string().min(1),
+  descriptor: optionalDescriptorSchema,
+  thumbnailUrl: optionalThumbnailSchema,
   sortOrder: z.number().int().min(0),
 });
 
@@ -19,9 +35,14 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ moduleId: str
   const supabase = getSupabaseAdminClient();
   const { data, error } = await supabase
     .from("modules")
-    .update({ title: payload.title, sort_order: payload.sortOrder })
+    .update({
+      title: payload.title,
+      descriptor: payload.descriptor,
+      thumbnail_url: payload.thumbnailUrl,
+      sort_order: payload.sortOrder,
+    })
     .eq("id", moduleId)
-    .select("id,course_id,title,sort_order")
+    .select("id,course_id,title,descriptor,thumbnail_url,sort_order")
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/app/app/admin/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/src/app/app/admin/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { AdminLessonQuestionManager } from "@/components/admin-lesson-question-manager";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getCourseLessonContentForAdmin } from "@/lib/repositories/diocese-admin";
+
+export default async function DioceseAdminLessonQuestionsPage({
+  params,
+}: {
+  params: Promise<{ courseId: string; lessonId: string }>;
+}) {
+  const { courseId, lessonId } = await params;
+  const data = await getCourseLessonContentForAdmin(courseId, lessonId);
+
+  if (!data) {
+    notFound();
+  }
+
+  return (
+    <div className="space-y-4">
+      <Button asChild size="sm" variant="outline">
+        <Link href={`/app/admin/courses/${courseId}`}>Back to course builder</Link>
+      </Button>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Lesson question builder: {data.lesson.title}</CardTitle>
+          <CardDescription>
+            Course: {data.course.title} · Module: {data.module.title}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <AdminLessonQuestionManager lesson={data.lesson} />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/app/admin/courses/[courseId]/page.tsx
+++ b/src/app/app/admin/courses/[courseId]/page.tsx
@@ -21,7 +21,7 @@ export default async function DioceseAdminCourseContentPage({
       <CardHeader>
         <CardTitle>Course content builder: {data.course.title}</CardTitle>
         <CardDescription>
-          Create and manage modules, lessons, and quiz questions for this course.
+          Build content with module cards, lesson cards, and a dedicated lesson page for question editing.
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/src/components/admin-lesson-question-manager.tsx
+++ b/src/components/admin-lesson-question-manager.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import type { DioceseLessonRow } from "@/lib/repositories/diocese-admin";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+interface QuestionDraft {
+  id: string;
+  prompt: string;
+  options: string[];
+  correctOptionIndex: number;
+}
+
+function buildQuestionDrafts(lesson: DioceseLessonRow): QuestionDraft[] {
+  return [...lesson.questions]
+    .sort((a, b) => a.sort_order - b.sort_order)
+    .map((question) => ({
+      id: question.id,
+      prompt: question.prompt,
+      options: question.options,
+      correctOptionIndex: question.correct_option_index,
+    }));
+}
+
+export function AdminLessonQuestionManager({ lesson }: { lesson: DioceseLessonRow }) {
+  const router = useRouter();
+  const [message, setMessage] = useState("");
+  const [questionDrafts, setQuestionDrafts] = useState<QuestionDraft[]>(() => buildQuestionDrafts(lesson));
+
+  useEffect(() => {
+    setQuestionDrafts(buildQuestionDrafts(lesson));
+  }, [lesson]);
+
+  async function createQuestion() {
+    const response = await fetch(`/api/admin/lessons/${lesson.id}/questions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt: "New question",
+        options: ["Option A", "Option B"],
+        correctOptionIndex: 0,
+        sortOrder: questionDrafts.length,
+      }),
+    });
+
+    const data = await response.json();
+    setMessage(response.ok ? "Question created." : data.error ?? "Failed to create question.");
+    if (response.ok) router.refresh();
+  }
+
+  async function saveQuestion(questionId: string, sortOrder: number) {
+    const draft = questionDrafts.find((candidate) => candidate.id === questionId);
+
+    if (!draft) {
+      setMessage("Unable to find question draft.");
+      return;
+    }
+
+    const prompt = draft.prompt.trim();
+    const options = draft.options.map((option) => option.trim()).filter(Boolean);
+
+    if (!prompt) {
+      setMessage("Question prompt is required.");
+      return;
+    }
+
+    if (options.length < 2) {
+      setMessage("Each question must have at least two options.");
+      return;
+    }
+
+    const correctOptionIndex = Math.min(Math.max(draft.correctOptionIndex, 0), options.length - 1);
+
+    const response = await fetch(`/api/admin/questions/${questionId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        prompt,
+        options,
+        correctOptionIndex,
+        sortOrder,
+      }),
+    });
+
+    const data = await response.json();
+    setMessage(response.ok ? "Question updated." : data.error ?? "Failed to update question.");
+    if (response.ok) router.refresh();
+  }
+
+  async function deleteQuestion(questionId: string) {
+    const response = await fetch(`/api/admin/questions/${questionId}`, { method: "DELETE" });
+    const data = await response.json();
+    setMessage(response.ok ? "Question deleted." : data.error ?? "Failed to delete question.");
+    if (response.ok) router.refresh();
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm text-muted-foreground">Create and edit quiz questions using separate option fields.</p>
+        <Button onClick={createQuestion} type="button">
+          Add question
+        </Button>
+      </div>
+
+      {questionDrafts.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>No questions yet</CardTitle>
+            <CardDescription>Add the first question to start building the lesson quiz.</CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        questionDrafts.map((question, questionIndex) => (
+          <Card key={question.id}>
+            <CardHeader>
+              <CardTitle>Question {questionIndex + 1}</CardTitle>
+              <CardDescription>Set prompt text, options, and the correct answer below.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Textarea
+                onChange={(event) =>
+                  setQuestionDrafts((prev) =>
+                    prev.map((candidate) =>
+                      candidate.id === question.id ? { ...candidate, prompt: event.target.value } : candidate,
+                    ),
+                  )
+                }
+                placeholder="Question prompt"
+                value={question.prompt}
+              />
+
+              <div className="space-y-2">
+                <p className="text-sm font-medium">Options</p>
+                {question.options.map((option, optionIndex) => (
+                  <div className="flex gap-2" key={`${question.id}-option-${optionIndex}`}>
+                    <Input
+                      onChange={(event) =>
+                        setQuestionDrafts((prev) =>
+                          prev.map((candidate) =>
+                            candidate.id === question.id
+                              ? {
+                                  ...candidate,
+                                  options: candidate.options.map((existingOption, existingIndex) =>
+                                    existingIndex === optionIndex ? event.target.value : existingOption,
+                                  ),
+                                }
+                              : candidate,
+                          ),
+                        )
+                      }
+                      placeholder={`Option ${optionIndex + 1}`}
+                      value={option}
+                    />
+                    <Button
+                      onClick={() =>
+                        setQuestionDrafts((prev) =>
+                          prev.map((candidate) => {
+                            if (candidate.id !== question.id || candidate.options.length <= 2) {
+                              return candidate;
+                            }
+
+                            const nextOptions = candidate.options.filter((_, existingIndex) => existingIndex !== optionIndex);
+                            let nextCorrectOptionIndex = candidate.correctOptionIndex;
+
+                            if (candidate.correctOptionIndex === optionIndex) {
+                              nextCorrectOptionIndex = 0;
+                            } else if (candidate.correctOptionIndex > optionIndex) {
+                              nextCorrectOptionIndex = candidate.correctOptionIndex - 1;
+                            }
+
+                            return {
+                              ...candidate,
+                              options: nextOptions,
+                              correctOptionIndex: nextCorrectOptionIndex,
+                            };
+                          }),
+                        )
+                      }
+                      size="sm"
+                      type="button"
+                      variant="destructive"
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                ))}
+                <Button
+                  onClick={() =>
+                    setQuestionDrafts((prev) =>
+                      prev.map((candidate) =>
+                        candidate.id === question.id
+                          ? { ...candidate, options: [...candidate.options, `Option ${candidate.options.length + 1}`] }
+                          : candidate,
+                      ),
+                    )
+                  }
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  Add option
+                </Button>
+              </div>
+
+              <div className="grid gap-2 md:grid-cols-2">
+                <label className="space-y-1 text-sm">
+                  <span>Correct answer</span>
+                  <Select
+                    onChange={(event) =>
+                      setQuestionDrafts((prev) =>
+                        prev.map((candidate) =>
+                          candidate.id === question.id
+                            ? { ...candidate, correctOptionIndex: Number.parseInt(event.target.value, 10) }
+                            : candidate,
+                        ),
+                      )
+                    }
+                    value={String(question.correctOptionIndex)}
+                  >
+                    {question.options.map((option, optionIndex) => (
+                      <option key={`${question.id}-correct-${optionIndex}`} value={String(optionIndex)}>
+                        {option.trim() ? option : `Option ${optionIndex + 1}`}
+                      </option>
+                    ))}
+                  </Select>
+                </label>
+              </div>
+
+              <div className="flex flex-wrap gap-2">
+                <Button onClick={() => saveQuestion(question.id, questionIndex)} size="sm" type="button" variant="secondary">
+                  Save question
+                </Button>
+                <Button onClick={() => deleteQuestion(question.id)} size="sm" type="button" variant="destructive">
+                  Delete question
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))
+      )}
+
+      {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
+    </div>
+  );
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-24 w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = "Textarea";

--- a/src/lib/repositories/diocese-admin.ts
+++ b/src/lib/repositories/diocese-admin.ts
@@ -59,6 +59,8 @@ export interface DioceseLessonRow {
   id: string;
   module_id: string;
   title: string;
+  descriptor: string | null;
+  thumbnail_url: string | null;
   youtube_video_id: string;
   sort_order: number;
   passing_score: number;
@@ -69,6 +71,8 @@ export interface DioceseModuleRow {
   id: string;
   course_id: string;
   title: string;
+  descriptor: string | null;
+  thumbnail_url: string | null;
   sort_order: number;
   lessons: DioceseLessonRow[];
 }
@@ -285,7 +289,7 @@ export async function getCourseContentForAdmin(courseId: string) {
   const { data: modules, error: modulesError } = await supabase
     .from("modules")
     .select(
-      "id,course_id,title,sort_order, lessons(id,module_id,title,youtube_video_id,sort_order,passing_score, questions(id,lesson_id,prompt,options,correct_option_index,sort_order))",
+      "id,course_id,title,descriptor,thumbnail_url,sort_order, lessons(id,module_id,title,descriptor,thumbnail_url,youtube_video_id,sort_order,passing_score, questions(id,lesson_id,prompt,options,correct_option_index,sort_order))",
     )
     .eq("course_id", courseId)
     .order("sort_order", { ascending: true });
@@ -296,4 +300,25 @@ export async function getCourseContentForAdmin(courseId: string) {
     course: course as DioceseCourseRow,
     modules: ((modules ?? []) as DioceseModuleRow[]) ?? [],
   };
+}
+
+export async function getCourseLessonContentForAdmin(courseId: string, lessonId: string) {
+  const content = await getCourseContentForAdmin(courseId);
+
+  if (!content) {
+    return null;
+  }
+
+  for (const moduleRow of content.modules) {
+    const lesson = moduleRow.lessons.find((candidate) => candidate.id === lessonId);
+    if (lesson) {
+      return {
+        course: content.course,
+        module: moduleRow,
+        lesson,
+      };
+    }
+  }
+
+  return null;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,8 @@ export interface Course {
 export interface Lesson {
   id: string;
   title: string;
+  descriptor: string | null;
+  thumbnail_url: string | null;
   youtube_video_id: string;
   passing_score: number;
   module_id: string;

--- a/supabase/migrations/0008_course_content_metadata.sql
+++ b/supabase/migrations/0008_course_content_metadata.sql
@@ -1,0 +1,7 @@
+alter table modules
+  add column if not exists descriptor text,
+  add column if not exists thumbnail_url text;
+
+alter table lessons
+  add column if not exists descriptor text,
+  add column if not exists thumbnail_url text;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -14,16 +14,16 @@ insert into course_parishes (course_id, parish_id)
 values ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', '11111111-1111-1111-1111-111111111111')
 on conflict do nothing;
 
-insert into modules (id, course_id, title, sort_order)
+insert into modules (id, course_id, title, descriptor, thumbnail_url, sort_order)
 values
-  ('cccccccc-cccc-cccc-cccc-ccccccccccc1', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Welcome Module', 1),
-  ('cccccccc-cccc-cccc-cccc-ccccccccccc2', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Foundations', 1)
+  ('cccccccc-cccc-cccc-cccc-ccccccccccc1', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Welcome Module', 'Introduces diocesan mission and platform basics.', '/globe.svg', 1),
+  ('cccccccc-cccc-cccc-cccc-ccccccccccc2', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Foundations', 'Core principles and sacramental overview for learners.', '/window.svg', 1)
 on conflict (id) do nothing;
 
-insert into lessons (id, module_id, title, youtube_video_id, sort_order, passing_score)
+insert into lessons (id, module_id, title, descriptor, thumbnail_url, youtube_video_id, sort_order, passing_score)
 values
-  ('dddddddd-dddd-dddd-dddd-ddddddddddd1', 'cccccccc-cccc-cccc-cccc-ccccccccccc1', 'Welcome to the Diocese', 'dQw4w9WgXcQ', 1, 80),
-  ('dddddddd-dddd-dddd-dddd-ddddddddddd2', 'cccccccc-cccc-cccc-cccc-ccccccccccc2', 'Sacrament Basics', 'ysz5S6PUM-U', 1, 80)
+  ('dddddddd-dddd-dddd-dddd-ddddddddddd1', 'cccccccc-cccc-cccc-cccc-ccccccccccc1', 'Welcome to the Diocese', 'Orientation to diocesan learning expectations and flow.', '/next.svg', 'dQw4w9WgXcQ', 1, 80),
+  ('dddddddd-dddd-dddd-dddd-ddddddddddd2', 'cccccccc-cccc-cccc-cccc-ccccccccccc2', 'Sacrament Basics', 'Covers the essential sacramental framework for beginners.', '/file.svg', 'ysz5S6PUM-U', 1, 80)
 on conflict (id) do nothing;
 
 insert into questions (id, lesson_id, prompt, options, correct_option_index, sort_order)


### PR DESCRIPTION
## Summary
- refactor the admin course content builder into card-based module and lesson editing
- add module and lesson metadata fields (`descriptor`, `thumbnail_url`) across migration, API routes, repository types, and seed data
- add a dedicated lesson question builder page (`/app/admin/courses/[courseId]/lessons/[lessonId]`)
- replace pipe-delimited question options with per-option form fields and correct-answer select
- add shared `Textarea` UI primitive used by the new editors

## Validation
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test -- src/app/api/admin/courses/[courseId]/modules/__tests__/route.test.ts src/app/api/admin/modules/[moduleId]/__tests__/route.test.ts src/app/api/admin/modules/[moduleId]/lessons/__tests__/route.test.ts src/app/api/admin/lessons/[lessonId]/__tests__/route.test.ts` ✅
- `npm run build` ✅
- `npm run test:coverage` ❌ (global branch coverage is 67.1% vs required 70%)
- `npm run test:e2e` ❌ (Playwright webServer build fails during prerender of `/app/courses` due Clerk provider usage in build context)

## Migration
- adds `supabase/migrations/0008_course_content_metadata.sql`
