### PR TITLE
Build parish admin cohorts, participation, and communications workflows

### DIFF
--- a/docs/parish-admin-notes.md
+++ b/docs/parish-admin-notes.md
@@ -1,0 +1,27 @@
+# Parish Admin Notes
+
+## Known Gap: Outbound Messaging Delivery
+- Current parish communications are log-only (`parish_message_sends` + `parish_message_recipients`).
+- The product does not yet send actual email/SMS/push notifications.
+- Delivery status is tracked as `not_configured` until a provider integration is implemented.
+
+## Delivery Scaffold (Current)
+- Added async delivery-job contract:
+  - `parish_message_delivery_jobs` queue table.
+  - Per-recipient delivery fields on `parish_message_recipients`.
+- Delivery mode is controlled by `PARISH_COMMUNICATIONS_DELIVERY_MODE`:
+  - `disabled` (default): behavior remains log-only.
+  - `mock`: message sends are marked `queued` and a job is enqueued.
+- Worker endpoint:
+  - `POST /api/internal/parish-admin/communications/deliver`
+  - Requires `PARISH_COMMUNICATIONS_WORKER_TOKEN` and matching header `x-parish-worker-token` (or `Authorization: Bearer ...`).
+  - Optional JSON body: `{ "limit": 10 }`
+- The `mock` provider currently validates recipient email presence and marks sends/recipients `sent` or `failed` accordingly.
+
+## Follow-up Issue Suggestion
+- Title: `Integrate outbound delivery for Parish Admin communications (email/SMS)`
+- Scope:
+  - Add provider abstraction and environment configuration.
+  - Implement async job/queue delivery pipeline.
+  - Add retry/backoff + failure logging.
+  - Add delivery metrics and admin-facing send status drill-down.

--- a/e2e/parish-admin.spec.ts
+++ b/e2e/parish-admin.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+import { readFile } from "node:fs/promises";
+
+const E2E_BASE_URL = "http://127.0.0.1:3100";
+const E2E_PARISH_ID = "11111111-1111-4111-8111-111111111111";
+
+test("parish admin participation watchlist supports filtering and csv export", async ({ context, page }, testInfo) => {
+  await context.addCookies([
+    { name: "e2e_onboarding_complete", value: "1", url: E2E_BASE_URL },
+    { name: "active_parish_id", value: E2E_PARISH_ID, url: E2E_BASE_URL },
+    { name: "e2e_role", value: "parish_admin", url: E2E_BASE_URL },
+  ]);
+
+  await page.goto("/app/parish-admin");
+  await expect(page.getByRole("heading", { name: "Participation Watchlist" })).toBeVisible();
+
+  const statusFilter = page
+    .locator("select")
+    .filter({ has: page.locator("option[value='completed']") })
+    .first();
+
+  await statusFilter.selectOption("completed");
+  await expect(page.getByText("No learners match current filters.")).toBeVisible();
+
+  const filteredDownloadPromise = page.waitForEvent("download");
+  await page.getByRole("link", { name: "Export CSV" }).click();
+  const filteredDownload = await filteredDownloadPromise;
+  const filteredPath = testInfo.outputPath("parish-participation-filtered.csv");
+  await filteredDownload.saveAs(filteredPath);
+  const filteredCsv = await readFile(filteredPath, "utf8");
+  expect(filteredDownload.suggestedFilename()).toContain("parish-participation.csv");
+  expect(filteredCsv).toContain("learner_name,learner_email");
+  expect(filteredCsv).not.toContain("E2E User");
+
+  await statusFilter.selectOption("not_started");
+  await expect(page.getByRole("cell", { name: "E2E User", exact: true }).first()).toBeVisible();
+
+  const exportDownloadPromise = page.waitForEvent("download");
+  await page.getByRole("link", { name: "Export CSV" }).click();
+  const exportDownload = await exportDownloadPromise;
+  const exportPath = testInfo.outputPath("parish-participation.csv");
+  await exportDownload.saveAs(exportPath);
+  const csv = await readFile(exportPath, "utf8");
+
+  expect(csv).toContain("learner_name,learner_email");
+  expect(csv).toContain("E2E User");
+  expect(csv).toContain("Not started");
+});

--- a/src/app/api/internal/parish-admin/communications/deliver/__tests__/route.test.ts
+++ b/src/app/api/internal/parish-admin/communications/deliver/__tests__/route.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/parish-communications/delivery-jobs", () => ({
+  processPendingParishMessageDeliveryJobs: vi.fn(),
+}));
+
+import { POST } from "@/app/api/internal/parish-admin/communications/deliver/route";
+import { processPendingParishMessageDeliveryJobs } from "@/lib/parish-communications/delivery-jobs";
+
+describe("/api/internal/parish-admin/communications/deliver", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    delete process.env.PARISH_COMMUNICATIONS_WORKER_TOKEN;
+  });
+
+  it("returns 500 when worker token is not configured", async () => {
+    const response = await POST(new Request("http://localhost/api/internal/parish-admin/communications/deliver", { method: "POST" }));
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "PARISH_COMMUNICATIONS_WORKER_TOKEN is not configured.",
+    });
+  });
+
+  it("returns 401 when token is invalid", async () => {
+    process.env.PARISH_COMMUNICATIONS_WORKER_TOKEN = "expected-token";
+    const response = await POST(
+      new Request("http://localhost/api/internal/parish-admin/communications/deliver", {
+        method: "POST",
+        headers: {
+          "x-parish-worker-token": "wrong-token",
+        },
+      }),
+    );
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "Unauthorized." });
+  });
+
+  it("processes pending jobs with valid token", async () => {
+    process.env.PARISH_COMMUNICATIONS_WORKER_TOKEN = "expected-token";
+    vi.mocked(processPendingParishMessageDeliveryJobs).mockResolvedValue({
+      processed: 2,
+      sent: 1,
+      failed: 0,
+      requeued: 1,
+    });
+
+    const response = await POST(
+      new Request("http://localhost/api/internal/parish-admin/communications/deliver", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer expected-token",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ limit: 5 }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(processPendingParishMessageDeliveryJobs).toHaveBeenCalledWith({ limit: 5 });
+    await expect(response.json()).resolves.toEqual({
+      processed: 2,
+      sent: 1,
+      failed: 0,
+      requeued: 1,
+    });
+  });
+});

--- a/src/app/api/internal/parish-admin/communications/deliver/route.ts
+++ b/src/app/api/internal/parish-admin/communications/deliver/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { processPendingParishMessageDeliveryJobs } from "@/lib/parish-communications/delivery-jobs";
+
+const requestSchema = z
+  .object({
+    limit: z.number().int().min(1).max(50).optional(),
+  })
+  .optional();
+
+function getBearerToken(value: string | null) {
+  if (!value) return null;
+  const [scheme, token] = value.split(" ");
+  if (scheme !== "Bearer" || !token) return null;
+  return token;
+}
+
+export async function POST(req: Request) {
+  const expectedToken = process.env.PARISH_COMMUNICATIONS_WORKER_TOKEN;
+  if (!expectedToken) {
+    return NextResponse.json(
+      { error: "PARISH_COMMUNICATIONS_WORKER_TOKEN is not configured." },
+      { status: 500 },
+    );
+  }
+
+  const suppliedToken = req.headers.get("x-parish-worker-token") ?? getBearerToken(req.headers.get("authorization"));
+  if (suppliedToken !== expectedToken) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  let parsedBody: z.infer<typeof requestSchema>;
+  try {
+    const raw = await req.json();
+    parsedBody = requestSchema.parse(raw);
+  } catch {
+    parsedBody = undefined;
+  }
+
+  const result = await processPendingParishMessageDeliveryJobs({
+    limit: parsedBody?.limit,
+  });
+
+  return NextResponse.json(result);
+}

--- a/src/app/api/parish-admin/cohort-assignments/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/cohort-assignments/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({ requireParishRole: vi.fn() }));
+vi.mock("@/lib/audit-log", () => ({ recordAdminAuditLog: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ getSupabaseAdminClient: vi.fn() }));
+
+import { PATCH } from "@/app/api/parish-admin/cohort-assignments/route";
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+describe("/api/parish-admin/cohort-assignments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "admin-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "parish_admin",
+    });
+  });
+
+  it("assigns an enrollment to a cohort", async () => {
+    const cohortMaybeSingle = vi.fn(async () => ({ data: { id: "cohort-1" }, error: null }));
+    const cohortEqParish = vi.fn(() => ({ maybeSingle: cohortMaybeSingle }));
+    const cohortEqId = vi.fn(() => ({ eq: cohortEqParish }));
+    const cohortSelect = vi.fn(() => ({ eq: cohortEqId }));
+
+    const enrollmentSingle = vi.fn(async () => ({ data: { id: "enroll-1", cohort_id: "cohort-1" }, error: null }));
+    const enrollmentSelect = vi.fn(() => ({ single: enrollmentSingle }));
+    const enrollmentEqParish = vi.fn(() => ({ select: enrollmentSelect }));
+    const enrollmentEqId = vi.fn(() => ({ eq: enrollmentEqParish }));
+    const enrollmentUpdate = vi.fn(() => ({ eq: enrollmentEqId }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "cohorts") return { select: cohortSelect };
+        if (table === "enrollments") return { update: enrollmentUpdate };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await PATCH(
+      new Request("http://localhost/api/parish-admin/cohort-assignments", {
+        method: "PATCH",
+        body: JSON.stringify({
+          enrollmentId: "22222222-2222-4222-8222-222222222222",
+          cohortId: "33333333-3333-4333-8333-333333333333",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      enrollment: { id: "enroll-1", cohort_id: "cohort-1" },
+    });
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears cohort assignment", async () => {
+    const enrollmentSingle = vi.fn(async () => ({ data: { id: "enroll-1", cohort_id: null }, error: null }));
+    const enrollmentSelect = vi.fn(() => ({ single: enrollmentSingle }));
+    const enrollmentEqParish = vi.fn(() => ({ select: enrollmentSelect }));
+    const enrollmentEqId = vi.fn(() => ({ eq: enrollmentEqParish }));
+    const enrollmentUpdate = vi.fn(() => ({ eq: enrollmentEqId }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "cohorts") return { select: vi.fn() };
+        if (table === "enrollments") return { update: enrollmentUpdate };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await PATCH(
+      new Request("http://localhost/api/parish-admin/cohort-assignments", {
+        method: "PATCH",
+        body: JSON.stringify({
+          enrollmentId: "22222222-2222-4222-8222-222222222222",
+          cohortId: null,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      enrollment: { id: "enroll-1", cohort_id: null },
+    });
+  });
+});

--- a/src/app/api/parish-admin/cohort-assignments/route.ts
+++ b/src/app/api/parish-admin/cohort-assignments/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+const updateAssignmentSchema = z.object({
+  enrollmentId: z.string().uuid(),
+  cohortId: z.string().uuid().nullable(),
+});
+
+export async function PATCH(req: Request) {
+  const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
+  const payload = updateAssignmentSchema.parse(await req.json());
+  const supabase = getSupabaseAdminClient();
+
+  if (payload.cohortId) {
+    const { data: cohort, error: cohortError } = await supabase
+      .from("cohorts")
+      .select("id")
+      .eq("id", payload.cohortId)
+      .eq("parish_id", parishId)
+      .maybeSingle();
+
+    if (cohortError) {
+      return NextResponse.json({ error: cohortError.message }, { status: 400 });
+    }
+
+    if (!cohort) {
+      return NextResponse.json({ error: "Cohort does not belong to this parish." }, { status: 400 });
+    }
+  }
+
+  const { data, error } = await supabase
+    .from("enrollments")
+    .update({ cohort_id: payload.cohortId })
+    .eq("id", payload.enrollmentId)
+    .eq("parish_id", parishId)
+    .select("id,clerk_user_id,course_id,cohort_id,created_at")
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  await recordAdminAuditLog({
+    actorClerkUserId: actorUserId,
+    action: "parish.enrollment_cohort_updated",
+    resourceType: "enrollment",
+    resourceId: payload.enrollmentId,
+    details: {
+      parish_id: parishId,
+      cohort_id: payload.cohortId,
+    },
+  });
+
+  return NextResponse.json({ enrollment: data });
+}

--- a/src/app/api/parish-admin/cohorts/[cohortId]/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/cohorts/[cohortId]/__tests__/route.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({ requireParishRole: vi.fn() }));
+vi.mock("@/lib/audit-log", () => ({ recordAdminAuditLog: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ getSupabaseAdminClient: vi.fn() }));
+
+import { DELETE, PATCH } from "@/app/api/parish-admin/cohorts/[cohortId]/route";
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+describe("/api/parish-admin/cohorts/[cohortId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "admin-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "parish_admin",
+    });
+  });
+
+  it("updates a cohort", async () => {
+    const existingMaybeSingle = vi.fn(async () => ({
+      data: { id: "cohort-1", facilitator_clerk_user_id: "facilitator-1" },
+      error: null,
+    }));
+    const existingEqParish = vi.fn(() => ({ maybeSingle: existingMaybeSingle }));
+    const existingEqId = vi.fn(() => ({ eq: existingEqParish }));
+    const cohortSelect = vi.fn(() => ({ eq: existingEqId }));
+
+    const membershipMaybeSingle = vi.fn(async () => ({ data: { role: "parish_admin" }, error: null }));
+    const membershipEqUser = vi.fn(() => ({ maybeSingle: membershipMaybeSingle }));
+    const membershipEqParish = vi.fn(() => ({ eq: membershipEqUser }));
+    const membershipSelect = vi.fn(() => ({ eq: membershipEqParish }));
+
+    const updateSingle = vi.fn(async () => ({ data: { id: "cohort-1", name: "Updated" }, error: null }));
+    const updateSelect = vi.fn(() => ({ single: updateSingle }));
+    const updateEqParish = vi.fn(() => ({ select: updateSelect }));
+    const updateEqId = vi.fn(() => ({ eq: updateEqParish }));
+    const cohortUpdate = vi.fn(() => ({ eq: updateEqId }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "parish_memberships") return { select: membershipSelect };
+        if (table === "cohorts") return { select: cohortSelect, update: cohortUpdate };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await PATCH(
+      new Request("http://localhost/api/parish-admin/cohorts/11111111-1111-4111-8111-111111111111", {
+        method: "PATCH",
+        body: JSON.stringify({
+          name: "Updated",
+          facilitatorClerkUserId: "facilitator-1",
+          cadence: "biweekly",
+          nextSessionAt: null,
+        }),
+      }),
+      { params: Promise.resolve({ cohortId: "11111111-1111-4111-8111-111111111111" }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ cohort: { id: "cohort-1", name: "Updated" } });
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 403 when instructor tries to update unassigned cohort", async () => {
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "instructor-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "instructor",
+    });
+
+    const existingMaybeSingle = vi.fn(async () => ({
+      data: { id: "cohort-1", facilitator_clerk_user_id: "someone-else" },
+      error: null,
+    }));
+    const existingEqParish = vi.fn(() => ({ maybeSingle: existingMaybeSingle }));
+    const existingEqId = vi.fn(() => ({ eq: existingEqParish }));
+    const cohortSelect = vi.fn(() => ({ eq: existingEqId }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "cohorts") return { select: cohortSelect, update: vi.fn() };
+        if (table === "parish_memberships") return { select: vi.fn() };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await PATCH(
+      new Request("http://localhost/api/parish-admin/cohorts/11111111-1111-4111-8111-111111111111", {
+        method: "PATCH",
+        body: JSON.stringify({
+          name: "Updated",
+          facilitatorClerkUserId: "instructor-1",
+          cadence: "weekly",
+          nextSessionAt: null,
+        }),
+      }),
+      { params: Promise.resolve({ cohortId: "11111111-1111-4111-8111-111111111111" }) },
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: "You can only manage cohorts assigned to you." });
+  });
+
+  it("deletes a cohort", async () => {
+    const cohortEqParish = vi.fn(async () => ({ error: null }));
+    const cohortEqId = vi.fn(() => ({ eq: cohortEqParish }));
+    const cohortDelete = vi.fn(() => ({ eq: cohortEqId }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ delete: cohortDelete })),
+    } as never);
+
+    const response = await DELETE(
+      new Request("http://localhost/api/parish-admin/cohorts/11111111-1111-4111-8111-111111111111", {
+        method: "DELETE",
+      }),
+      { params: Promise.resolve({ cohortId: "11111111-1111-4111-8111-111111111111" }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/parish-admin/cohorts/[cohortId]/route.ts
+++ b/src/app/api/parish-admin/cohorts/[cohortId]/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+const paramsSchema = z.object({
+  cohortId: z.string().uuid(),
+});
+
+const cadenceSchema = z.enum(["weekly", "biweekly", "monthly", "custom"]);
+
+const updateCohortSchema = z.object({
+  name: z.string().min(1),
+  facilitatorClerkUserId: z.string().min(1).nullable().optional(),
+  cadence: cadenceSchema,
+  nextSessionAt: z.string().datetime().nullable().optional(),
+});
+
+async function validateFacilitator(parishId: string, facilitatorClerkUserId: string) {
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from("parish_memberships")
+    .select("role")
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", facilitatorClerkUserId)
+    .maybeSingle();
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  if (!data || (data.role !== "parish_admin" && data.role !== "instructor")) {
+    return { error: "Facilitator must be a parish admin or instructor in this parish." };
+  }
+
+  return { error: null as string | null };
+}
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ cohortId: string }> }) {
+  const { clerkUserId: actorUserId, parishId, role } = await requireParishRole("instructor");
+  const { cohortId } = paramsSchema.parse(await ctx.params);
+  const payload = updateCohortSchema.parse(await req.json());
+  const supabase = getSupabaseAdminClient();
+
+  const { data: existingCohort, error: existingCohortError } = await supabase
+    .from("cohorts")
+    .select("id,facilitator_clerk_user_id")
+    .eq("id", cohortId)
+    .eq("parish_id", parishId)
+    .maybeSingle();
+
+  if (existingCohortError) {
+    return NextResponse.json({ error: existingCohortError.message }, { status: 400 });
+  }
+
+  if (!existingCohort) {
+    return NextResponse.json({ error: "Cohort not found." }, { status: 404 });
+  }
+
+  if (role === "instructor" && existingCohort.facilitator_clerk_user_id !== actorUserId) {
+    return NextResponse.json({ error: "You can only manage cohorts assigned to you." }, { status: 403 });
+  }
+
+  if (role === "parish_admin" && payload.facilitatorClerkUserId) {
+    const facilitatorValidation = await validateFacilitator(parishId, payload.facilitatorClerkUserId);
+    if (facilitatorValidation.error) {
+      return NextResponse.json({ error: facilitatorValidation.error }, { status: 400 });
+    }
+  }
+
+  if (
+    role === "instructor" &&
+    payload.facilitatorClerkUserId &&
+    payload.facilitatorClerkUserId !== existingCohort.facilitator_clerk_user_id
+  ) {
+    return NextResponse.json({ error: "Only parish admins can reassign facilitators." }, { status: 403 });
+  }
+
+  const { data, error } = await supabase
+    .from("cohorts")
+    .update({
+      name: payload.name,
+      facilitator_clerk_user_id:
+        role === "parish_admin"
+          ? (payload.facilitatorClerkUserId ?? null)
+          : existingCohort.facilitator_clerk_user_id,
+      cadence: payload.cadence,
+      next_session_at: payload.nextSessionAt ?? null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", cohortId)
+    .eq("parish_id", parishId)
+    .select("id,name,facilitator_clerk_user_id,cadence,next_session_at,created_at,updated_at")
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  await recordAdminAuditLog({
+    actorClerkUserId: actorUserId,
+    action: "parish.cohort_updated",
+    resourceType: "cohort",
+    resourceId: cohortId,
+    details: {
+      parish_id: parishId,
+      name: payload.name,
+      facilitator_clerk_user_id: payload.facilitatorClerkUserId ?? null,
+      cadence: payload.cadence,
+      next_session_at: payload.nextSessionAt ?? null,
+    },
+  });
+
+  return NextResponse.json({ cohort: data });
+}
+
+export async function DELETE(_req: Request, ctx: { params: Promise<{ cohortId: string }> }) {
+  const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
+  const { cohortId } = paramsSchema.parse(await ctx.params);
+  const supabase = getSupabaseAdminClient();
+
+  const { error } = await supabase.from("cohorts").delete().eq("id", cohortId).eq("parish_id", parishId);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  await recordAdminAuditLog({
+    actorClerkUserId: actorUserId,
+    action: "parish.cohort_deleted",
+    resourceType: "cohort",
+    resourceId: cohortId,
+    details: {
+      parish_id: parishId,
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/parish-admin/cohorts/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/cohorts/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({ requireParishRole: vi.fn() }));
+vi.mock("@/lib/audit-log", () => ({ recordAdminAuditLog: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ getSupabaseAdminClient: vi.fn() }));
+
+import { GET, POST } from "@/app/api/parish-admin/cohorts/route";
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+describe("/api/parish-admin/cohorts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "admin-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "parish_admin",
+    });
+  });
+
+  it("lists cohorts for active parish", async () => {
+    const limit = vi.fn(async () => ({ data: [{ id: "cohort-1", name: "RCIA" }], error: null }));
+    const order = vi.fn(() => ({ limit }));
+    const eq = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ eq }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ select })),
+    } as never);
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ cohorts: [{ id: "cohort-1", name: "RCIA" }] });
+  });
+
+  it("limits cohort list to assigned facilitator cohorts for instructors", async () => {
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "instructor-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "instructor",
+    });
+
+    const limit = vi.fn(async () => ({ data: [{ id: "cohort-1" }], error: null }));
+    const facilitatorEq = vi.fn(() => ({ limit }));
+    const order = vi.fn(() => ({ eq: facilitatorEq }));
+    const parishEq = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ eq: parishEq }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ select })),
+    } as never);
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ cohorts: [{ id: "cohort-1" }] });
+    expect(facilitatorEq).toHaveBeenCalledWith("facilitator_clerk_user_id", "instructor-1");
+  });
+
+  it("creates a cohort", async () => {
+    const membershipMaybeSingle = vi.fn(async () => ({ data: { role: "instructor" }, error: null }));
+    const membershipEqUser = vi.fn(() => ({ maybeSingle: membershipMaybeSingle }));
+    const membershipEqParish = vi.fn(() => ({ eq: membershipEqUser }));
+    const membershipSelect = vi.fn(() => ({ eq: membershipEqParish }));
+
+    const cohortSingle = vi.fn(async () => ({ data: { id: "cohort-1", name: "RCIA A" }, error: null }));
+    const cohortSelect = vi.fn(() => ({ single: cohortSingle }));
+    const cohortInsert = vi.fn(() => ({ select: cohortSelect }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "parish_memberships") return { select: membershipSelect };
+        if (table === "cohorts") return { insert: cohortInsert };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/cohorts", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "RCIA A",
+          facilitatorClerkUserId: "facilitator-1",
+          cadence: "weekly",
+          nextSessionAt: "2026-02-20T19:00:00.000Z",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({ cohort: { id: "cohort-1", name: "RCIA A" } });
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 400 when facilitator is not eligible", async () => {
+    const membershipMaybeSingle = vi.fn(async () => ({ data: { role: "student" }, error: null }));
+    const membershipEqUser = vi.fn(() => ({ maybeSingle: membershipMaybeSingle }));
+    const membershipEqParish = vi.fn(() => ({ eq: membershipEqUser }));
+    const membershipSelect = vi.fn(() => ({ eq: membershipEqParish }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "parish_memberships") return { select: membershipSelect };
+        if (table === "cohorts") return { insert: vi.fn() };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/cohorts", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "RCIA A",
+          facilitatorClerkUserId: "student-1",
+          cadence: "weekly",
+          nextSessionAt: null,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Facilitator must be a parish admin or instructor in this parish.",
+    });
+  });
+});

--- a/src/app/api/parish-admin/cohorts/route.ts
+++ b/src/app/api/parish-admin/cohorts/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+const cadenceSchema = z.enum(["weekly", "biweekly", "monthly", "custom"]);
+
+const createCohortSchema = z.object({
+  name: z.string().min(1),
+  facilitatorClerkUserId: z.string().min(1).nullable().optional(),
+  cadence: cadenceSchema.default("weekly"),
+  nextSessionAt: z.string().datetime().nullable().optional(),
+});
+
+async function validateFacilitator(parishId: string, facilitatorClerkUserId: string) {
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from("parish_memberships")
+    .select("role")
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", facilitatorClerkUserId)
+    .maybeSingle();
+
+  if (error) {
+    return { error: error.message };
+  }
+
+  if (!data || (data.role !== "parish_admin" && data.role !== "instructor")) {
+    return { error: "Facilitator must be a parish admin or instructor in this parish." };
+  }
+
+  return { error: null as string | null };
+}
+
+export async function GET() {
+  const { parishId, role, clerkUserId } = await requireParishRole("instructor");
+  const supabase = getSupabaseAdminClient();
+
+  let query = supabase
+    .from("cohorts")
+    .select("id,name,facilitator_clerk_user_id,cadence,next_session_at,created_at,updated_at")
+    .eq("parish_id", parishId)
+    .order("created_at", { ascending: false });
+
+  if (role === "instructor") {
+    query = query.eq("facilitator_clerk_user_id", clerkUserId);
+  }
+
+  const { data, error } = await query.limit(200);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ cohorts: data ?? [] });
+}
+
+export async function POST(req: Request) {
+  const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
+  const payload = createCohortSchema.parse(await req.json());
+  const supabase = getSupabaseAdminClient();
+
+  if (payload.facilitatorClerkUserId) {
+    const facilitatorValidation = await validateFacilitator(parishId, payload.facilitatorClerkUserId);
+    if (facilitatorValidation.error) {
+      return NextResponse.json({ error: facilitatorValidation.error }, { status: 400 });
+    }
+  }
+
+  const { data, error } = await supabase
+    .from("cohorts")
+    .insert({
+      parish_id: parishId,
+      name: payload.name,
+      facilitator_clerk_user_id: payload.facilitatorClerkUserId ?? null,
+      cadence: payload.cadence,
+      next_session_at: payload.nextSessionAt ?? null,
+    })
+    .select("id,name,facilitator_clerk_user_id,cadence,next_session_at,created_at,updated_at")
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  await recordAdminAuditLog({
+    actorClerkUserId: actorUserId,
+    action: "parish.cohort_created",
+    resourceType: "cohort",
+    resourceId: data.id as string,
+    details: {
+      parish_id: parishId,
+      name: payload.name,
+      facilitator_clerk_user_id: payload.facilitatorClerkUserId ?? null,
+      cadence: payload.cadence,
+      next_session_at: payload.nextSessionAt ?? null,
+    },
+  });
+
+  return NextResponse.json({ cohort: data }, { status: 201 });
+}

--- a/src/app/api/parish-admin/communications/[sendId]/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/communications/[sendId]/__tests__/route.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({ requireParishRole: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ getSupabaseAdminClient: vi.fn() }));
+
+import { GET } from "@/app/api/parish-admin/communications/[sendId]/route";
+import { requireParishRole } from "@/lib/authz";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+describe("/api/parish-admin/communications/[sendId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "admin-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "parish_admin",
+    });
+  });
+
+  it("returns send details with recipient summary", async () => {
+    const sendMaybeSingle = vi.fn(async () => ({
+      data: {
+        id: "22222222-2222-4222-8222-222222222222",
+        subject: "Reminder",
+        body: "Please continue.",
+        delivery_status: "queued",
+        recipient_count: 2,
+        created_at: "2026-02-11T00:00:00.000Z",
+      },
+      error: null,
+    }));
+    const sendEqParish = vi.fn(() => ({ maybeSingle: sendMaybeSingle }));
+    const sendEqId = vi.fn(() => ({ eq: sendEqParish }));
+    const sendSelect = vi.fn(() => ({ eq: sendEqId }));
+
+    const recipientLimit = vi.fn(async () => ({
+      data: [
+        {
+          clerk_user_id: "user-1",
+          delivery_status: "sent",
+          delivery_attempted_at: "2026-02-11T10:00:00.000Z",
+          delivery_error: null,
+        },
+        {
+          clerk_user_id: "user-2",
+          delivery_status: "failed",
+          delivery_attempted_at: "2026-02-11T10:00:00.000Z",
+          delivery_error: "Mailbox not found.",
+        },
+      ],
+      error: null,
+    }));
+    const recipientOrder = vi.fn(() => ({ limit: recipientLimit }));
+    const recipientEqParish = vi.fn(() => ({ order: recipientOrder }));
+    const recipientEqSend = vi.fn(() => ({ eq: recipientEqParish }));
+    const recipientSelect = vi.fn(() => ({ eq: recipientEqSend }));
+
+    const profilesIn = vi.fn(async () => ({
+      data: [
+        { clerk_user_id: "user-1", email: "u1@example.com", display_name: "User One" },
+        { clerk_user_id: "user-2", email: "u2@example.com", display_name: null },
+      ],
+      error: null,
+    }));
+    const profileSelect = vi.fn(() => ({ in: profilesIn }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "parish_message_sends") return { select: sendSelect };
+        if (table === "parish_message_recipients") return { select: recipientSelect };
+        if (table === "user_profiles") return { select: profileSelect };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ sendId: "22222222-2222-4222-8222-222222222222" }),
+    });
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.summary).toEqual({
+      total: 2,
+      not_configured: 0,
+      pending: 0,
+      sent: 1,
+      failed: 1,
+    });
+    expect(json.recipients).toHaveLength(2);
+  });
+
+  it("returns 404 when send is not found", async () => {
+    const sendMaybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const sendEqParish = vi.fn(() => ({ maybeSingle: sendMaybeSingle }));
+    const sendEqId = vi.fn(() => ({ eq: sendEqParish }));
+    const sendSelect = vi.fn(() => ({ eq: sendEqId }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "parish_message_sends") return { select: sendSelect };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ sendId: "22222222-2222-4222-8222-222222222222" }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Message send not found." });
+  });
+});

--- a/src/app/api/parish-admin/communications/[sendId]/route.ts
+++ b/src/app/api/parish-admin/communications/[sendId]/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireParishRole } from "@/lib/authz";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+const paramsSchema = z.object({
+  sendId: z.string().uuid(),
+});
+
+type RecipientDeliveryStatus = "not_configured" | "pending" | "sent" | "failed";
+
+export async function GET(_req: Request, ctx: { params: Promise<{ sendId: string }> }) {
+  const { parishId } = await requireParishRole("parish_admin");
+  const params = paramsSchema.parse(await ctx.params);
+  const supabase = getSupabaseAdminClient();
+
+  const { data: send, error: sendError } = await supabase
+    .from("parish_message_sends")
+    .select("id,subject,body,delivery_status,recipient_count,created_at")
+    .eq("id", params.sendId)
+    .eq("parish_id", parishId)
+    .maybeSingle();
+
+  if (sendError) {
+    return NextResponse.json({ error: sendError.message }, { status: 400 });
+  }
+  if (!send) {
+    return NextResponse.json({ error: "Message send not found." }, { status: 404 });
+  }
+
+  const { data: recipientRows, error: recipientError } = await supabase
+    .from("parish_message_recipients")
+    .select("clerk_user_id,delivery_status,delivery_attempted_at,delivery_error")
+    .eq("send_id", params.sendId)
+    .eq("parish_id", parishId)
+    .order("clerk_user_id", { ascending: true })
+    .limit(500);
+
+  if (recipientError) {
+    return NextResponse.json({ error: recipientError.message }, { status: 400 });
+  }
+
+  const recipients =
+    (recipientRows as Array<{
+      clerk_user_id: string;
+      delivery_status: RecipientDeliveryStatus;
+      delivery_attempted_at: string | null;
+      delivery_error: string | null;
+    }> | null) ?? [];
+
+  const recipientIds = recipients.map((recipient) => recipient.clerk_user_id);
+  let profiles: Array<{ clerk_user_id: string; email: string | null; display_name: string | null }> = [];
+  if (recipientIds.length > 0) {
+    const { data: profileRows, error: profileError } = await supabase
+      .from("user_profiles")
+      .select("clerk_user_id,email,display_name")
+      .in("clerk_user_id", recipientIds);
+    if (profileError) {
+      return NextResponse.json({ error: profileError.message }, { status: 400 });
+    }
+    profiles =
+      (profileRows as Array<{
+        clerk_user_id: string;
+        email: string | null;
+        display_name: string | null;
+      }> | null) ?? [];
+  }
+
+  const profileById = new Map(profiles.map((profile) => [profile.clerk_user_id, profile]));
+  const summary = {
+    total: recipients.length,
+    not_configured: 0,
+    pending: 0,
+    sent: 0,
+    failed: 0,
+  };
+
+  const detailedRecipients = recipients.map((recipient) => {
+    summary[recipient.delivery_status] += 1;
+    const profile = profileById.get(recipient.clerk_user_id);
+    return {
+      clerk_user_id: recipient.clerk_user_id,
+      display_name: profile?.display_name ?? null,
+      email: profile?.email ?? null,
+      delivery_status: recipient.delivery_status,
+      delivery_attempted_at: recipient.delivery_attempted_at,
+      delivery_error: recipient.delivery_error,
+    };
+  });
+
+  return NextResponse.json({
+    send,
+    summary,
+    recipients: detailedRecipients,
+  });
+}

--- a/src/app/api/parish-admin/communications/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/communications/__tests__/route.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({ requireParishRole: vi.fn() }));
+vi.mock("@/lib/audit-log", () => ({ recordAdminAuditLog: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ getSupabaseAdminClient: vi.fn() }));
+
+import { GET, POST } from "@/app/api/parish-admin/communications/route";
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+describe("/api/parish-admin/communications", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.PARISH_COMMUNICATIONS_DELIVERY_MODE;
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "admin-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "parish_admin",
+    });
+  });
+
+  it("lists message sends", async () => {
+    const limit = vi.fn(async () => ({ data: [{ id: "send-1" }], error: null }));
+    const order = vi.fn(() => ({ limit }));
+    const eq = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ eq }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ select })),
+    } as never);
+
+    const response = await GET();
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ sends: [{ id: "send-1" }] });
+  });
+
+  it("logs a message for all members", async () => {
+    const membershipEq = vi.fn(async () => ({
+      data: [{ clerk_user_id: "user-1" }, { clerk_user_id: "user-2" }],
+      error: null,
+    }));
+    const membershipSelect = vi.fn(() => ({ eq: membershipEq }));
+
+    const sendSingle = vi.fn(async () => ({ data: { id: "send-1", recipient_count: 2 }, error: null }));
+    const sendSelect = vi.fn(() => ({ single: sendSingle }));
+    const sendInsert = vi.fn(() => ({ select: sendSelect }));
+
+    const recipientInsert = vi.fn(async () => ({ error: null }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "parish_memberships") return { select: membershipSelect };
+        if (table === "parish_message_sends") return { insert: sendInsert };
+        if (table === "parish_message_recipients") return { insert: recipientInsert };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/communications", {
+        method: "POST",
+        body: JSON.stringify({
+          subject: "Reminder",
+          body: "Please continue your course this week.",
+          audienceType: "all_members",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.send.id).toBe("send-1");
+    expect(String(json.deliveryNote)).toContain("not configured");
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 400 when audience resolves to no recipients", async () => {
+    const membershipEq = vi.fn(async () => ({ data: [], error: null }));
+    const membershipSelect = vi.fn(() => ({ eq: membershipEq }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "parish_memberships") return { select: membershipSelect };
+        if (table === "parish_message_sends") return { insert: vi.fn() };
+        if (table === "parish_message_recipients") return { insert: vi.fn() };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/communications", {
+        method: "POST",
+        body: JSON.stringify({
+          subject: "Reminder",
+          body: "Please continue your course this week.",
+          audienceType: "all_members",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "No recipients match this audience." });
+  });
+
+  it("queues a delivery job when async delivery mode is enabled", async () => {
+    process.env.PARISH_COMMUNICATIONS_DELIVERY_MODE = "mock";
+
+    const membershipEq = vi.fn(async () => ({
+      data: [{ clerk_user_id: "user-1" }],
+      error: null,
+    }));
+    const membershipSelect = vi.fn(() => ({ eq: membershipEq }));
+
+    const sendSingle = vi.fn(async () => ({ data: { id: "send-2", recipient_count: 1 }, error: null }));
+    const sendSelect = vi.fn(() => ({ single: sendSingle }));
+    const sendInsert = vi.fn(() => ({ select: sendSelect }));
+
+    const recipientInsert = vi.fn(async () => ({ error: null }));
+    const jobInsert = vi.fn(async () => ({ error: null }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "parish_memberships") return { select: membershipSelect };
+        if (table === "parish_message_sends") return { insert: sendInsert };
+        if (table === "parish_message_recipients") return { insert: recipientInsert };
+        if (table === "parish_message_delivery_jobs") return { insert: jobInsert };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/communications", {
+        method: "POST",
+        body: JSON.stringify({
+          subject: "Queued reminder",
+          body: "This should queue.",
+          audienceType: "all_members",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(String(json.deliveryNote)).toContain("queued");
+    expect(jobInsert).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/parish-admin/communications/route.ts
+++ b/src/app/api/parish-admin/communications/route.ts
@@ -1,0 +1,230 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getParishDeliveryConfig } from "@/lib/parish-communications/delivery-provider";
+import { enqueueParishMessageDeliveryJob } from "@/lib/parish-communications/delivery-jobs";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+const audienceTypeSchema = z.enum(["all_members", "stalled_learners", "cohort", "course"]);
+
+const sendMessageSchema = z.object({
+  subject: z.string().trim().min(1).max(160),
+  body: z.string().trim().min(1).max(5000),
+  audienceType: audienceTypeSchema,
+  audienceValue: z.string().uuid().optional(),
+});
+
+async function resolveRecipients({
+  parishId,
+  audienceType,
+  audienceValue,
+}: {
+  parishId: string;
+  audienceType: z.infer<typeof audienceTypeSchema>;
+  audienceValue?: string;
+}) {
+  const supabase = getSupabaseAdminClient();
+  const stalledCutoff = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString();
+
+  if (audienceType === "all_members") {
+    const { data, error } = await supabase
+      .from("parish_memberships")
+      .select("clerk_user_id")
+      .eq("parish_id", parishId);
+    if (error) {
+      return { error: error.message, recipients: [] as string[] };
+    }
+    const recipients = Array.from(
+      new Set((((data ?? []) as Array<{ clerk_user_id: string }>).map((row) => row.clerk_user_id)) ?? []),
+    );
+    return { error: null as string | null, recipients };
+  }
+
+  if (audienceType === "stalled_learners") {
+    const { data, error } = await supabase
+      .from("video_progress")
+      .select("clerk_user_id")
+      .eq("parish_id", parishId)
+      .eq("completed", false)
+      .lt("updated_at", stalledCutoff);
+    if (error) {
+      return { error: error.message, recipients: [] as string[] };
+    }
+    const recipients = Array.from(
+      new Set((((data ?? []) as Array<{ clerk_user_id: string }>).map((row) => row.clerk_user_id)) ?? []),
+    );
+    return { error: null as string | null, recipients };
+  }
+
+  if (!audienceValue) {
+    return { error: "audienceValue is required for cohort/course audiences.", recipients: [] as string[] };
+  }
+
+  if (audienceType === "cohort") {
+    const { data: cohort, error: cohortError } = await supabase
+      .from("cohorts")
+      .select("id")
+      .eq("parish_id", parishId)
+      .eq("id", audienceValue)
+      .maybeSingle();
+    if (cohortError) {
+      return { error: cohortError.message, recipients: [] as string[] };
+    }
+    if (!cohort) {
+      return { error: "Cohort does not belong to this parish.", recipients: [] as string[] };
+    }
+    const { data, error } = await supabase
+      .from("enrollments")
+      .select("clerk_user_id")
+      .eq("parish_id", parishId)
+      .eq("cohort_id", audienceValue);
+    if (error) {
+      return { error: error.message, recipients: [] as string[] };
+    }
+    const recipients = Array.from(
+      new Set((((data ?? []) as Array<{ clerk_user_id: string }>).map((row) => row.clerk_user_id)) ?? []),
+    );
+    return { error: null as string | null, recipients };
+  }
+
+  const { data, error } = await supabase
+    .from("enrollments")
+    .select("clerk_user_id")
+    .eq("parish_id", parishId)
+    .eq("course_id", audienceValue);
+  if (error) {
+    return { error: error.message, recipients: [] as string[] };
+  }
+  const recipients = Array.from(
+    new Set((((data ?? []) as Array<{ clerk_user_id: string }>).map((row) => row.clerk_user_id)) ?? []),
+  );
+  return { error: null as string | null, recipients };
+}
+
+export async function GET() {
+  const { parishId } = await requireParishRole("parish_admin");
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from("parish_message_sends")
+    .select(
+      "id,audience_type,audience_value,subject,body,recipient_count,delivery_status,created_by_clerk_user_id,created_at",
+    )
+    .eq("parish_id", parishId)
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ sends: data ?? [] });
+}
+
+export async function POST(req: Request) {
+  const { clerkUserId, parishId } = await requireParishRole("parish_admin");
+  const payload = sendMessageSchema.parse(await req.json());
+  const supabase = getSupabaseAdminClient();
+  const deliveryConfig = getParishDeliveryConfig();
+
+  if (
+    (payload.audienceType === "cohort" || payload.audienceType === "course") &&
+    !payload.audienceValue
+  ) {
+    return NextResponse.json(
+      { error: "audienceValue is required for cohort/course audiences." },
+      { status: 400 },
+    );
+  }
+
+  const recipientResolution = await resolveRecipients({
+    parishId,
+    audienceType: payload.audienceType,
+    audienceValue: payload.audienceValue,
+  });
+
+  if (recipientResolution.error) {
+    return NextResponse.json({ error: recipientResolution.error }, { status: 400 });
+  }
+
+  const recipients = recipientResolution.recipients;
+  if (recipients.length === 0) {
+    return NextResponse.json({ error: "No recipients match this audience." }, { status: 400 });
+  }
+
+  const { data: send, error: sendError } = await supabase
+    .from("parish_message_sends")
+    .insert({
+      parish_id: parishId,
+      created_by_clerk_user_id: clerkUserId,
+      audience_type: payload.audienceType,
+      audience_value: payload.audienceValue ?? null,
+      subject: payload.subject,
+      body: payload.body,
+      recipient_count: recipients.length,
+      delivery_status: deliveryConfig.enabled ? "queued" : "not_configured",
+      provider: deliveryConfig.provider,
+    })
+    .select(
+      "id,audience_type,audience_value,subject,body,recipient_count,delivery_status,created_by_clerk_user_id,created_at",
+    )
+    .single();
+
+  if (sendError) {
+    return NextResponse.json({ error: sendError.message }, { status: 400 });
+  }
+
+  const { error: recipientInsertError } = await supabase.from("parish_message_recipients").insert(
+    recipients.map((recipientUserId) => ({
+      send_id: send.id,
+      parish_id: parishId,
+      clerk_user_id: recipientUserId,
+      delivery_status: deliveryConfig.enabled ? "pending" : "not_configured",
+      delivery_attempted_at: null,
+      provider_message_id: null,
+      delivery_error: null,
+    })),
+  );
+
+  if (recipientInsertError) {
+    return NextResponse.json({ error: recipientInsertError.message }, { status: 400 });
+  }
+
+  if (deliveryConfig.enabled && deliveryConfig.provider) {
+    try {
+      await enqueueParishMessageDeliveryJob({
+        parishId,
+        sendId: send.id as string,
+        provider: deliveryConfig.provider,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to enqueue delivery job.";
+      await supabase.from("parish_message_sends").update({ delivery_status: "failed" }).eq("id", send.id as string);
+      return NextResponse.json({ error: message }, { status: 500 });
+    }
+  }
+
+  await recordAdminAuditLog({
+    actorClerkUserId: clerkUserId,
+    action: "parish.communication_logged",
+    resourceType: "parish_message_send",
+    resourceId: send.id as string,
+    details: {
+      parish_id: parishId,
+      audience_type: payload.audienceType,
+      audience_value: payload.audienceValue ?? null,
+      recipient_count: recipients.length,
+      delivery_status: deliveryConfig.enabled ? "queued" : "not_configured",
+      provider: deliveryConfig.provider,
+    },
+  });
+
+  return NextResponse.json({
+    send,
+    deliveryNote:
+      deliveryConfig.enabled
+        ? "Message queued for async delivery."
+        : "Outbound delivery is not configured yet. This message has been logged for tracking only.",
+  });
+}

--- a/src/app/api/parish-admin/course-adoptions/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/course-adoptions/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({ requireParishRole: vi.fn() }));
+vi.mock("@/lib/audit-log", () => ({ recordAdminAuditLog: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ getSupabaseAdminClient: vi.fn() }));
+
+import { DELETE, POST } from "@/app/api/parish-admin/course-adoptions/route";
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+describe("/api/parish-admin/course-adoptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "admin-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "parish_admin",
+    });
+  });
+
+  it("adopts a parish-scoped course", async () => {
+    const courseMaybeSingle = vi.fn(async () => ({
+      data: { id: "c1", scope: "PARISH", published: true },
+      error: null,
+    }));
+    const courseEq = vi.fn(() => ({ maybeSingle: courseMaybeSingle }));
+    const courseSelect = vi.fn(() => ({ eq: courseEq }));
+
+    const upsert = vi.fn(async () => ({ error: null }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "courses") return { select: courseSelect };
+        if (table === "course_parishes") return { upsert };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/course-adoptions", {
+        method: "POST",
+        body: JSON.stringify({ courseId: "22222222-2222-4222-8222-222222222222" }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(upsert).toHaveBeenCalledWith(
+      {
+        parish_id: "11111111-1111-4111-8111-111111111111",
+        course_id: "22222222-2222-4222-8222-222222222222",
+      },
+      { onConflict: "course_id,parish_id" },
+    );
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes adoption when no enrollments exist", async () => {
+    const courseMaybeSingle = vi.fn(async () => ({
+      data: { id: "c1", scope: "PARISH" },
+      error: null,
+    }));
+    const courseEq = vi.fn(() => ({ maybeSingle: courseMaybeSingle }));
+    const courseSelect = vi.fn(() => ({ eq: courseEq }));
+
+    const enrollmentEqCourse = vi.fn(async () => ({ count: 0, error: null }));
+    const enrollmentEqParish = vi.fn(() => ({ eq: enrollmentEqCourse }));
+    const enrollmentSelect = vi.fn(() => ({ eq: enrollmentEqParish }));
+
+    const deleteEqCourse = vi.fn(async () => ({ error: null }));
+    const deleteEqParish = vi.fn(() => ({ eq: deleteEqCourse }));
+    const del = vi.fn(() => ({ eq: deleteEqParish }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "courses") return { select: courseSelect };
+        if (table === "enrollments") return { select: enrollmentSelect };
+        if (table === "course_parishes") return { delete: del };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await DELETE(
+      new Request("http://localhost/api/parish-admin/course-adoptions", {
+        method: "DELETE",
+        body: JSON.stringify({ courseId: "22222222-2222-4222-8222-222222222222" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 409 when enrollments still exist for adopted course", async () => {
+    const courseMaybeSingle = vi.fn(async () => ({
+      data: { id: "c1", scope: "PARISH" },
+      error: null,
+    }));
+    const courseEq = vi.fn(() => ({ maybeSingle: courseMaybeSingle }));
+    const courseSelect = vi.fn(() => ({ eq: courseEq }));
+
+    const enrollmentEqCourse = vi.fn(async () => ({ count: 2, error: null }));
+    const enrollmentEqParish = vi.fn(() => ({ eq: enrollmentEqCourse }));
+    const enrollmentSelect = vi.fn(() => ({ eq: enrollmentEqParish }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "courses") return { select: courseSelect };
+        if (table === "enrollments") return { select: enrollmentSelect };
+        if (table === "course_parishes") return { delete: vi.fn() };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await DELETE(
+      new Request("http://localhost/api/parish-admin/course-adoptions", {
+        method: "DELETE",
+        body: JSON.stringify({ courseId: "22222222-2222-4222-8222-222222222222" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: "Remove learner enrollments from this course before removing adoption.",
+    });
+  });
+});

--- a/src/app/api/parish-admin/course-adoptions/route.ts
+++ b/src/app/api/parish-admin/course-adoptions/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+const courseAdoptionSchema = z.object({
+  courseId: z.string().uuid(),
+});
+
+export async function POST(req: Request) {
+  const { clerkUserId, parishId } = await requireParishRole("parish_admin");
+  const payload = courseAdoptionSchema.parse(await req.json());
+  const supabase = getSupabaseAdminClient();
+
+  const { data: course, error: courseError } = await supabase
+    .from("courses")
+    .select("id,scope,published")
+    .eq("id", payload.courseId)
+    .maybeSingle();
+
+  if (courseError) {
+    return NextResponse.json({ error: courseError.message }, { status: 400 });
+  }
+
+  if (!course || course.scope !== "PARISH" || course.published !== true) {
+    return NextResponse.json(
+      { error: "Only published parish-scoped courses can be adopted." },
+      { status: 400 },
+    );
+  }
+
+  const { error } = await supabase.from("course_parishes").upsert(
+    {
+      parish_id: parishId,
+      course_id: payload.courseId,
+    },
+    { onConflict: "course_id,parish_id" },
+  );
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  await recordAdminAuditLog({
+    actorClerkUserId: clerkUserId,
+    action: "parish.course_adopted",
+    resourceType: "course_parish",
+    resourceId: payload.courseId,
+    details: { parish_id: parishId },
+  });
+
+  return NextResponse.json({ ok: true }, { status: 201 });
+}
+
+export async function DELETE(req: Request) {
+  const { clerkUserId, parishId } = await requireParishRole("parish_admin");
+  const payload = courseAdoptionSchema.parse(await req.json());
+  const supabase = getSupabaseAdminClient();
+
+  const { data: course, error: courseError } = await supabase
+    .from("courses")
+    .select("id,scope")
+    .eq("id", payload.courseId)
+    .maybeSingle();
+
+  if (courseError) {
+    return NextResponse.json({ error: courseError.message }, { status: 400 });
+  }
+
+  if (!course || course.scope !== "PARISH") {
+    return NextResponse.json({ error: "Only parish-scoped adoptions can be removed." }, { status: 400 });
+  }
+
+  const { count, error: enrollmentCountError } = await supabase
+    .from("enrollments")
+    .select("id", { count: "exact", head: true })
+    .eq("parish_id", parishId)
+    .eq("course_id", payload.courseId);
+
+  if (enrollmentCountError) {
+    return NextResponse.json({ error: enrollmentCountError.message }, { status: 400 });
+  }
+
+  if ((count ?? 0) > 0) {
+    return NextResponse.json(
+      { error: "Remove learner enrollments from this course before removing adoption." },
+      { status: 409 },
+    );
+  }
+
+  const { error } = await supabase
+    .from("course_parishes")
+    .delete()
+    .eq("parish_id", parishId)
+    .eq("course_id", payload.courseId);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  await recordAdminAuditLog({
+    actorClerkUserId: clerkUserId,
+    action: "parish.course_adoption_removed",
+    resourceType: "course_parish",
+    resourceId: payload.courseId,
+    details: { parish_id: parishId },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/parish-admin/enrollments/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/enrollments/__tests__/route.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({ requireParishRole: vi.fn() }));
+vi.mock("@/lib/audit-log", () => ({ recordAdminAuditLog: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ getSupabaseAdminClient: vi.fn() }));
+
+import { DELETE, GET, POST } from "@/app/api/parish-admin/enrollments/route";
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+describe("/api/parish-admin/enrollments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "admin-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "parish_admin",
+    });
+  });
+
+  it("lists enrollments for the active parish", async () => {
+    const limit = vi.fn(async () => ({ data: [{ id: "e1" }], error: null }));
+    const order = vi.fn(() => ({ limit }));
+    const eq = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ eq }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ select })),
+    } as never);
+
+    const response = await GET(new Request("http://localhost/api/parish-admin/enrollments"));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ enrollments: [{ id: "e1" }] });
+  });
+
+  it("limits enrollment list to instructor-assigned cohorts", async () => {
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "instructor-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "instructor",
+    });
+
+    const cohortsEqFacilitator = vi.fn(async () => ({ data: [{ id: "cohort-1" }], error: null }));
+    const cohortsEqParish = vi.fn(() => ({ eq: cohortsEqFacilitator }));
+    const cohortsSelect = vi.fn(() => ({ eq: cohortsEqParish }));
+
+    const inCohort = vi.fn(async () => ({ data: [{ id: "e2" }], error: null }));
+    const limit = vi.fn(() => ({ in: inCohort }));
+    const order = vi.fn(() => ({ limit }));
+    const eqParish = vi.fn(() => ({ order }));
+    const enrollmentsSelect = vi.fn(() => ({ eq: eqParish }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "cohorts") return { select: cohortsSelect };
+        if (table === "enrollments") return { select: enrollmentsSelect };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await GET(new Request("http://localhost/api/parish-admin/enrollments"));
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ enrollments: [{ id: "e2" }] });
+    expect(cohortsEqFacilitator).toHaveBeenCalledWith("facilitator_clerk_user_id", "instructor-1");
+    expect(inCohort).toHaveBeenCalledWith("cohort_id", ["cohort-1"]);
+  });
+
+  it("creates an enrollment for a parish member", async () => {
+    const memberMaybeSingle = vi.fn(async () => ({ data: { clerk_user_id: "user-1" }, error: null }));
+    const memberEqUser = vi.fn(() => ({ maybeSingle: memberMaybeSingle }));
+    const memberEqParish = vi.fn(() => ({ eq: memberEqUser }));
+    const memberSelect = vi.fn(() => ({ eq: memberEqParish }));
+
+    const courseMaybeSingle = vi.fn(async () => ({ data: { id: "c1", scope: "DIOCESE", published: true }, error: null }));
+    const courseEq = vi.fn(() => ({ maybeSingle: courseMaybeSingle }));
+    const courseSelect = vi.fn(() => ({ eq: courseEq }));
+
+    const enrollmentSingle = vi.fn(async () => ({ data: { id: "e1" }, error: null }));
+    const enrollmentSelect = vi.fn(() => ({ single: enrollmentSingle }));
+    const enrollmentUpsert = vi.fn(() => ({ select: enrollmentSelect }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "parish_memberships") return { select: memberSelect };
+        if (table === "courses") return { select: courseSelect };
+        if (table === "enrollments") return { upsert: enrollmentUpsert };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/enrollments", {
+        method: "POST",
+        body: JSON.stringify({
+          clerkUserId: "user-1",
+          courseId: "22222222-2222-4222-8222-222222222222",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({ enrollment: { id: "e1" } });
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 400 when learner is not in active parish", async () => {
+    const memberMaybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const memberEqUser = vi.fn(() => ({ maybeSingle: memberMaybeSingle }));
+    const memberEqParish = vi.fn(() => ({ eq: memberEqUser }));
+    const memberSelect = vi.fn(() => ({ eq: memberEqParish }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "parish_memberships") return { select: memberSelect };
+        if (table === "courses") return { select: vi.fn() };
+        if (table === "enrollments") return { upsert: vi.fn() };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/enrollments", {
+        method: "POST",
+        body: JSON.stringify({
+          clerkUserId: "user-1",
+          courseId: "22222222-2222-4222-8222-222222222222",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Learner must belong to this parish before enrollment.",
+    });
+  });
+
+  it("removes an enrollment", async () => {
+    const eqCourse = vi.fn(async () => ({ error: null }));
+    const eqUser = vi.fn(() => ({ eq: eqCourse }));
+    const eqParish = vi.fn(() => ({ eq: eqUser }));
+    const del = vi.fn(() => ({ eq: eqParish }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ delete: del })),
+    } as never);
+
+    const response = await DELETE(
+      new Request("http://localhost/api/parish-admin/enrollments", {
+        method: "DELETE",
+        body: JSON.stringify({
+          clerkUserId: "user-1",
+          courseId: "22222222-2222-4222-8222-222222222222",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/parish-admin/enrollments/route.ts
+++ b/src/app/api/parish-admin/enrollments/route.ts
@@ -1,0 +1,170 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+const createEnrollmentSchema = z.object({
+  clerkUserId: z.string().min(1),
+  courseId: z.string().uuid(),
+});
+
+const deleteEnrollmentSchema = createEnrollmentSchema;
+
+export async function GET(req: Request) {
+  const { parishId, role, clerkUserId } = await requireParishRole("instructor");
+  const url = new URL(req.url);
+  const courseId = url.searchParams.get("courseId");
+
+  const supabase = getSupabaseAdminClient();
+  let query = supabase
+    .from("enrollments")
+    .select("id,clerk_user_id,course_id,cohort_id,created_at")
+    .eq("parish_id", parishId)
+    .order("created_at", { ascending: false })
+    .limit(500);
+
+  if (role === "instructor") {
+    const { data: cohorts, error: cohortsError } = await supabase
+      .from("cohorts")
+      .select("id")
+      .eq("parish_id", parishId)
+      .eq("facilitator_clerk_user_id", clerkUserId);
+    if (cohortsError) {
+      return NextResponse.json({ error: cohortsError.message }, { status: 400 });
+    }
+
+    const cohortIds = ((cohorts ?? []) as Array<{ id: string }>).map((cohort) => cohort.id);
+    if (cohortIds.length === 0) {
+      return NextResponse.json({ enrollments: [] });
+    }
+    query = query.in("cohort_id", cohortIds);
+  }
+
+  if (courseId) {
+    query = query.eq("course_id", courseId);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ enrollments: data ?? [] });
+}
+
+export async function POST(req: Request) {
+  const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
+  const payload = createEnrollmentSchema.parse(await req.json());
+  const supabase = getSupabaseAdminClient();
+
+  const { data: membership, error: membershipError } = await supabase
+    .from("parish_memberships")
+    .select("clerk_user_id")
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", payload.clerkUserId)
+    .maybeSingle();
+
+  if (membershipError) {
+    return NextResponse.json({ error: membershipError.message }, { status: 400 });
+  }
+
+  if (!membership) {
+    return NextResponse.json({ error: "Learner must belong to this parish before enrollment." }, { status: 400 });
+  }
+
+  const { data: course, error: courseError } = await supabase
+    .from("courses")
+    .select("id,scope,published")
+    .eq("id", payload.courseId)
+    .maybeSingle();
+
+  if (courseError) {
+    return NextResponse.json({ error: courseError.message }, { status: 400 });
+  }
+
+  if (!course || course.published !== true) {
+    return NextResponse.json({ error: "Selected course is not available for enrollment." }, { status: 400 });
+  }
+
+  if (course.scope === "PARISH") {
+    const { data: adoption, error: adoptionError } = await supabase
+      .from("course_parishes")
+      .select("course_id")
+      .eq("course_id", payload.courseId)
+      .eq("parish_id", parishId)
+      .maybeSingle();
+
+    if (adoptionError) {
+      return NextResponse.json({ error: adoptionError.message }, { status: 400 });
+    }
+
+    if (!adoption) {
+      return NextResponse.json({ error: "Adopt this parish-scoped course before enrolling learners." }, { status: 400 });
+    }
+  }
+
+  const { data, error } = await supabase
+    .from("enrollments")
+    .upsert(
+      {
+        parish_id: parishId,
+        clerk_user_id: payload.clerkUserId,
+        course_id: payload.courseId,
+      },
+      { onConflict: "parish_id,clerk_user_id,course_id" },
+    )
+    .select("id,clerk_user_id,course_id,cohort_id,created_at")
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  await recordAdminAuditLog({
+    actorClerkUserId: actorUserId,
+    action: "parish.enrollment_saved",
+    resourceType: "enrollment",
+    resourceId: data.id as string,
+    details: {
+      parish_id: parishId,
+      course_id: payload.courseId,
+      clerk_user_id: payload.clerkUserId,
+    },
+  });
+
+  return NextResponse.json({ enrollment: data }, { status: 201 });
+}
+
+export async function DELETE(req: Request) {
+  const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
+  const payload = deleteEnrollmentSchema.parse(await req.json());
+  const supabase = getSupabaseAdminClient();
+
+  const { error } = await supabase
+    .from("enrollments")
+    .delete()
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", payload.clerkUserId)
+    .eq("course_id", payload.courseId);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  await recordAdminAuditLog({
+    actorClerkUserId: actorUserId,
+    action: "parish.enrollment_removed",
+    resourceType: "enrollment",
+    resourceId: null,
+    details: {
+      parish_id: parishId,
+      course_id: payload.courseId,
+      clerk_user_id: payload.clerkUserId,
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/parish-admin/participation/export/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/participation/export/__tests__/route.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({ requireParishRole: vi.fn() }));
+vi.mock("@/lib/repositories/parish-admin", () => ({ getParishAdminDashboardDataForUser: vi.fn() }));
+
+import { GET } from "@/app/api/parish-admin/participation/export/route";
+import { requireParishRole } from "@/lib/authz";
+import { getParishAdminDashboardDataForUser } from "@/lib/repositories/parish-admin";
+
+describe("GET /api/parish-admin/participation/export", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "admin-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "parish_admin",
+    });
+  });
+
+  it("returns CSV export", async () => {
+    vi.mocked(getParishAdminDashboardDataForUser).mockResolvedValue({
+      role: "parish_admin",
+      overview: {
+        memberCount: 1,
+        enrollmentCount: 1,
+        activeLearnerCount: 1,
+        stalledLearnerCount: 0,
+        completionRate: 50,
+      },
+      visibleCourses: [
+        { id: "22222222-2222-4222-8222-222222222222", title: "RCIA", description: null, published: true, scope: "PARISH" },
+      ],
+      dioceseCourses: [],
+      adoptedParishCourses: [],
+      availableParishCourses: [],
+      enrollments: [],
+      members: [{ clerk_user_id: "user-1", role: "student", email: "person@example.com", display_name: "Person One" }],
+      cohorts: [{ id: "33333333-3333-4333-8333-333333333333", name: "Cohort A", facilitator_clerk_user_id: null, cadence: "weekly", next_session_at: null, created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" }],
+      communicationSends: [],
+      participationRows: [
+        {
+          enrollment_id: "enroll-1",
+          clerk_user_id: "user-1",
+          course_id: "22222222-2222-4222-8222-222222222222",
+          cohort_id: "33333333-3333-4333-8333-333333333333",
+          enrolled_at: "2026-01-02T00:00:00.000Z",
+          completed_lessons: 2,
+          started_lessons: 2,
+          total_lessons: 4,
+          progress_percent: 50,
+          last_activity_at: "2026-01-10T00:00:00.000Z",
+          status: "active",
+        },
+      ],
+    });
+
+    const response = await GET(new Request("http://localhost/api/parish-admin/participation/export"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toContain("text/csv");
+    const body = await response.text();
+    expect(body).toContain("learner_name,learner_email");
+    expect(body).toContain("\"Person One\"");
+    expect(body).toContain("\"RCIA\"");
+  });
+
+  it("applies cohort and status filters", async () => {
+    vi.mocked(getParishAdminDashboardDataForUser).mockResolvedValue({
+      role: "parish_admin",
+      overview: {
+        memberCount: 2,
+        enrollmentCount: 2,
+        activeLearnerCount: 1,
+        stalledLearnerCount: 1,
+        completionRate: 50,
+      },
+      visibleCourses: [
+        { id: "22222222-2222-4222-8222-222222222222", title: "RCIA", description: null, published: true, scope: "PARISH" },
+      ],
+      dioceseCourses: [],
+      adoptedParishCourses: [],
+      availableParishCourses: [],
+      enrollments: [],
+      members: [
+        { clerk_user_id: "user-1", role: "student", email: "a@example.com", display_name: "Alpha" },
+        { clerk_user_id: "user-2", role: "student", email: "b@example.com", display_name: "Beta" },
+      ],
+      cohorts: [{ id: "33333333-3333-4333-8333-333333333333", name: "Cohort A", facilitator_clerk_user_id: null, cadence: "weekly", next_session_at: null, created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" }],
+      communicationSends: [],
+      participationRows: [
+        {
+          enrollment_id: "enroll-1",
+          clerk_user_id: "user-1",
+          course_id: "22222222-2222-4222-8222-222222222222",
+          cohort_id: "33333333-3333-4333-8333-333333333333",
+          enrolled_at: "2026-01-02T00:00:00.000Z",
+          completed_lessons: 1,
+          started_lessons: 1,
+          total_lessons: 4,
+          progress_percent: 25,
+          last_activity_at: "2026-01-03T00:00:00.000Z",
+          status: "stalled",
+        },
+        {
+          enrollment_id: "enroll-2",
+          clerk_user_id: "user-2",
+          course_id: "22222222-2222-4222-8222-222222222222",
+          cohort_id: null,
+          enrolled_at: "2026-01-02T00:00:00.000Z",
+          completed_lessons: 0,
+          started_lessons: 0,
+          total_lessons: 4,
+          progress_percent: 0,
+          last_activity_at: null,
+          status: "not_started",
+        },
+      ],
+    });
+
+    const response = await GET(
+      new Request(
+        "http://localhost/api/parish-admin/participation/export?cohortId=33333333-3333-4333-8333-333333333333&status=stalled",
+      ),
+    );
+    const body = await response.text();
+    expect(body).toContain("\"Alpha\"");
+    expect(body).not.toContain("\"Beta\"");
+  });
+
+  it("returns 400 for invalid filters", async () => {
+    const response = await GET(
+      new Request("http://localhost/api/parish-admin/participation/export?status=invalid"),
+    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid participation export filters." });
+  });
+});

--- a/src/app/api/parish-admin/participation/export/route.ts
+++ b/src/app/api/parish-admin/participation/export/route.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+
+import { requireParishRole } from "@/lib/authz";
+import type {
+  ParishAdminCourseRow,
+  ParishAdminCohortRow,
+  ParishAdminMemberRow,
+  ParishAdminParticipationRow,
+  ParishParticipationStatus,
+} from "@/lib/repositories/parish-admin";
+import { getParishAdminDashboardDataForUser } from "@/lib/repositories/parish-admin";
+
+const querySchema = z.object({
+  courseId: z.string().uuid().optional(),
+  cohortId: z.union([z.string().uuid(), z.literal("unassigned")]).optional(),
+  status: z.enum(["not_started", "active", "stalled", "completed"]).optional(),
+  search: z.string().trim().max(120).optional(),
+});
+
+const statusLabels: Record<ParishParticipationStatus, string> = {
+  not_started: "Not started",
+  active: "Active",
+  stalled: "Stalled",
+  completed: "Completed",
+};
+
+function toLearnerLabel(member: ParishAdminMemberRow | undefined, clerkUserId: string) {
+  return member?.display_name ?? member?.email ?? clerkUserId;
+}
+
+function filterRows({
+  rows,
+  members,
+  courses,
+  cohorts,
+  filters,
+}: {
+  rows: ParishAdminParticipationRow[];
+  members: ParishAdminMemberRow[];
+  courses: ParishAdminCourseRow[];
+  cohorts: ParishAdminCohortRow[];
+  filters: z.infer<typeof querySchema>;
+}) {
+  const memberById = new Map(members.map((member) => [member.clerk_user_id, member]));
+  const courseTitleById = new Map(courses.map((course) => [course.id, course.title]));
+  const cohortNameById = new Map(cohorts.map((cohort) => [cohort.id, cohort.name]));
+  const normalizedSearch = filters.search?.trim().toLowerCase() ?? "";
+
+  return rows.filter((row) => {
+    if (filters.courseId && row.course_id !== filters.courseId) return false;
+    if (filters.cohortId === "unassigned" && row.cohort_id) return false;
+    if (filters.cohortId && filters.cohortId !== "unassigned" && row.cohort_id !== filters.cohortId) return false;
+    if (filters.status && row.status !== filters.status) return false;
+
+    if (!normalizedSearch) return true;
+    const learnerLabel = toLearnerLabel(memberById.get(row.clerk_user_id), row.clerk_user_id).toLowerCase();
+    const courseTitle = (courseTitleById.get(row.course_id) ?? row.course_id).toLowerCase();
+    const cohortName = (row.cohort_id ? cohortNameById.get(row.cohort_id) ?? row.cohort_id : "unassigned").toLowerCase();
+    const clerkUserId = row.clerk_user_id.toLowerCase();
+
+    return (
+      learnerLabel.includes(normalizedSearch) ||
+      courseTitle.includes(normalizedSearch) ||
+      cohortName.includes(normalizedSearch) ||
+      clerkUserId.includes(normalizedSearch)
+    );
+  });
+}
+
+function csvValue(value: string | number | null) {
+  return `"${String(value ?? "").replaceAll('"', '""')}"`;
+}
+
+export async function GET(req: Request) {
+  const { parishId, role, clerkUserId } = await requireParishRole("instructor");
+  const url = new URL(req.url);
+  const parsed = querySchema.safeParse({
+    courseId: url.searchParams.get("courseId") ?? undefined,
+    cohortId: url.searchParams.get("cohortId") ?? undefined,
+    status: url.searchParams.get("status") ?? undefined,
+    search: url.searchParams.get("search") ?? undefined,
+  });
+
+  if (!parsed.success) {
+    return Response.json({ error: "Invalid participation export filters." }, { status: 400 });
+  }
+
+  const data = await getParishAdminDashboardDataForUser({
+    parishId,
+    role,
+    clerkUserId,
+  });
+  const memberById = new Map(data.members.map((member) => [member.clerk_user_id, member]));
+  const courseTitleById = new Map(data.visibleCourses.map((course) => [course.id, course.title]));
+  const cohortNameById = new Map(data.cohorts.map((cohort) => [cohort.id, cohort.name]));
+  const rows = filterRows({
+    rows: data.participationRows,
+    members: data.members,
+    courses: data.visibleCourses,
+    cohorts: data.cohorts,
+    filters: parsed.data,
+  });
+
+  const headers = [
+    "learner_name",
+    "learner_email",
+    "clerk_user_id",
+    "course",
+    "cohort",
+    "status",
+    "progress_percent",
+    "completed_lessons",
+    "total_lessons",
+    "last_activity_at",
+    "enrolled_at",
+  ];
+  const lines = [
+    headers.join(","),
+    ...rows.map((row) =>
+      [
+        toLearnerLabel(memberById.get(row.clerk_user_id), row.clerk_user_id),
+        memberById.get(row.clerk_user_id)?.email ?? "",
+        row.clerk_user_id,
+        courseTitleById.get(row.course_id) ?? row.course_id,
+        row.cohort_id ? cohortNameById.get(row.cohort_id) ?? row.cohort_id : "Unassigned",
+        statusLabels[row.status],
+        row.progress_percent,
+        row.completed_lessons,
+        row.total_lessons,
+        row.last_activity_at ?? "",
+        row.enrolled_at,
+      ]
+        .map(csvValue)
+        .join(","),
+    ),
+  ];
+
+  return new Response(lines.join("\n"), {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": 'attachment; filename="parish-participation.csv"',
+    },
+  });
+}

--- a/src/app/api/parish-admin/people/[clerkUserId]/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/people/[clerkUserId]/__tests__/route.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({ requireParishRole: vi.fn() }));
+vi.mock("@/lib/audit-log", () => ({ recordAdminAuditLog: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ getSupabaseAdminClient: vi.fn() }));
+
+import { DELETE, PATCH } from "@/app/api/parish-admin/people/[clerkUserId]/route";
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+describe("/api/parish-admin/people/[clerkUserId]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "admin-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "parish_admin",
+    });
+  });
+
+  it("updates a member role", async () => {
+    const membershipSingle = vi.fn(async () => ({
+      data: { parish_id: "p1", clerk_user_id: "user-1", role: "instructor" },
+      error: null,
+    }));
+    const membershipSelect = vi.fn(() => ({ maybeSingle: membershipSingle }));
+    const membershipEqUser = vi.fn(() => ({ select: membershipSelect }));
+    const membershipEqParish = vi.fn(() => ({ eq: membershipEqUser }));
+    const membershipUpdate = vi.fn(() => ({ eq: membershipEqParish }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ update: membershipUpdate })),
+    } as never);
+
+    const response = await PATCH(
+      new Request("http://localhost/api/parish-admin/people/user-1", {
+        method: "PATCH",
+        body: JSON.stringify({ role: "instructor" }),
+      }),
+      { params: Promise.resolve({ clerkUserId: "user-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      membership: { parish_id: "p1", clerk_user_id: "user-1", role: "instructor" },
+    });
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("removes a member", async () => {
+    const eqUser = vi.fn(async () => ({ error: null }));
+    const eqParish = vi.fn(() => ({ eq: eqUser }));
+    const del = vi.fn(() => ({ eq: eqParish }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ delete: del })),
+    } as never);
+
+    const response = await DELETE(
+      new Request("http://localhost/api/parish-admin/people/user-1", { method: "DELETE" }),
+      { params: Promise.resolve({ clerkUserId: "user-1" }) },
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks self-removal", async () => {
+    const response = await DELETE(
+      new Request("http://localhost/api/parish-admin/people/admin-1", { method: "DELETE" }),
+      { params: Promise.resolve({ clerkUserId: "admin-1" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "You cannot remove your own parish membership." });
+  });
+});

--- a/src/app/api/parish-admin/people/[clerkUserId]/route.ts
+++ b/src/app/api/parish-admin/people/[clerkUserId]/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+const paramsSchema = z.object({
+  clerkUserId: z.string().min(1),
+});
+
+const updateRoleSchema = z.object({
+  role: z.enum(["parish_admin", "instructor", "student"]),
+});
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ clerkUserId: string }> }) {
+  const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
+  const { clerkUserId } = paramsSchema.parse(await ctx.params);
+  const payload = updateRoleSchema.parse(await req.json());
+
+  if (clerkUserId === actorUserId) {
+    return NextResponse.json({ error: "You cannot change your own parish role." }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from("parish_memberships")
+    .update({ role: payload.role })
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", clerkUserId)
+    .select("parish_id,clerk_user_id,role")
+    .maybeSingle();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  if (!data) {
+    return NextResponse.json({ error: "Membership not found." }, { status: 404 });
+  }
+
+  await recordAdminAuditLog({
+    actorClerkUserId: actorUserId,
+    action: "parish.member_role_updated",
+    resourceType: "parish_membership",
+    resourceId: clerkUserId,
+    details: {
+      parish_id: parishId,
+      role: payload.role,
+    },
+  });
+
+  return NextResponse.json({ membership: data });
+}
+
+export async function DELETE(_req: Request, ctx: { params: Promise<{ clerkUserId: string }> }) {
+  const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
+  const { clerkUserId } = paramsSchema.parse(await ctx.params);
+
+  if (clerkUserId === actorUserId) {
+    return NextResponse.json({ error: "You cannot remove your own parish membership." }, { status: 400 });
+  }
+
+  const supabase = getSupabaseAdminClient();
+  const { error } = await supabase
+    .from("parish_memberships")
+    .delete()
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", clerkUserId);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  await recordAdminAuditLog({
+    actorClerkUserId: actorUserId,
+    action: "parish.member_removed",
+    resourceType: "parish_membership",
+    resourceId: clerkUserId,
+    details: {
+      parish_id: parishId,
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/parish-admin/people/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/people/__tests__/route.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({ requireParishRole: vi.fn() }));
+vi.mock("@/lib/audit-log", () => ({ recordAdminAuditLog: vi.fn() }));
+vi.mock("@/lib/supabase/server", () => ({ getSupabaseAdminClient: vi.fn() }));
+
+import { POST, PUT } from "@/app/api/parish-admin/people/route";
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+describe("/api/parish-admin/people", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "admin-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      role: "parish_admin",
+    });
+  });
+
+  it("adds a member by email", async () => {
+    const userLimit = vi.fn(async () => ({
+      data: [{ clerk_user_id: "user-1", email: "person@example.com", display_name: "Person" }],
+      error: null,
+    }));
+    const userOrder = vi.fn(() => ({ limit: userLimit }));
+    const userIlike = vi.fn(() => ({ order: userOrder }));
+    const userSelect = vi.fn(() => ({ ilike: userIlike }));
+
+    const membershipSingle = vi.fn(async () => ({ data: { clerk_user_id: "user-1", role: "student" }, error: null }));
+    const membershipSelect = vi.fn(() => ({ single: membershipSingle }));
+    const membershipUpsert = vi.fn(() => ({ select: membershipSelect }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "user_profiles") return { select: userSelect };
+        if (table === "parish_memberships") return { upsert: membershipUpsert };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/people", {
+        method: "POST",
+        body: JSON.stringify({ identifier: "person@example.com", role: "student" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      membership: { clerk_user_id: "user-1", role: "student" },
+      user: { clerk_user_id: "user-1", email: "person@example.com", display_name: "Person" },
+    });
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("imports memberships from csv", async () => {
+    const userLimit = vi.fn(async () => ({
+      data: [{ clerk_user_id: "user-1", email: "person@example.com", display_name: "Person" }],
+      error: null,
+    }));
+    const userOrder = vi.fn(() => ({ limit: userLimit }));
+    const userIlike = vi.fn(() => ({ order: userOrder }));
+    const userSelect = vi.fn(() => ({ ilike: userIlike }));
+
+    const membershipUpsert = vi.fn(async () => ({ error: null }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "user_profiles") return { select: userSelect };
+        if (table === "parish_memberships") return { upsert: membershipUpsert };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await PUT(
+      new Request("http://localhost/api/parish-admin/people", {
+        method: "PUT",
+        body: JSON.stringify({
+          csvText: "email,role\nperson@example.com,student",
+          defaultRole: "student",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      summary: {
+        totalRows: 1,
+        importedCount: 1,
+        skippedCount: 0,
+      },
+      results: [
+        {
+          row: 2,
+          identifier: "user-1",
+          role: "student",
+          status: "imported",
+          message: "Membership saved.",
+        },
+      ],
+    });
+    expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 400 when csv header is missing required columns", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ select: vi.fn() })),
+    } as never);
+
+    const response = await PUT(
+      new Request("http://localhost/api/parish-admin/people", {
+        method: "PUT",
+        body: JSON.stringify({
+          csvText: "name,role\nperson,student",
+          defaultRole: "student",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "CSV header must include either clerk_user_id or email.",
+    });
+  });
+});

--- a/src/app/api/parish-admin/people/route.ts
+++ b/src/app/api/parish-admin/people/route.ts
@@ -1,0 +1,291 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { requireParishRole } from "@/lib/authz";
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import { ParishRole } from "@/lib/types";
+
+const parishMembershipRoleSchema = z.enum(["parish_admin", "instructor", "student"]);
+
+const upsertPersonSchema = z.object({
+  identifier: z.string().trim().min(1),
+  role: parishMembershipRoleSchema.default("student"),
+});
+
+type SupabaseUserProfile = {
+  clerk_user_id: string;
+  email: string | null;
+  display_name: string | null;
+};
+
+async function resolveUserByIdentifier(identifier: string): Promise<SupabaseUserProfile | null> {
+  const normalizedIdentifier = identifier.trim();
+  const supabase = getSupabaseAdminClient();
+  const isEmail = normalizedIdentifier.includes("@");
+
+  if (isEmail) {
+    const { data, error } = await supabase
+      .from("user_profiles")
+      .select("clerk_user_id,email,display_name")
+      .ilike("email", normalizedIdentifier)
+      .order("created_at", { ascending: false })
+      .limit(1);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const row = ((data ?? []) as SupabaseUserProfile[])[0];
+    return row ?? null;
+  }
+
+  const { data, error } = await supabase
+    .from("user_profiles")
+    .select("clerk_user_id,email,display_name")
+    .eq("clerk_user_id", normalizedIdentifier)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return (data as SupabaseUserProfile | null) ?? null;
+}
+
+export async function POST(req: Request) {
+  const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
+  const payload = upsertPersonSchema.parse(await req.json());
+
+  const userProfile = await resolveUserByIdentifier(payload.identifier);
+  if (!userProfile) {
+    return NextResponse.json(
+      {
+        error:
+          "No existing platform account matches that identifier. Use an existing email or clerk_user_id.",
+      },
+      { status: 404 },
+    );
+  }
+
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from("parish_memberships")
+    .upsert(
+      {
+        parish_id: parishId,
+        clerk_user_id: userProfile.clerk_user_id,
+        role: payload.role,
+      },
+      { onConflict: "parish_id,clerk_user_id" },
+    )
+    .select("parish_id,clerk_user_id,role")
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  await recordAdminAuditLog({
+    actorClerkUserId: actorUserId,
+    action: "parish.member_upserted",
+    resourceType: "parish_membership",
+    resourceId: userProfile.clerk_user_id,
+    details: {
+      parish_id: parishId,
+      role: payload.role,
+      identifier: payload.identifier,
+    },
+  });
+
+  return NextResponse.json({
+    membership: data,
+    user: {
+      clerk_user_id: userProfile.clerk_user_id,
+      email: userProfile.email,
+      display_name: userProfile.display_name,
+    },
+  });
+}
+
+function parseCsvLine(line: string): string[] {
+  const cells: string[] = [];
+  let current = "";
+  let insideQuotes = false;
+
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    const next = line[i + 1];
+
+    if (ch === "\"") {
+      if (insideQuotes && next === "\"") {
+        current += "\"";
+        i += 1;
+      } else {
+        insideQuotes = !insideQuotes;
+      }
+      continue;
+    }
+
+    if (ch === "," && !insideQuotes) {
+      cells.push(current.trim());
+      current = "";
+      continue;
+    }
+
+    current += ch;
+  }
+
+  cells.push(current.trim());
+  return cells.map((value) => value.replace(/^"(.*)"$/, "$1").trim());
+}
+
+function normalizeHeaderCell(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, "_");
+}
+
+function parseCsvRows(csvText: string) {
+  return csvText
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => parseCsvLine(line));
+}
+
+const importMembersSchema = z.object({
+  csvText: z.string().min(1),
+  defaultRole: parishMembershipRoleSchema.default("student"),
+});
+
+interface ImportResultRow {
+  row: number;
+  identifier: string;
+  role: ParishRole;
+  status: "imported" | "skipped";
+  message: string;
+}
+
+export async function PUT(req: Request) {
+  const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
+  const payload = importMembersSchema.parse(await req.json());
+  const parsedRows = parseCsvRows(payload.csvText);
+
+  if (parsedRows.length === 0) {
+    return NextResponse.json({ error: "CSV is empty." }, { status: 400 });
+  }
+
+  const header = parsedRows[0].map((cell) => normalizeHeaderCell(cell));
+  const clerkIdIndex = header.indexOf("clerk_user_id");
+  const emailIndex = header.indexOf("email");
+  const roleIndex = header.indexOf("role");
+
+  if (clerkIdIndex === -1 && emailIndex === -1) {
+    return NextResponse.json(
+      { error: "CSV header must include either clerk_user_id or email." },
+      { status: 400 },
+    );
+  }
+
+  const dataRows = parsedRows.slice(1);
+  const supabase = getSupabaseAdminClient();
+  const results: ImportResultRow[] = [];
+
+  for (let rowIdx = 0; rowIdx < dataRows.length; rowIdx += 1) {
+    const row = dataRows[rowIdx];
+    const rowNumber = rowIdx + 2;
+    const clerkId = clerkIdIndex >= 0 ? (row[clerkIdIndex] ?? "").trim() : "";
+    const email = emailIndex >= 0 ? (row[emailIndex] ?? "").trim() : "";
+    const identifier = clerkId || email;
+
+    const parsedRole = parishMembershipRoleSchema.safeParse(roleIndex >= 0 ? row[roleIndex] : undefined);
+    const role = parsedRole.success ? parsedRole.data : payload.defaultRole;
+
+    if (!identifier) {
+      results.push({
+        row: rowNumber,
+        identifier: "",
+        role,
+        status: "skipped",
+        message: "Missing identifier (email or clerk_user_id).",
+      });
+      continue;
+    }
+
+    let userProfile: SupabaseUserProfile | null = null;
+    try {
+      userProfile = await resolveUserByIdentifier(identifier);
+    } catch (error) {
+      results.push({
+        row: rowNumber,
+        identifier,
+        role,
+        status: "skipped",
+        message: error instanceof Error ? error.message : "Failed to resolve user profile.",
+      });
+      continue;
+    }
+
+    if (!userProfile) {
+      results.push({
+        row: rowNumber,
+        identifier,
+        role,
+        status: "skipped",
+        message: "No platform account found.",
+      });
+      continue;
+    }
+
+    const { error } = await supabase.from("parish_memberships").upsert(
+      {
+        parish_id: parishId,
+        clerk_user_id: userProfile.clerk_user_id,
+        role,
+      },
+      { onConflict: "parish_id,clerk_user_id" },
+    );
+
+    if (error) {
+      results.push({
+        row: rowNumber,
+        identifier,
+        role,
+        status: "skipped",
+        message: error.message,
+      });
+      continue;
+    }
+
+    results.push({
+      row: rowNumber,
+      identifier: userProfile.clerk_user_id,
+      role,
+      status: "imported",
+      message: "Membership saved.",
+    });
+  }
+
+  const importedCount = results.filter((result) => result.status === "imported").length;
+  const skippedCount = results.length - importedCount;
+
+  await recordAdminAuditLog({
+    actorClerkUserId: actorUserId,
+    action: "parish.members_imported",
+    resourceType: "parish_memberships",
+    resourceId: parishId,
+    details: {
+      parish_id: parishId,
+      imported_count: importedCount,
+      skipped_count: skippedCount,
+    },
+  });
+
+  return NextResponse.json({
+    summary: {
+      totalRows: results.length,
+      importedCount,
+      skippedCount,
+    },
+    results,
+  });
+}

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -3,21 +3,23 @@ import { UserButton } from "@clerk/nextjs";
 
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
-import { requireAuth } from "@/lib/authz";
-
-const navItems = [
-  { label: "Courses", href: "/app/courses" },
-  { label: "Select Parish", href: "/app/select-parish?manage=1" },
-  { label: "Parish Admin", href: "/app/parish-admin" },
-  { label: "Diocese Admin", href: "/app/admin" },
-];
+import { isE2ESmokeMode } from "@/lib/e2e-mode";
+import { isDioceseAdmin, requireAuth } from "@/lib/authz";
 
 export default async function AppLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  await requireAuth();
+  const clerkUserId = await requireAuth();
+  const showDioceseAdmin = await isDioceseAdmin(clerkUserId);
+  const showUserButton = !isE2ESmokeMode() && Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
+  const navItems = [
+    { label: "Courses", href: "/app/courses" },
+    { label: "Select Parish", href: "/app/select-parish?manage=1" },
+    { label: "Parish Admin", href: "/app/parish-admin" },
+    ...(showDioceseAdmin ? [{ label: "Diocese Admin", href: "/app/admin" }] : []),
+  ];
 
   return (
     <div className="min-h-screen">
@@ -38,7 +40,7 @@ export default async function AppLayout({
           </nav>
           <div className="flex items-center gap-3">
             <ThemeToggle />
-            <UserButton />
+            {showUserButton ? <UserButton /> : null}
           </div>
         </div>
       </header>

--- a/src/app/app/parish-admin/page.tsx
+++ b/src/app/app/parish-admin/page.tsx
@@ -1,45 +1,220 @@
-import Link from "next/link";
-
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ParishCourseAdoptionManager } from "@/components/parish-course-adoption-manager";
+import { ParishCohortManager } from "@/components/parish-cohort-manager";
+import { ParishCommunicationsManager } from "@/components/parish-communications-manager";
+import { ParishEnrollmentManager } from "@/components/parish-enrollment-manager";
+import { ParishPeopleManager } from "@/components/parish-people-manager";
+import { ParishParticipationManager } from "@/components/parish-participation-manager";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { requireParishRole } from "@/lib/authz";
-import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import { getParishAdminDashboardDataForUser } from "@/lib/repositories/parish-admin";
 
-export default async function ParishAdminPage() {
-  const { parishId } = await requireParishRole("parish_admin");
-  const supabase = getSupabaseAdminClient();
-  const [{ data: courses }, { data: metrics }] = await Promise.all([
-    supabase.rpc("get_visible_courses", { p_parish_id: parishId }),
-    supabase.rpc("parish_course_metrics", { p_parish_id: parishId }),
-  ]);
+function firstValue(value: string | string[] | undefined) {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+export default async function ParishAdminPage({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const params = await searchParams;
+  const communicationPrefill = {
+    audienceType: firstValue(params.audienceType) ?? null,
+    audienceValue: firstValue(params.audienceValue) ?? null,
+    subject: firstValue(params.subject) ?? null,
+    body: firstValue(params.body) ?? null,
+  };
+  const { parishId, role, clerkUserId } = await requireParishRole("instructor");
+  const {
+    visibleCourses,
+    dioceseCourses,
+    adoptedParishCourses,
+    availableParishCourses,
+    enrollments,
+    members,
+    cohorts,
+    overview,
+    communicationSends,
+    participationRows,
+  } = await getParishAdminDashboardDataForUser({ parishId, role, clerkUserId });
+  const roleLabel = role === "parish_admin" ? "Parish Admin" : "Facilitator";
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">Parish Admin Dashboard</h1>
+      <header className="space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <h1 className="text-2xl font-semibold">Parish Admin Dashboard</h1>
+          <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium text-foreground">
+            {roleLabel}
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {role === "parish_admin"
+            ? "Adopt parish-scoped courses, manage learner enrollments, and monitor current participation."
+            : "Manage your assigned cohorts and monitor participation for your learners."}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {role === "parish_admin"
+            ? "Full parish controls: course adoption, enrollment management, and cohort administration."
+            : "Limited scope: you can view and update cohorts where you are the assigned facilitator."}
+        </p>
+      </header>
+
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Parish members</CardDescription>
+            <CardTitle className="text-2xl">{overview.memberCount.toLocaleString()}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Total enrollments</CardDescription>
+            <CardTitle className="text-2xl">{overview.enrollmentCount.toLocaleString()}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Active learners</CardDescription>
+            <CardTitle className="text-2xl">{overview.activeLearnerCount.toLocaleString()}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Stalled learners (7+ days)</CardDescription>
+            <CardTitle className="text-2xl">{overview.stalledLearnerCount.toLocaleString()}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Completion rate</CardDescription>
+            <CardTitle className="text-2xl">{overview.completionRate}%</CardTitle>
+          </CardHeader>
+        </Card>
+      </section>
+
+      {role === "parish_admin" ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Adopt Parish Courses</CardTitle>
+            <CardDescription>
+              Parish-scoped courses require explicit adoption before they can be assigned to parishioners.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-auto">
+            <ParishCourseAdoptionManager
+              adoptedCourses={adoptedParishCourses}
+              availableCourses={availableParishCourses}
+            />
+          </CardContent>
+        </Card>
+      ) : null}
+
       <Card>
         <CardHeader>
-          <CardTitle>Visible Courses</CardTitle>
+          <CardTitle>Participation Watchlist</CardTitle>
+          <CardDescription>
+            Track learner progress by status and identify who needs intervention.
+          </CardDescription>
         </CardHeader>
-        <CardContent>
-          <ul className="space-y-1">
-            {((courses ?? []) as Array<{ id: string; title: string }>).map((course) => (
-              <li key={course.id}>
-                <Button asChild className="h-auto p-0 font-medium" variant="link">
-                  <Link href={`/app/courses/${course.id}`}>{course.title}</Link>
-                </Button>
-              </li>
-            ))}
-          </ul>
+        <CardContent className="overflow-auto">
+          <ParishParticipationManager
+            canLogCommunications={role === "parish_admin"}
+            cohorts={cohorts}
+            courses={visibleCourses}
+            members={members}
+            participationRows={participationRows}
+          />
         </CardContent>
       </Card>
+
       <Card>
         <CardHeader>
-          <CardTitle>Parish Course Analytics</CardTitle>
+          <CardTitle>Cohorts</CardTitle>
+          <CardDescription>
+            Organize enrolled learners into groups, assign facilitators, and set cadence.
+          </CardDescription>
         </CardHeader>
-        <CardContent>
-          <pre className="overflow-auto text-xs">{JSON.stringify(metrics ?? [], null, 2)}</pre>
+        <CardContent className="overflow-auto">
+          <ParishCohortManager
+            canManageAll={role === "parish_admin"}
+            cohorts={cohorts}
+            courses={visibleCourses}
+            enrollments={enrollments}
+            members={members}
+          />
         </CardContent>
       </Card>
+
+      {role === "parish_admin" ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Enrollment Management</CardTitle>
+            <CardDescription>
+              Enroll parish members in visible courses and remove enrollments when needed.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-auto">
+            <ParishEnrollmentManager courses={visibleCourses} enrollments={enrollments} members={members} />
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {role === "parish_admin" ? (
+        <Card id="communications">
+          <CardHeader>
+            <CardTitle>Communications</CardTitle>
+            <CardDescription>
+              Log nudges and announcements by audience while delivery integration is still pending.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-auto">
+            <ParishCommunicationsManager
+              cohorts={cohorts}
+              courses={visibleCourses}
+              prefill={communicationPrefill}
+              sends={communicationSends}
+            />
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {role === "parish_admin" ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>People</CardTitle>
+            <CardDescription>
+              Add existing platform users to this parish, update roles, and import memberships in bulk via CSV.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="overflow-auto">
+            <ParishPeopleManager members={members} />
+          </CardContent>
+        </Card>
+      ) : null}
+
+      {role === "parish_admin" ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Diocese-wide Courses</CardTitle>
+            <CardDescription>These courses are already visible to your parish by diocesan policy.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {dioceseCourses.length > 0 ? (
+              <ul className="space-y-1 text-sm">
+                {dioceseCourses.map((course) => (
+                  <li key={course.id}>
+                    <span className="font-medium">{course.title}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">No diocese-wide courses are currently published.</p>
+            )}
+          </CardContent>
+        </Card>
+      ) : null}
     </div>
   );
 }

--- a/src/components/parish-cohort-manager.tsx
+++ b/src/components/parish-cohort-manager.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import type {
+  ParishAdminCohortRow,
+  ParishAdminCourseRow,
+  ParishAdminEnrollmentRow,
+  ParishAdminMemberRow,
+} from "@/lib/repositories/parish-admin";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+
+type CohortCadence = ParishAdminCohortRow["cadence"];
+
+interface CohortDraft {
+  id: string;
+  name: string;
+  facilitatorClerkUserId: string;
+  cadence: CohortCadence;
+  nextSessionAt: string;
+}
+
+function toDateTimeLocalValue(dateValue: string | null) {
+  if (!dateValue) return "";
+  const date = new Date(dateValue);
+  if (Number.isNaN(date.getTime())) return "";
+  const localDate = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+  return localDate.toISOString().slice(0, 16);
+}
+
+function toIsoDateTimeOrNull(dateValue: string) {
+  if (!dateValue) return null;
+  const parsed = new Date(dateValue);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toISOString();
+}
+
+function getMemberLabel(member: ParishAdminMemberRow) {
+  const base = member.display_name ?? member.email ?? member.clerk_user_id;
+  return `${base} (${member.role})`;
+}
+
+export function ParishCohortManager({
+  canManageAll,
+  cohorts,
+  members,
+  enrollments,
+  courses,
+}: {
+  canManageAll: boolean;
+  cohorts: ParishAdminCohortRow[];
+  members: ParishAdminMemberRow[];
+  enrollments: ParishAdminEnrollmentRow[];
+  courses: ParishAdminCourseRow[];
+}) {
+  const router = useRouter();
+  const [newName, setNewName] = useState("");
+  const [newFacilitatorId, setNewFacilitatorId] = useState("");
+  const [newCadence, setNewCadence] = useState<CohortCadence>("weekly");
+  const [newNextSessionAt, setNewNextSessionAt] = useState("");
+  const [selectedEnrollmentId, setSelectedEnrollmentId] = useState(enrollments[0]?.id ?? "");
+  const [selectedAssignmentCohortId, setSelectedAssignmentCohortId] = useState("");
+  const [message, setMessage] = useState("");
+  const [drafts, setDrafts] = useState<Record<string, CohortDraft>>(
+    Object.fromEntries(
+      cohorts.map((cohort) => [
+        cohort.id,
+        {
+          id: cohort.id,
+          name: cohort.name,
+          facilitatorClerkUserId: cohort.facilitator_clerk_user_id ?? "",
+          cadence: cohort.cadence,
+          nextSessionAt: toDateTimeLocalValue(cohort.next_session_at),
+        },
+      ]),
+    ),
+  );
+
+  const memberById = useMemo(
+    () => new Map(members.map((member) => [member.clerk_user_id, member])),
+    [members],
+  );
+  const courseById = useMemo(() => new Map(courses.map((course) => [course.id, course])), [courses]);
+  const cohortById = useMemo(() => new Map(cohorts.map((cohort) => [cohort.id, cohort])), [cohorts]);
+  const enrollmentCountByCohort = useMemo(() => {
+    const counts = new Map<string, number>();
+    enrollments.forEach((enrollment) => {
+      if (!enrollment.cohort_id) return;
+      counts.set(enrollment.cohort_id, (counts.get(enrollment.cohort_id) ?? 0) + 1);
+    });
+    return counts;
+  }, [enrollments]);
+
+  const selectedEnrollmentIdValue = enrollments.some((enrollment) => enrollment.id === selectedEnrollmentId)
+    ? selectedEnrollmentId
+    : (enrollments[0]?.id ?? "");
+  const selectedEnrollment = enrollments.find((enrollment) => enrollment.id === selectedEnrollmentIdValue) ?? null;
+  const selectedAssignmentCohortIdValue =
+    selectedAssignmentCohortId === "" || cohorts.some((cohort) => cohort.id === selectedAssignmentCohortId)
+      ? selectedAssignmentCohortId
+      : (selectedEnrollment?.cohort_id ?? "");
+
+  async function createCohort() {
+    const response = await fetch("/api/parish-admin/cohorts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: newName,
+        facilitatorClerkUserId: newFacilitatorId || null,
+        cadence: newCadence,
+        nextSessionAt: toIsoDateTimeOrNull(newNextSessionAt),
+      }),
+    });
+    const data = await response.json();
+    setMessage(response.ok ? "Cohort created." : data.error ?? "Failed to create cohort.");
+    if (!response.ok) return;
+
+    setNewName("");
+    setNewFacilitatorId("");
+    setNewCadence("weekly");
+    setNewNextSessionAt("");
+    router.refresh();
+  }
+
+  async function saveCohort(cohortId: string) {
+    const draft = drafts[cohortId];
+    if (!draft) return;
+
+    const response = await fetch(`/api/parish-admin/cohorts/${cohortId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: draft.name,
+        facilitatorClerkUserId: draft.facilitatorClerkUserId || null,
+        cadence: draft.cadence,
+        nextSessionAt: toIsoDateTimeOrNull(draft.nextSessionAt),
+      }),
+    });
+    const data = await response.json();
+    setMessage(response.ok ? "Cohort updated." : data.error ?? "Failed to update cohort.");
+    if (response.ok) {
+      router.refresh();
+    }
+  }
+
+  async function deleteCohort(cohortId: string) {
+    const response = await fetch(`/api/parish-admin/cohorts/${cohortId}`, {
+      method: "DELETE",
+    });
+    const data = await response.json();
+    setMessage(response.ok ? "Cohort deleted." : data.error ?? "Failed to delete cohort.");
+    if (response.ok) {
+      router.refresh();
+    }
+  }
+
+  async function assignEnrollmentToCohort() {
+    if (!selectedEnrollmentIdValue) return;
+    const response = await fetch("/api/parish-admin/cohort-assignments", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        enrollmentId: selectedEnrollmentIdValue,
+        cohortId: selectedAssignmentCohortIdValue || null,
+      }),
+    });
+    const data = await response.json();
+    setMessage(response.ok ? "Enrollment assignment updated." : data.error ?? "Failed to assign enrollment.");
+    if (response.ok) {
+      router.refresh();
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      {canManageAll ? (
+        <div className="grid gap-2 rounded-md border border-border p-3 md:grid-cols-[1.2fr_1fr_1fr_1fr_auto]">
+          <Input onChange={(e) => setNewName(e.target.value)} placeholder="Cohort name" value={newName} />
+
+          <Select onChange={(e) => setNewFacilitatorId(e.target.value)} value={newFacilitatorId}>
+            <option value="">No facilitator assigned</option>
+            {members.map((member) => (
+              <option key={member.clerk_user_id} value={member.clerk_user_id}>
+                {getMemberLabel(member)}
+              </option>
+            ))}
+          </Select>
+
+          <Select onChange={(e) => setNewCadence(e.target.value as CohortCadence)} value={newCadence}>
+            <option value="weekly">Weekly</option>
+            <option value="biweekly">Biweekly</option>
+            <option value="monthly">Monthly</option>
+            <option value="custom">Custom</option>
+          </Select>
+
+          <Input
+            onChange={(e) => setNewNextSessionAt(e.target.value)}
+            placeholder="Next session"
+            type="datetime-local"
+            value={newNextSessionAt}
+          />
+
+          <Button disabled={!newName.trim()} onClick={createCohort} type="button">
+            Create cohort
+          </Button>
+        </div>
+      ) : null}
+
+      {canManageAll ? (
+        <div className="grid gap-2 rounded-md border border-border p-3 md:grid-cols-[1.4fr_1.2fr_1fr_1fr_auto]">
+          <Select onChange={(e) => setSelectedEnrollmentId(e.target.value)} value={selectedEnrollmentIdValue}>
+            {enrollments.length > 0 ? (
+              enrollments.map((enrollment) => {
+                const member = memberById.get(enrollment.clerk_user_id);
+                const course = courseById.get(enrollment.course_id);
+                const assignedCohort = enrollment.cohort_id ? cohortById.get(enrollment.cohort_id) : null;
+                return (
+                  <option key={enrollment.id} value={enrollment.id}>
+                    {(member ? getMemberLabel(member) : enrollment.clerk_user_id) +
+                      " - " +
+                      (course?.title ?? enrollment.course_id) +
+                      (assignedCohort ? ` (${assignedCohort.name})` : " (Unassigned)")}
+                  </option>
+                );
+              })
+            ) : (
+              <option value="">No enrollments available</option>
+            )}
+          </Select>
+
+          <Select onChange={(e) => setSelectedAssignmentCohortId(e.target.value)} value={selectedAssignmentCohortIdValue}>
+            <option value="">Unassigned</option>
+            {cohorts.map((cohort) => (
+              <option key={cohort.id} value={cohort.id}>
+                {cohort.name}
+              </option>
+            ))}
+          </Select>
+
+          <div className="rounded-md border border-border px-3 py-2 text-sm text-muted-foreground">
+            Current:{" "}
+            {selectedEnrollment?.cohort_id
+              ? (cohortById.get(selectedEnrollment.cohort_id)?.name ?? "Unknown")
+              : "Unassigned"}
+          </div>
+
+          <div className="rounded-md border border-border px-3 py-2 text-sm text-muted-foreground">
+            Enrollments: {enrollments.length}
+          </div>
+
+          <Button
+            disabled={!selectedEnrollmentIdValue}
+            onClick={assignEnrollmentToCohort}
+            type="button"
+            variant="secondary"
+          >
+            Update assignment
+          </Button>
+        </div>
+      ) : null}
+
+      {cohorts.length > 0 ? (
+        <table className="w-full text-left text-sm">
+          <thead className="text-muted-foreground">
+            <tr>
+              <th className="py-2 pr-4 font-medium">Name</th>
+              <th className="py-2 pr-4 font-medium">Facilitator</th>
+              <th className="py-2 pr-4 font-medium">Cadence</th>
+              <th className="py-2 pr-4 font-medium">Next session</th>
+              <th className="py-2 pr-4 font-medium">Members</th>
+              <th className="py-2 pr-4 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {cohorts.map((cohort) => {
+              const draft = drafts[cohort.id];
+              const facilitator = cohort.facilitator_clerk_user_id
+                ? memberById.get(cohort.facilitator_clerk_user_id)
+                : null;
+              return (
+                <tr className="border-t" key={cohort.id}>
+                  <td className="py-2 pr-4">
+                    <Input
+                      onChange={(e) =>
+                        setDrafts((prev) => ({ ...prev, [cohort.id]: { ...prev[cohort.id], name: e.target.value } }))
+                      }
+                      value={draft?.name ?? cohort.name}
+                    />
+                  </td>
+                  <td className="py-2 pr-4">
+                    {canManageAll ? (
+                      <Select
+                        onChange={(e) =>
+                          setDrafts((prev) => ({
+                            ...prev,
+                            [cohort.id]: { ...prev[cohort.id], facilitatorClerkUserId: e.target.value },
+                          }))
+                        }
+                        value={draft?.facilitatorClerkUserId ?? cohort.facilitator_clerk_user_id ?? ""}
+                      >
+                        <option value="">No facilitator assigned</option>
+                        {members.map((member) => (
+                          <option key={member.clerk_user_id} value={member.clerk_user_id}>
+                            {getMemberLabel(member)}
+                          </option>
+                        ))}
+                      </Select>
+                    ) : (
+                      <p className="text-sm text-muted-foreground">
+                        {facilitator ? getMemberLabel(facilitator) : "No facilitator assigned"}
+                      </p>
+                    )}
+                  </td>
+                  <td className="py-2 pr-4">
+                    <Select
+                      onChange={(e) =>
+                        setDrafts((prev) => ({
+                          ...prev,
+                          [cohort.id]: { ...prev[cohort.id], cadence: e.target.value as CohortCadence },
+                        }))
+                      }
+                      value={draft?.cadence ?? cohort.cadence}
+                    >
+                      <option value="weekly">Weekly</option>
+                      <option value="biweekly">Biweekly</option>
+                      <option value="monthly">Monthly</option>
+                      <option value="custom">Custom</option>
+                    </Select>
+                  </td>
+                  <td className="py-2 pr-4">
+                    <Input
+                      onChange={(e) =>
+                        setDrafts((prev) => ({
+                          ...prev,
+                          [cohort.id]: { ...prev[cohort.id], nextSessionAt: e.target.value },
+                        }))
+                      }
+                      type="datetime-local"
+                      value={draft?.nextSessionAt ?? toDateTimeLocalValue(cohort.next_session_at)}
+                    />
+                  </td>
+                  <td className="py-2 pr-4">{enrollmentCountByCohort.get(cohort.id) ?? 0}</td>
+                  <td className="py-2 pr-4">
+                    <div className="flex gap-2">
+                      <Button onClick={() => saveCohort(cohort.id)} size="sm" type="button" variant="secondary">
+                        Save
+                      </Button>
+                      {canManageAll ? (
+                        <Button onClick={() => deleteCohort(cohort.id)} size="sm" type="button" variant="destructive">
+                          Delete
+                        </Button>
+                      ) : null}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      ) : (
+        <p className="text-sm text-muted-foreground">No cohorts created yet.</p>
+      )}
+
+      {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
+    </div>
+  );
+}

--- a/src/components/parish-communications-manager.tsx
+++ b/src/components/parish-communications-manager.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import type {
+  ParishAdminCohortRow,
+  ParishAdminCommunicationSendRow,
+  ParishAdminCourseRow,
+} from "@/lib/repositories/parish-admin";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+
+type AudienceType = "all_members" | "stalled_learners" | "cohort" | "course";
+
+function isAudienceType(value: string | null): value is AudienceType {
+  return value === "all_members" || value === "stalled_learners" || value === "cohort" || value === "course";
+}
+
+function formatAudienceLabel(
+  send: ParishAdminCommunicationSendRow,
+  cohortNameById: Map<string, string>,
+  courseTitleById: Map<string, string>,
+) {
+  if (send.audience_type === "all_members") return "All members";
+  if (send.audience_type === "stalled_learners") return "Stalled learners";
+  if (send.audience_type === "cohort") {
+    return `Cohort: ${cohortNameById.get(send.audience_value ?? "") ?? send.audience_value ?? "Unknown"}`;
+  }
+  return `Course: ${courseTitleById.get(send.audience_value ?? "") ?? send.audience_value ?? "Unknown"}`;
+}
+
+export function ParishCommunicationsManager({
+  cohorts,
+  courses,
+  sends,
+  prefill,
+}: {
+  cohorts: ParishAdminCohortRow[];
+  courses: ParishAdminCourseRow[];
+  sends: ParishAdminCommunicationSendRow[];
+  prefill?: {
+    audienceType?: string | null;
+    audienceValue?: string | null;
+    subject?: string | null;
+    body?: string | null;
+  };
+}) {
+  const router = useRouter();
+  const initialAudienceType: AudienceType = isAudienceType(prefill?.audienceType ?? null)
+    ? (prefill?.audienceType as AudienceType)
+    : "all_members";
+  const initialAudienceValue =
+    initialAudienceType === "cohort"
+      ? cohorts.some((cohort) => cohort.id === prefill?.audienceValue)
+        ? (prefill?.audienceValue ?? "")
+        : ""
+      : initialAudienceType === "course"
+        ? courses.some((course) => course.id === prefill?.audienceValue)
+          ? (prefill?.audienceValue ?? "")
+          : ""
+        : "";
+  const [audienceType, setAudienceType] = useState<AudienceType>(initialAudienceType);
+  const [audienceValue, setAudienceValue] = useState(initialAudienceValue);
+  const [subject, setSubject] = useState((prefill?.subject ?? "").slice(0, 160));
+  const [body, setBody] = useState((prefill?.body ?? "").slice(0, 5000));
+  const [message, setMessage] = useState("");
+
+  const cohortNameById = useMemo(
+    () => new Map(cohorts.map((cohort) => [cohort.id, cohort.name])),
+    [cohorts],
+  );
+  const courseTitleById = useMemo(
+    () => new Map(courses.map((course) => [course.id, course.title])),
+    [courses],
+  );
+
+  const needsAudienceValue = audienceType === "cohort" || audienceType === "course";
+  const selectedAudienceValue =
+    needsAudienceValue && audienceValue
+      ? audienceValue
+      : needsAudienceValue
+        ? (audienceType === "cohort" ? cohorts[0]?.id ?? "" : courses[0]?.id ?? "")
+        : "";
+
+  async function logMessage() {
+    const response = await fetch("/api/parish-admin/communications", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        audienceType,
+        audienceValue: needsAudienceValue ? selectedAudienceValue : undefined,
+        subject,
+        body,
+      }),
+    });
+    const data = await response.json();
+
+    if (!response.ok) {
+      setMessage(data.error ?? "Failed to log message.");
+      return;
+    }
+
+    setMessage(data.deliveryNote ?? "Message logged.");
+    setSubject("");
+    setBody("");
+    router.refresh();
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="rounded-md border border-border bg-muted px-3 py-2 text-sm text-muted-foreground">
+        Delivery is currently log-only. Email/SMS sending is not configured yet.
+      </p>
+
+      <div className="grid gap-2 rounded-md border border-border p-3 md:grid-cols-[220px_220px_1fr_auto]">
+        <Select onChange={(e) => setAudienceType(e.target.value as AudienceType)} value={audienceType}>
+          <option value="all_members">All members</option>
+          <option value="stalled_learners">Stalled learners</option>
+          <option value="cohort">Specific cohort</option>
+          <option value="course">Specific course</option>
+        </Select>
+
+        {audienceType === "cohort" ? (
+          <Select onChange={(e) => setAudienceValue(e.target.value)} value={selectedAudienceValue}>
+            {cohorts.map((cohort) => (
+              <option key={cohort.id} value={cohort.id}>
+                {cohort.name}
+              </option>
+            ))}
+          </Select>
+        ) : audienceType === "course" ? (
+          <Select onChange={(e) => setAudienceValue(e.target.value)} value={selectedAudienceValue}>
+            {courses.map((course) => (
+              <option key={course.id} value={course.id}>
+                {course.title}
+              </option>
+            ))}
+          </Select>
+        ) : (
+          <div className="rounded-md border border-border px-3 py-2 text-sm text-muted-foreground">
+            Audience auto-selected
+          </div>
+        )}
+
+        <Input maxLength={160} onChange={(e) => setSubject(e.target.value)} placeholder="Subject" value={subject} />
+
+        <Button
+          disabled={!subject.trim() || !body.trim() || (needsAudienceValue && !selectedAudienceValue)}
+          onClick={logMessage}
+          type="button"
+        >
+          Log message
+        </Button>
+      </div>
+
+      <textarea
+        className="min-h-32 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+        maxLength={5000}
+        onChange={(e) => setBody(e.target.value)}
+        placeholder="Message body"
+        value={body}
+      />
+
+      <table className="w-full text-left text-sm">
+        <thead className="text-muted-foreground">
+          <tr>
+            <th className="py-2 pr-4 font-medium">When</th>
+            <th className="py-2 pr-4 font-medium">Audience</th>
+            <th className="py-2 pr-4 font-medium">Subject</th>
+            <th className="py-2 pr-4 font-medium">Recipients</th>
+            <th className="py-2 pr-4 font-medium">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sends.map((send) => (
+            <tr className="border-t" key={send.id}>
+              <td className="py-2 pr-4">{new Date(send.created_at).toLocaleString()}</td>
+              <td className="py-2 pr-4">{formatAudienceLabel(send, cohortNameById, courseTitleById)}</td>
+              <td className="py-2 pr-4">{send.subject}</td>
+              <td className="py-2 pr-4">{send.recipient_count}</td>
+              <td className="py-2 pr-4">{send.delivery_status}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {sends.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No communication logs yet.</p>
+      ) : null}
+      {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
+    </div>
+  );
+}

--- a/src/components/parish-course-adoption-manager.tsx
+++ b/src/components/parish-course-adoption-manager.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import type { ParishAdminCourseRow } from "@/lib/repositories/parish-admin";
+import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
+
+export function ParishCourseAdoptionManager({
+  adoptedCourses,
+  availableCourses,
+}: {
+  adoptedCourses: ParishAdminCourseRow[];
+  availableCourses: ParishAdminCourseRow[];
+}) {
+  const router = useRouter();
+  const [selectedCourseId, setSelectedCourseId] = useState(availableCourses[0]?.id ?? "");
+  const [message, setMessage] = useState("");
+  const selectedCourseIdValue = availableCourses.some((course) => course.id === selectedCourseId)
+    ? selectedCourseId
+    : (availableCourses[0]?.id ?? "");
+
+  async function adoptCourse() {
+    if (!selectedCourseIdValue) return;
+
+    const response = await fetch("/api/parish-admin/course-adoptions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ courseId: selectedCourseIdValue }),
+    });
+    const data = await response.json();
+    setMessage(response.ok ? "Course adopted for this parish." : data.error ?? "Failed to adopt course.");
+    if (!response.ok) return;
+
+    router.refresh();
+  }
+
+  async function removeAdoption(courseId: string) {
+    const response = await fetch("/api/parish-admin/course-adoptions", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ courseId }),
+    });
+    const data = await response.json();
+    setMessage(response.ok ? "Course removed from parish adoptions." : data.error ?? "Failed to remove course.");
+    if (response.ok) {
+      router.refresh();
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-2 rounded-md border border-border p-3 md:grid-cols-[1fr_auto]">
+        <Select onChange={(e) => setSelectedCourseId(e.target.value)} value={selectedCourseIdValue}>
+          {availableCourses.length > 0 ? (
+            availableCourses.map((course) => (
+              <option key={course.id} value={course.id}>
+                {course.title}
+              </option>
+            ))
+          ) : (
+            <option value="">No additional parish courses available</option>
+          )}
+        </Select>
+        <Button disabled={!selectedCourseIdValue} onClick={adoptCourse} type="button">
+          Adopt course
+        </Button>
+      </div>
+
+      {adoptedCourses.length > 0 ? (
+        <table className="w-full text-left text-sm">
+          <thead className="text-muted-foreground">
+            <tr>
+              <th className="py-2 pr-4 font-medium">Course</th>
+              <th className="py-2 pr-4 font-medium">Description</th>
+              <th className="py-2 pr-4 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {adoptedCourses.map((course) => (
+              <tr className="border-t" key={course.id}>
+                <td className="py-2 pr-4">{course.title}</td>
+                <td className="py-2 pr-4 text-muted-foreground">{course.description ?? "No description"}</td>
+                <td className="py-2 pr-4">
+                  <Button onClick={() => removeAdoption(course.id)} size="sm" type="button" variant="destructive">
+                    Remove
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="text-sm text-muted-foreground">No parish-scoped courses are adopted yet.</p>
+      )}
+
+      {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
+    </div>
+  );
+}

--- a/src/components/parish-enrollment-manager.tsx
+++ b/src/components/parish-enrollment-manager.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import type {
+  ParishAdminCourseRow,
+  ParishAdminEnrollmentRow,
+  ParishAdminMemberRow,
+} from "@/lib/repositories/parish-admin";
+import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
+
+function getMemberLabel(member: ParishAdminMemberRow) {
+  const base = member.display_name ?? member.email ?? member.clerk_user_id;
+  return `${base} (${member.role})`;
+}
+
+export function ParishEnrollmentManager({
+  members,
+  courses,
+  enrollments,
+}: {
+  members: ParishAdminMemberRow[];
+  courses: ParishAdminCourseRow[];
+  enrollments: ParishAdminEnrollmentRow[];
+}) {
+  const router = useRouter();
+  const [selectedUserId, setSelectedUserId] = useState(members[0]?.clerk_user_id ?? "");
+  const [selectedCourseId, setSelectedCourseId] = useState(courses[0]?.id ?? "");
+  const [message, setMessage] = useState("");
+
+  const memberById = useMemo(
+    () => new Map(members.map((member) => [member.clerk_user_id, member])),
+    [members],
+  );
+  const courseById = useMemo(() => new Map(courses.map((course) => [course.id, course])), [courses]);
+  const selectedUserIdValue = members.some((member) => member.clerk_user_id === selectedUserId)
+    ? selectedUserId
+    : (members[0]?.clerk_user_id ?? "");
+  const selectedCourseIdValue = courses.some((course) => course.id === selectedCourseId)
+    ? selectedCourseId
+    : (courses[0]?.id ?? "");
+
+  async function addEnrollment() {
+    if (!selectedUserIdValue || !selectedCourseIdValue) return;
+
+    const response = await fetch("/api/parish-admin/enrollments", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ clerkUserId: selectedUserIdValue, courseId: selectedCourseIdValue }),
+    });
+    const data = await response.json();
+    setMessage(response.ok ? "Enrollment saved." : data.error ?? "Failed to save enrollment.");
+    if (response.ok) {
+      router.refresh();
+    }
+  }
+
+  async function removeEnrollment(item: ParishAdminEnrollmentRow) {
+    const response = await fetch("/api/parish-admin/enrollments", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        clerkUserId: item.clerk_user_id,
+        courseId: item.course_id,
+      }),
+    });
+    const data = await response.json();
+    setMessage(response.ok ? "Enrollment removed." : data.error ?? "Failed to remove enrollment.");
+    if (response.ok) {
+      router.refresh();
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-2 rounded-md border border-border p-3 md:grid-cols-[1fr_1fr_auto]">
+        <Select onChange={(e) => setSelectedUserId(e.target.value)} value={selectedUserIdValue}>
+          {members.length > 0 ? (
+            members.map((member) => (
+              <option key={member.clerk_user_id} value={member.clerk_user_id}>
+                {getMemberLabel(member)}
+              </option>
+            ))
+          ) : (
+            <option value="">No parish members found</option>
+          )}
+        </Select>
+
+        <Select onChange={(e) => setSelectedCourseId(e.target.value)} value={selectedCourseIdValue}>
+          {courses.length > 0 ? (
+            courses.map((course) => (
+              <option key={course.id} value={course.id}>
+                {course.title}
+              </option>
+            ))
+          ) : (
+            <option value="">No visible courses</option>
+          )}
+        </Select>
+
+        <Button disabled={!selectedUserIdValue || !selectedCourseIdValue} onClick={addEnrollment} type="button">
+          Add enrollment
+        </Button>
+      </div>
+
+      {enrollments.length > 0 ? (
+        <table className="w-full text-left text-sm">
+          <thead className="text-muted-foreground">
+            <tr>
+              <th className="py-2 pr-4 font-medium">Learner</th>
+              <th className="py-2 pr-4 font-medium">Course</th>
+              <th className="py-2 pr-4 font-medium">Created</th>
+              <th className="py-2 pr-4 font-medium">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {enrollments.map((item) => {
+              const member = memberById.get(item.clerk_user_id);
+              const course = courseById.get(item.course_id);
+              return (
+                <tr className="border-t" key={item.id}>
+                  <td className="py-2 pr-4">
+                    <div className="flex flex-col">
+                      <span>{member ? getMemberLabel(member) : item.clerk_user_id}</span>
+                      <span className="font-mono text-xs text-muted-foreground">{item.clerk_user_id}</span>
+                    </div>
+                  </td>
+                  <td className="py-2 pr-4">{course?.title ?? item.course_id}</td>
+                  <td className="py-2 pr-4">{new Date(item.created_at).toLocaleDateString()}</td>
+                  <td className="py-2 pr-4">
+                    <Button onClick={() => removeEnrollment(item)} size="sm" type="button" variant="destructive">
+                      Remove
+                    </Button>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      ) : (
+        <p className="text-sm text-muted-foreground">No enrollments exist for this parish yet.</p>
+      )}
+
+      {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
+    </div>
+  );
+}

--- a/src/components/parish-participation-manager.tsx
+++ b/src/components/parish-participation-manager.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import type {
+  ParishAdminCohortRow,
+  ParishAdminCourseRow,
+  ParishAdminMemberRow,
+  ParishAdminParticipationRow,
+  ParishParticipationStatus,
+} from "@/lib/repositories/parish-admin";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+
+const STATUS_LABELS: Record<ParishParticipationStatus, string> = {
+  not_started: "Not started",
+  active: "Active",
+  stalled: "Stalled",
+  completed: "Completed",
+};
+
+function formatDate(value: string | null) {
+  if (!value) return "No activity yet";
+  return new Date(value).toLocaleDateString();
+}
+
+function toLearnerLabel(member: ParishAdminMemberRow | undefined, clerkUserId: string) {
+  return member?.display_name ?? member?.email ?? clerkUserId;
+}
+
+function buildCommunicationHref({
+  audienceType,
+  audienceValue,
+  subject,
+  body,
+}: {
+  audienceType: "cohort" | "course";
+  audienceValue: string;
+  subject: string;
+  body: string;
+}) {
+  const params = new URLSearchParams();
+  params.set("audienceType", audienceType);
+  params.set("audienceValue", audienceValue);
+  params.set("subject", subject);
+  params.set("body", body);
+  return `/app/parish-admin?${params.toString()}#communications`;
+}
+
+export function ParishParticipationManager({
+  courses,
+  cohorts,
+  members,
+  participationRows,
+  canLogCommunications,
+}: {
+  courses: ParishAdminCourseRow[];
+  cohorts: ParishAdminCohortRow[];
+  members: ParishAdminMemberRow[];
+  participationRows: ParishAdminParticipationRow[];
+  canLogCommunications: boolean;
+}) {
+  const [courseFilter, setCourseFilter] = useState("all");
+  const [cohortFilter, setCohortFilter] = useState("all");
+  const [statusFilter, setStatusFilter] = useState<ParishParticipationStatus | "all">("all");
+  const [search, setSearch] = useState("");
+
+  const courseTitleById = useMemo(() => new Map(courses.map((course) => [course.id, course.title])), [courses]);
+  const cohortNameById = useMemo(() => new Map(cohorts.map((cohort) => [cohort.id, cohort.name])), [cohorts]);
+  const memberById = useMemo(() => new Map(members.map((member) => [member.clerk_user_id, member])), [members]);
+
+  const statusCounts = useMemo(() => {
+    return participationRows.reduce(
+      (acc, row) => {
+        acc[row.status] += 1;
+        return acc;
+      },
+      {
+        not_started: 0,
+        active: 0,
+        stalled: 0,
+        completed: 0,
+      } satisfies Record<ParishParticipationStatus, number>,
+    );
+  }, [participationRows]);
+
+  const filteredRows = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+
+    return participationRows.filter((row) => {
+      if (courseFilter !== "all" && row.course_id !== courseFilter) return false;
+      if (cohortFilter === "unassigned") {
+        if (row.cohort_id) return false;
+      } else if (cohortFilter !== "all" && row.cohort_id !== cohortFilter) {
+        return false;
+      }
+      if (statusFilter !== "all" && row.status !== statusFilter) return false;
+
+      if (!normalizedSearch) return true;
+      const learnerLabel = toLearnerLabel(memberById.get(row.clerk_user_id), row.clerk_user_id).toLowerCase();
+      const courseTitle = (courseTitleById.get(row.course_id) ?? row.course_id).toLowerCase();
+      const cohortName = (row.cohort_id ? cohortNameById.get(row.cohort_id) ?? row.cohort_id : "unassigned").toLowerCase();
+      const clerkUserId = row.clerk_user_id.toLowerCase();
+
+      return (
+        learnerLabel.includes(normalizedSearch) ||
+        courseTitle.includes(normalizedSearch) ||
+        cohortName.includes(normalizedSearch) ||
+        clerkUserId.includes(normalizedSearch)
+      );
+    });
+  }, [cohortFilter, cohortNameById, courseFilter, courseTitleById, memberById, participationRows, search, statusFilter]);
+
+  const hasFilters = Boolean(search.trim()) || courseFilter !== "all" || cohortFilter !== "all" || statusFilter !== "all";
+  const exportHref = useMemo(() => {
+    const params = new URLSearchParams();
+    if (courseFilter !== "all") params.set("courseId", courseFilter);
+    if (cohortFilter !== "all") params.set("cohortId", cohortFilter);
+    if (statusFilter !== "all") params.set("status", statusFilter);
+    if (search.trim()) params.set("search", search.trim());
+    const query = params.toString();
+    return `/api/parish-admin/participation/export${query ? `?${query}` : ""}`;
+  }, [cohortFilter, courseFilter, search, statusFilter]);
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="rounded-md border border-border bg-muted p-3">
+          <p className="text-xs text-muted-foreground">Stalled</p>
+          <p className="text-xl font-semibold">{statusCounts.stalled}</p>
+        </div>
+        <div className="rounded-md border border-border bg-muted p-3">
+          <p className="text-xs text-muted-foreground">Not started</p>
+          <p className="text-xl font-semibold">{statusCounts.not_started}</p>
+        </div>
+        <div className="rounded-md border border-border bg-muted p-3">
+          <p className="text-xs text-muted-foreground">Active</p>
+          <p className="text-xl font-semibold">{statusCounts.active}</p>
+        </div>
+        <div className="rounded-md border border-border bg-muted p-3">
+          <p className="text-xs text-muted-foreground">Completed</p>
+          <p className="text-xl font-semibold">{statusCounts.completed}</p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Select onChange={(e) => setCourseFilter(e.target.value)} value={courseFilter}>
+          <option value="all">All courses</option>
+          {courses.map((course) => (
+            <option key={course.id} value={course.id}>
+              {course.title}
+            </option>
+          ))}
+        </Select>
+
+        <Select onChange={(e) => setCohortFilter(e.target.value)} value={cohortFilter}>
+          <option value="all">All cohorts</option>
+          <option value="unassigned">Unassigned</option>
+          {cohorts.map((cohort) => (
+            <option key={cohort.id} value={cohort.id}>
+              {cohort.name}
+            </option>
+          ))}
+        </Select>
+
+        <Select onChange={(e) => setStatusFilter(e.target.value as ParishParticipationStatus | "all")} value={statusFilter}>
+          <option value="all">All statuses</option>
+          <option value="stalled">Stalled</option>
+          <option value="not_started">Not started</option>
+          <option value="active">Active</option>
+          <option value="completed">Completed</option>
+        </Select>
+
+        <Input
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search learner, course, or cohort"
+          value={search}
+        />
+
+        {hasFilters ? (
+          <Button
+            onClick={() => {
+              setCourseFilter("all");
+              setCohortFilter("all");
+              setStatusFilter("all");
+              setSearch("");
+            }}
+            type="button"
+            variant="ghost"
+          >
+            Clear filters
+          </Button>
+        ) : null}
+
+        <Button asChild type="button" variant="outline">
+          <a href={exportHref}>Export CSV</a>
+        </Button>
+      </div>
+
+      <table className="w-full text-left text-sm">
+        <thead className="text-muted-foreground">
+          <tr>
+            <th className="py-2 pr-4 font-medium">Learner</th>
+            <th className="py-2 pr-4 font-medium">Course</th>
+            <th className="py-2 pr-4 font-medium">Cohort</th>
+            <th className="py-2 pr-4 font-medium">Progress</th>
+            <th className="py-2 pr-4 font-medium">Status</th>
+            <th className="py-2 pr-4 font-medium">Last activity</th>
+            <th className="py-2 pr-4 font-medium">Enrolled</th>
+            {canLogCommunications ? <th className="py-2 pr-4 font-medium">Actions</th> : null}
+          </tr>
+        </thead>
+        <tbody>
+          {filteredRows.map((row) => (
+            <tr className="border-t" key={row.enrollment_id}>
+              <td className="py-2 pr-4">
+                <p>{toLearnerLabel(memberById.get(row.clerk_user_id), row.clerk_user_id)}</p>
+                <p className="text-xs text-muted-foreground">{row.clerk_user_id}</p>
+              </td>
+              <td className="py-2 pr-4">{courseTitleById.get(row.course_id) ?? row.course_id}</td>
+              <td className="py-2 pr-4">{row.cohort_id ? cohortNameById.get(row.cohort_id) ?? row.cohort_id : "Unassigned"}</td>
+              <td className="py-2 pr-4">
+                {row.completed_lessons}/{row.total_lessons} ({row.progress_percent}%)
+              </td>
+              <td className="py-2 pr-4">{STATUS_LABELS[row.status]}</td>
+              <td className="py-2 pr-4">{formatDate(row.last_activity_at)}</td>
+              <td className="py-2 pr-4">{new Date(row.enrolled_at).toLocaleDateString()}</td>
+              {canLogCommunications ? (
+                <td className="py-2 pr-4">
+                  <div className="flex flex-wrap gap-2">
+                    {row.cohort_id ? (
+                      <Button asChild size="sm" type="button" variant="secondary">
+                        <a
+                          href={buildCommunicationHref({
+                            audienceType: "cohort",
+                            audienceValue: row.cohort_id,
+                            subject:
+                              row.status === "stalled"
+                                ? "Cohort progress follow-up"
+                                : "Cohort encouragement message",
+                            body:
+                              row.status === "stalled"
+                                ? "We have noticed some stalled progress in this cohort. Please complete your next lesson this week."
+                                : "Keep going this week. Please continue with your next lesson and stay on cadence.",
+                          })}
+                        >
+                          Message cohort
+                        </a>
+                      </Button>
+                    ) : null}
+                    <Button asChild size="sm" type="button" variant="outline">
+                      <a
+                        href={buildCommunicationHref({
+                          audienceType: "course",
+                          audienceValue: row.course_id,
+                          subject:
+                            row.status === "not_started"
+                              ? "Welcome reminder to start this course"
+                              : "Course progress check-in",
+                          body:
+                            row.status === "not_started"
+                              ? "Welcome to this course. Please begin your first lesson this week."
+                              : "Friendly reminder to continue your course progress this week.",
+                        })}
+                      >
+                        Message course
+                      </a>
+                    </Button>
+                  </div>
+                </td>
+              ) : null}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {filteredRows.length === 0 ? <p className="text-sm text-muted-foreground">No learners match current filters.</p> : null}
+    </div>
+  );
+}

--- a/src/components/parish-people-manager.tsx
+++ b/src/components/parish-people-manager.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import type { ParishAdminMemberRow } from "@/lib/repositories/parish-admin";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+
+interface ImportResultRow {
+  row: number;
+  identifier: string;
+  role: "parish_admin" | "instructor" | "student";
+  status: "imported" | "skipped";
+  message: string;
+}
+
+interface MemberDraft {
+  role: "parish_admin" | "instructor" | "student";
+}
+
+function getMemberLabel(member: ParishAdminMemberRow) {
+  return member.display_name ?? member.email ?? member.clerk_user_id;
+}
+
+export function ParishPeopleManager({ members }: { members: ParishAdminMemberRow[] }) {
+  const router = useRouter();
+  const [identifier, setIdentifier] = useState("");
+  const [newRole, setNewRole] = useState<"parish_admin" | "instructor" | "student">("student");
+  const [search, setSearch] = useState("");
+  const [importCsvText, setImportCsvText] = useState("email,role");
+  const [importDefaultRole, setImportDefaultRole] = useState<"parish_admin" | "instructor" | "student">("student");
+  const [importResults, setImportResults] = useState<ImportResultRow[]>([]);
+  const [message, setMessage] = useState("");
+  const [drafts, setDrafts] = useState<Record<string, MemberDraft>>(
+    Object.fromEntries(
+      members.map((member) => [
+        member.clerk_user_id,
+        {
+          role: member.role,
+        },
+      ]),
+    ),
+  );
+
+  const filteredMembers = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    if (!normalizedSearch) return members;
+
+    return members.filter((member) => {
+      return (
+        member.clerk_user_id.toLowerCase().includes(normalizedSearch) ||
+        (member.display_name ?? "").toLowerCase().includes(normalizedSearch) ||
+        (member.email ?? "").toLowerCase().includes(normalizedSearch) ||
+        member.role.toLowerCase().includes(normalizedSearch)
+      );
+    });
+  }, [members, search]);
+
+  async function addMember() {
+    const response = await fetch("/api/parish-admin/people", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        identifier,
+        role: newRole,
+      }),
+    });
+
+    const data = await response.json();
+    setMessage(response.ok ? "Member added." : data.error ?? "Failed to add member.");
+    if (!response.ok) return;
+
+    setIdentifier("");
+    router.refresh();
+  }
+
+  async function updateRole(clerkUserId: string) {
+    const draft = drafts[clerkUserId];
+    if (!draft) return;
+
+    const response = await fetch(`/api/parish-admin/people/${encodeURIComponent(clerkUserId)}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        role: draft.role,
+      }),
+    });
+    const data = await response.json();
+    setMessage(response.ok ? "Role updated." : data.error ?? "Failed to update role.");
+    if (response.ok) {
+      router.refresh();
+    }
+  }
+
+  async function removeMember(clerkUserId: string) {
+    const response = await fetch(`/api/parish-admin/people/${encodeURIComponent(clerkUserId)}`, {
+      method: "DELETE",
+    });
+    const data = await response.json();
+    setMessage(response.ok ? "Member removed." : data.error ?? "Failed to remove member.");
+    if (response.ok) {
+      router.refresh();
+    }
+  }
+
+  async function importMembers() {
+    const response = await fetch("/api/parish-admin/people", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        csvText: importCsvText,
+        defaultRole: importDefaultRole,
+      }),
+    });
+    const data = await response.json();
+    setMessage(response.ok ? `Import finished: ${data.summary.importedCount} imported, ${data.summary.skippedCount} skipped.` : data.error ?? "Failed to import members.");
+    setImportResults((data.results ?? []) as ImportResultRow[]);
+    if (response.ok) {
+      router.refresh();
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-2 rounded-md border border-border p-3 md:grid-cols-[1.2fr_1fr_auto]">
+        <Input
+          onChange={(e) => setIdentifier(e.target.value)}
+          placeholder="Email or clerk_user_id"
+          value={identifier}
+        />
+        <Select onChange={(e) => setNewRole(e.target.value as "parish_admin" | "instructor" | "student")} value={newRole}>
+          <option value="student">student</option>
+          <option value="instructor">instructor</option>
+          <option value="parish_admin">parish_admin</option>
+        </Select>
+        <Button disabled={!identifier.trim()} onClick={addMember} type="button">
+          Add member
+        </Button>
+      </div>
+
+      <div className="grid gap-2 rounded-md border border-border p-3">
+        <div className="grid gap-2 md:grid-cols-[1fr_220px_auto]">
+          <Select
+            onChange={(e) => setImportDefaultRole(e.target.value as "parish_admin" | "instructor" | "student")}
+            value={importDefaultRole}
+          >
+            <option value="student">Default role: student</option>
+            <option value="instructor">Default role: instructor</option>
+            <option value="parish_admin">Default role: parish_admin</option>
+          </Select>
+          <Button onClick={importMembers} type="button" variant="secondary">
+            Import CSV
+          </Button>
+        </div>
+        <textarea
+          className="min-h-28 rounded-md border border-input bg-background px-3 py-2 font-mono text-xs"
+          onChange={(e) => setImportCsvText(e.target.value)}
+          placeholder={"email,role\nperson@example.com,student\nanother@example.com,instructor"}
+          value={importCsvText}
+        />
+        <p className="text-xs text-muted-foreground">
+          Required headers: <span className="font-mono">email</span> or <span className="font-mono">clerk_user_id</span>. Optional: <span className="font-mono">role</span>.
+        </p>
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <Input
+          className="max-w-sm"
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search members by name, email, role, or ID"
+          value={search}
+        />
+        <p className="text-sm text-muted-foreground">{filteredMembers.length} members</p>
+      </div>
+
+      <table className="w-full text-left text-sm">
+        <thead className="text-muted-foreground">
+          <tr>
+            <th className="py-2 pr-4 font-medium">Name</th>
+            <th className="py-2 pr-4 font-medium">Email</th>
+            <th className="py-2 pr-4 font-medium">Clerk user ID</th>
+            <th className="py-2 pr-4 font-medium">Role</th>
+            <th className="py-2 pr-4 font-medium">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filteredMembers.map((member) => (
+            <tr className="border-t" key={member.clerk_user_id}>
+              <td className="py-2 pr-4">{getMemberLabel(member)}</td>
+              <td className="py-2 pr-4">{member.email ?? "—"}</td>
+              <td className="py-2 pr-4 font-mono text-xs">{member.clerk_user_id}</td>
+              <td className="py-2 pr-4">
+                <Select
+                  onChange={(e) =>
+                    setDrafts((prev) => ({
+                      ...prev,
+                      [member.clerk_user_id]: {
+                        role: e.target.value as "parish_admin" | "instructor" | "student",
+                      },
+                    }))
+                  }
+                  value={drafts[member.clerk_user_id]?.role ?? member.role}
+                >
+                  <option value="student">student</option>
+                  <option value="instructor">instructor</option>
+                  <option value="parish_admin">parish_admin</option>
+                </Select>
+              </td>
+              <td className="py-2 pr-4">
+                <div className="flex gap-2">
+                  <Button onClick={() => updateRole(member.clerk_user_id)} size="sm" type="button" variant="secondary">
+                    Save role
+                  </Button>
+                  <Button onClick={() => removeMember(member.clerk_user_id)} size="sm" type="button" variant="destructive">
+                    Remove
+                  </Button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {importResults.length > 0 ? (
+        <div className="rounded-md border border-border p-3">
+          <h3 className="text-sm font-medium">Import results</h3>
+          <table className="mt-2 w-full text-left text-xs">
+            <thead className="text-muted-foreground">
+              <tr>
+                <th className="py-1 pr-3 font-medium">Row</th>
+                <th className="py-1 pr-3 font-medium">Identifier</th>
+                <th className="py-1 pr-3 font-medium">Role</th>
+                <th className="py-1 pr-3 font-medium">Status</th>
+                <th className="py-1 pr-3 font-medium">Message</th>
+              </tr>
+            </thead>
+            <tbody>
+              {importResults.map((result) => (
+                <tr className="border-t" key={`${result.row}-${result.identifier}-${result.status}`}>
+                  <td className="py-1 pr-3">{result.row}</td>
+                  <td className="py-1 pr-3 font-mono">{result.identifier || "—"}</td>
+                  <td className="py-1 pr-3">{result.role}</td>
+                  <td className="py-1 pr-3">{result.status}</td>
+                  <td className="py-1 pr-3 text-muted-foreground">{result.message}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+
+      {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
+    </div>
+  );
+}

--- a/src/lib/parish-communications/delivery-jobs.ts
+++ b/src/lib/parish-communications/delivery-jobs.ts
@@ -1,0 +1,294 @@
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import { deliverParishMessage, type ParishDeliveryProvider } from "@/lib/parish-communications/delivery-provider";
+
+interface DeliveryJobRow {
+  id: string;
+  send_id: string;
+  parish_id: string;
+  provider: string;
+  status: "pending" | "processing" | "sent" | "failed";
+  attempts: number;
+  max_attempts: number;
+}
+
+interface SendRow {
+  id: string;
+  subject: string;
+  body: string;
+}
+
+interface RecipientRow {
+  clerk_user_id: string;
+}
+
+interface ProfileRow {
+  clerk_user_id: string;
+  email: string | null;
+}
+
+export interface ProcessParishDeliveryJobsResult {
+  processed: number;
+  sent: number;
+  failed: number;
+  requeued: number;
+}
+
+const MAX_JOB_BATCH = 50;
+
+function buildRetryTime(attempts: number) {
+  const backoffSeconds = Math.min(3600, Math.pow(2, Math.max(1, attempts)) * 30);
+  return new Date(Date.now() + backoffSeconds * 1000).toISOString();
+}
+
+function summarizeFailureErrors(failed: Array<{ clerkUserId: string; error: string }>) {
+  const unique = Array.from(new Set(failed.map((item) => item.error)));
+  return unique.join("; ").slice(0, 500);
+}
+
+async function updateRecipientStatuses({
+  sendId,
+  sentRecipientIds,
+  failed,
+}: {
+  sendId: string;
+  sentRecipientIds: string[];
+  failed: Array<{ clerkUserId: string; error: string }>;
+}) {
+  const supabase = getSupabaseAdminClient();
+  const attemptedAt = new Date().toISOString();
+
+  if (sentRecipientIds.length > 0) {
+    const { error } = await supabase
+      .from("parish_message_recipients")
+      .update({
+        delivery_status: "sent",
+        delivery_attempted_at: attemptedAt,
+        delivery_error: null,
+      })
+      .eq("send_id", sendId)
+      .in("clerk_user_id", sentRecipientIds);
+    if (error) throw error;
+  }
+
+  for (const failure of failed) {
+    const { error } = await supabase
+      .from("parish_message_recipients")
+      .update({
+        delivery_status: "failed",
+        delivery_attempted_at: attemptedAt,
+        delivery_error: failure.error,
+      })
+      .eq("send_id", sendId)
+      .eq("clerk_user_id", failure.clerkUserId);
+    if (error) throw error;
+  }
+}
+
+async function finalizeJobAsSent(job: DeliveryJobRow) {
+  const supabase = getSupabaseAdminClient();
+  const attempts = job.attempts + 1;
+  const [{ error: sendError }, { error: jobError }] = await Promise.all([
+    supabase.from("parish_message_sends").update({ delivery_status: "sent" }).eq("id", job.send_id),
+    supabase
+      .from("parish_message_delivery_jobs")
+      .update({
+        status: "sent",
+        attempts,
+        last_error: null,
+        locked_at: null,
+        locked_by: null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", job.id),
+  ]);
+
+  if (sendError) throw sendError;
+  if (jobError) throw jobError;
+}
+
+async function scheduleJobRetry({
+  job,
+  errorMessage,
+}: {
+  job: DeliveryJobRow;
+  errorMessage: string;
+}) {
+  const supabase = getSupabaseAdminClient();
+  const attempts = job.attempts + 1;
+  const isTerminal = attempts >= job.max_attempts;
+  const sendStatus = isTerminal ? "failed" : "queued";
+  const jobStatus = isTerminal ? "failed" : "pending";
+  const nextAttemptAt = isTerminal ? new Date().toISOString() : buildRetryTime(attempts);
+
+  const [{ error: sendError }, { error: jobError }] = await Promise.all([
+    supabase.from("parish_message_sends").update({ delivery_status: sendStatus }).eq("id", job.send_id),
+    supabase
+      .from("parish_message_delivery_jobs")
+      .update({
+        status: jobStatus,
+        attempts,
+        last_error: errorMessage,
+        next_attempt_at: nextAttemptAt,
+        locked_at: null,
+        locked_by: null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", job.id),
+  ]);
+
+  if (sendError) throw sendError;
+  if (jobError) throw jobError;
+
+  return { isTerminal };
+}
+
+export async function enqueueParishMessageDeliveryJob({
+  parishId,
+  sendId,
+  provider,
+}: {
+  parishId: string;
+  sendId: string;
+  provider: ParishDeliveryProvider;
+}) {
+  const supabase = getSupabaseAdminClient();
+  const { error } = await supabase.from("parish_message_delivery_jobs").insert({
+    parish_id: parishId,
+    send_id: sendId,
+    provider,
+    status: "pending",
+    attempts: 0,
+    max_attempts: 5,
+    next_attempt_at: new Date().toISOString(),
+  });
+  if (error) throw error;
+}
+
+async function processOneJob(job: DeliveryJobRow): Promise<"sent" | "failed" | "requeued"> {
+  const supabase = getSupabaseAdminClient();
+  const claimResult = await supabase
+    .from("parish_message_delivery_jobs")
+    .update({
+      status: "processing",
+      locked_at: new Date().toISOString(),
+      locked_by: `api:${process.pid}`,
+      updated_at: new Date().toISOString(),
+    })
+    .eq("id", job.id)
+    .eq("status", "pending")
+    .select("id,send_id,parish_id,provider,status,attempts,max_attempts")
+    .maybeSingle();
+
+  if (claimResult.error) throw claimResult.error;
+  if (!claimResult.data) {
+    return "requeued";
+  }
+
+  const claimed = claimResult.data as DeliveryJobRow;
+
+  try {
+    const sendResult = await supabase
+      .from("parish_message_sends")
+      .select("id,subject,body")
+      .eq("id", claimed.send_id)
+      .maybeSingle();
+    if (sendResult.error) throw sendResult.error;
+    const send = sendResult.data as SendRow | null;
+    if (!send) {
+      await scheduleJobRetry({ job: claimed, errorMessage: "Message send record is missing." });
+      return claimed.attempts + 1 >= claimed.max_attempts ? "failed" : "requeued";
+    }
+
+    const recipientsResult = await supabase
+      .from("parish_message_recipients")
+      .select("clerk_user_id")
+      .eq("send_id", claimed.send_id)
+      .neq("delivery_status", "sent");
+    if (recipientsResult.error) throw recipientsResult.error;
+    const recipients = (recipientsResult.data ?? []) as RecipientRow[];
+
+    if (recipients.length === 0) {
+      await finalizeJobAsSent(claimed);
+      return "sent";
+    }
+
+    const recipientIds = recipients.map((row) => row.clerk_user_id);
+    const profilesResult = await supabase
+      .from("user_profiles")
+      .select("clerk_user_id,email")
+      .in("clerk_user_id", recipientIds);
+    if (profilesResult.error) throw profilesResult.error;
+    const profiles = (profilesResult.data ?? []) as ProfileRow[];
+    const profileByClerkId = new Map(profiles.map((profile) => [profile.clerk_user_id, profile]));
+
+    const provider = claimed.provider as ParishDeliveryProvider;
+    const result = await deliverParishMessage({
+      provider,
+      subject: send.subject,
+      body: send.body,
+      recipients: recipientIds.map((clerkUserId) => ({
+        clerkUserId,
+        email: profileByClerkId.get(clerkUserId)?.email ?? null,
+      })),
+    });
+
+    await updateRecipientStatuses({
+      sendId: claimed.send_id,
+      sentRecipientIds: result.sent,
+      failed: result.failed,
+    });
+
+    if (result.failed.length === 0) {
+      await finalizeJobAsSent(claimed);
+      return "sent";
+    }
+
+    const retryResult = await scheduleJobRetry({
+      job: claimed,
+      errorMessage: summarizeFailureErrors(result.failed),
+    });
+    return retryResult.isTerminal ? "failed" : "requeued";
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unknown delivery error.";
+    const retryResult = await scheduleJobRetry({ job: claimed, errorMessage: message });
+    return retryResult.isTerminal ? "failed" : "requeued";
+  }
+}
+
+export async function processPendingParishMessageDeliveryJobs({
+  limit = 10,
+}: {
+  limit?: number;
+} = {}): Promise<ProcessParishDeliveryJobsResult> {
+  const cappedLimit = Math.max(1, Math.min(limit, MAX_JOB_BATCH));
+  const supabase = getSupabaseAdminClient();
+  const now = new Date().toISOString();
+
+  const { data, error } = await supabase
+    .from("parish_message_delivery_jobs")
+    .select("id,send_id,parish_id,provider,status,attempts,max_attempts")
+    .eq("status", "pending")
+    .lte("next_attempt_at", now)
+    .order("created_at", { ascending: true })
+    .limit(cappedLimit);
+
+  if (error) throw error;
+
+  const jobs = (data ?? []) as DeliveryJobRow[];
+  const summary: ProcessParishDeliveryJobsResult = {
+    processed: 0,
+    sent: 0,
+    failed: 0,
+    requeued: 0,
+  };
+
+  for (const job of jobs) {
+    const status = await processOneJob(job);
+    summary.processed += 1;
+    if (status === "sent") summary.sent += 1;
+    if (status === "failed") summary.failed += 1;
+    if (status === "requeued") summary.requeued += 1;
+  }
+
+  return summary;
+}

--- a/src/lib/parish-communications/delivery-provider.ts
+++ b/src/lib/parish-communications/delivery-provider.ts
@@ -1,0 +1,53 @@
+export type ParishDeliveryProvider = "mock";
+
+export interface ParishDeliveryConfig {
+  enabled: boolean;
+  provider: ParishDeliveryProvider | null;
+}
+
+export interface ParishDeliveryRecipient {
+  clerkUserId: string;
+  email: string | null;
+}
+
+export interface ParishDeliveryRequest {
+  provider: ParishDeliveryProvider;
+  subject: string;
+  body: string;
+  recipients: ParishDeliveryRecipient[];
+}
+
+export interface ParishDeliveryResult {
+  sent: string[];
+  failed: Array<{ clerkUserId: string; error: string }>;
+}
+
+export function getParishDeliveryConfig(): ParishDeliveryConfig {
+  const mode = (process.env.PARISH_COMMUNICATIONS_DELIVERY_MODE ?? "disabled").toLowerCase();
+  if (mode === "mock") {
+    return { enabled: true, provider: "mock" };
+  }
+  return { enabled: false, provider: null };
+}
+
+export async function deliverParishMessage(request: ParishDeliveryRequest): Promise<ParishDeliveryResult> {
+  if (request.provider !== "mock") {
+    throw new Error(`Unsupported parish delivery provider: ${request.provider}`);
+  }
+
+  const sent: string[] = [];
+  const failed: Array<{ clerkUserId: string; error: string }> = [];
+
+  for (const recipient of request.recipients) {
+    if (!recipient.email) {
+      failed.push({
+        clerkUserId: recipient.clerkUserId,
+        error: "Recipient has no email on file.",
+      });
+      continue;
+    }
+    sent.push(recipient.clerkUserId);
+  }
+
+  return { sent, failed };
+}

--- a/src/lib/repositories/parish-admin.ts
+++ b/src/lib/repositories/parish-admin.ts
@@ -1,0 +1,504 @@
+import { E2E_COURSE } from "@/lib/e2e-fixtures";
+import { isE2ESmokeMode } from "@/lib/e2e-mode";
+import { ParishRole } from "@/lib/types";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+export interface ParishAdminOverview {
+  memberCount: number;
+  enrollmentCount: number;
+  activeLearnerCount: number;
+  stalledLearnerCount: number;
+  completionRate: number;
+}
+
+export interface ParishAdminCourseRow {
+  id: string;
+  title: string;
+  description: string | null;
+  published: boolean;
+  scope: "DIOCESE" | "PARISH";
+}
+
+export interface ParishAdminEnrollmentRow {
+  id: string;
+  clerk_user_id: string;
+  course_id: string;
+  cohort_id: string | null;
+  created_at: string;
+}
+
+export interface ParishAdminMemberRow {
+  clerk_user_id: string;
+  role: ParishRole;
+  email: string | null;
+  display_name: string | null;
+}
+
+export interface ParishAdminCohortRow {
+  id: string;
+  name: string;
+  facilitator_clerk_user_id: string | null;
+  cadence: "weekly" | "biweekly" | "monthly" | "custom";
+  next_session_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ParishMetricRow {
+  learners_started: number;
+  learners_completed: number;
+}
+
+export interface ParishAdminDashboardData {
+  role: ParishRole;
+  overview: ParishAdminOverview;
+  visibleCourses: ParishAdminCourseRow[];
+  dioceseCourses: ParishAdminCourseRow[];
+  adoptedParishCourses: ParishAdminCourseRow[];
+  availableParishCourses: ParishAdminCourseRow[];
+  enrollments: ParishAdminEnrollmentRow[];
+  members: ParishAdminMemberRow[];
+  cohorts: ParishAdminCohortRow[];
+  communicationSends: ParishAdminCommunicationSendRow[];
+  participationRows: ParishAdminParticipationRow[];
+}
+
+export interface ParishAdminCommunicationSendRow {
+  id: string;
+  audience_type: "all_members" | "stalled_learners" | "cohort" | "course";
+  audience_value: string | null;
+  subject: string;
+  body: string;
+  recipient_count: number;
+  delivery_status: "not_configured" | "queued" | "sent" | "failed";
+  created_by_clerk_user_id: string;
+  created_at: string;
+}
+
+export type ParishParticipationStatus = "not_started" | "active" | "stalled" | "completed";
+
+export interface ParishAdminParticipationRow {
+  enrollment_id: string;
+  clerk_user_id: string;
+  course_id: string;
+  cohort_id: string | null;
+  enrolled_at: string;
+  completed_lessons: number;
+  started_lessons: number;
+  total_lessons: number;
+  progress_percent: number;
+  last_activity_at: string | null;
+  status: ParishParticipationStatus;
+}
+
+function sortCoursesByTitle(courses: ParishAdminCourseRow[]) {
+  return [...courses].sort((a, b) => a.title.localeCompare(b.title));
+}
+
+export async function getParishAdminDashboardData(parishId: string): Promise<ParishAdminDashboardData> {
+  return getParishAdminDashboardDataForUser({
+    parishId,
+    role: "parish_admin",
+    clerkUserId: "",
+  });
+}
+
+export async function getParishAdminDashboardDataForUser({
+  parishId,
+  role,
+  clerkUserId,
+}: {
+  parishId: string;
+  role: ParishRole;
+  clerkUserId: string;
+}): Promise<ParishAdminDashboardData> {
+  if (isE2ESmokeMode()) {
+    const e2eCourses: ParishAdminCourseRow[] = [E2E_COURSE];
+    return {
+      role,
+      overview: {
+        memberCount: 1,
+        enrollmentCount: 1,
+        activeLearnerCount: 1,
+        stalledLearnerCount: 0,
+        completionRate: 0,
+      },
+      visibleCourses: e2eCourses,
+      dioceseCourses: [],
+      adoptedParishCourses: e2eCourses,
+      availableParishCourses: [],
+      enrollments: [
+        {
+          id: "e2e-enrollment",
+          clerk_user_id: "e2e-user",
+          course_id: E2E_COURSE.id,
+          cohort_id: "e2e-cohort",
+          created_at: new Date().toISOString(),
+        },
+      ],
+      members: [
+        {
+          clerk_user_id: "e2e-user",
+          role: "parish_admin",
+          email: "e2e@example.test",
+          display_name: "E2E User",
+        },
+      ],
+      cohorts: [
+        {
+          id: "e2e-cohort",
+          name: "Core Formation Cohort",
+          facilitator_clerk_user_id: "e2e-user",
+          cadence: "weekly",
+          next_session_at: null,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ],
+      communicationSends: [],
+      participationRows: [
+        {
+          enrollment_id: "e2e-enrollment",
+          clerk_user_id: "e2e-user",
+          course_id: E2E_COURSE.id,
+          cohort_id: "e2e-cohort",
+          enrolled_at: new Date().toISOString(),
+          completed_lessons: 0,
+          started_lessons: 0,
+          total_lessons: 0,
+          progress_percent: 0,
+          last_activity_at: null,
+          status: "not_started",
+        },
+      ],
+    };
+  }
+
+  const supabase = getSupabaseAdminClient();
+  const stalledCutoff = new Date(Date.now() - 1000 * 60 * 60 * 24 * 7).toISOString();
+
+  let cohortsQuery = supabase
+    .from("cohorts")
+    .select("id,name,facilitator_clerk_user_id,cadence,next_session_at,created_at,updated_at")
+    .eq("parish_id", parishId)
+    .order("created_at", { ascending: false })
+    .limit(200);
+  if (role === "instructor") {
+    cohortsQuery = cohortsQuery.eq("facilitator_clerk_user_id", clerkUserId);
+  }
+
+  const [visibleCoursesResult, allParishCoursesResult, adoptedCourseRowsResult, cohortsResult, metricRowsResult] =
+    await Promise.all([
+      supabase.rpc("get_visible_courses", { p_parish_id: parishId }),
+      supabase
+        .from("courses")
+        .select("id,title,description,published,scope")
+        .eq("published", true)
+        .eq("scope", "PARISH"),
+      supabase.from("course_parishes").select("course_id").eq("parish_id", parishId),
+      cohortsQuery,
+      supabase.rpc("parish_course_metrics", { p_parish_id: parishId }),
+    ]);
+
+  if (visibleCoursesResult.error) throw visibleCoursesResult.error;
+  if (allParishCoursesResult.error) throw allParishCoursesResult.error;
+  if (adoptedCourseRowsResult.error) throw adoptedCourseRowsResult.error;
+  if (cohortsResult.error) throw cohortsResult.error;
+  if (metricRowsResult.error) throw metricRowsResult.error;
+
+  const cohorts = ((cohortsResult.data ?? []) as ParishAdminCohortRow[]) ?? [];
+  const scopedCohortIds = cohorts.map((cohort) => cohort.id);
+
+  let enrollments: ParishAdminEnrollmentRow[] = [];
+  if (role === "instructor" && scopedCohortIds.length === 0) {
+    enrollments = [];
+  } else {
+    let enrollmentsQuery = supabase
+      .from("enrollments")
+      .select("id,clerk_user_id,course_id,cohort_id,created_at")
+      .eq("parish_id", parishId)
+      .order("created_at", { ascending: false })
+      .limit(500);
+
+    if (role === "instructor") {
+      enrollmentsQuery = enrollmentsQuery.in("cohort_id", scopedCohortIds);
+    }
+
+    const enrollmentsResult = await enrollmentsQuery;
+    if (enrollmentsResult.error) throw enrollmentsResult.error;
+    enrollments = ((enrollmentsResult.data ?? []) as ParishAdminEnrollmentRow[]) ?? [];
+  }
+
+  const scopedUserIds = Array.from(new Set(enrollments.map((enrollment) => enrollment.clerk_user_id)));
+  const cohortFacilitatorIds = cohorts
+    .map((cohort) => cohort.facilitator_clerk_user_id)
+    .filter((id): id is string => Boolean(id));
+  const memberIds = Array.from(new Set([...scopedUserIds, ...cohortFacilitatorIds, clerkUserId]));
+
+  let membershipsQuery = supabase.from("parish_memberships").select("clerk_user_id,role").eq("parish_id", parishId);
+  if (role === "instructor") {
+    membershipsQuery = membershipsQuery.in("clerk_user_id", memberIds);
+  }
+
+  const membershipsResult = await membershipsQuery;
+  if (membershipsResult.error) throw membershipsResult.error;
+
+  const membershipRows = ((membershipsResult.data ?? []) as Array<{ clerk_user_id: string; role: ParishRole }>) ?? [];
+
+  let profileRows: Array<{ clerk_user_id: string; email: string | null; display_name: string | null }> = [];
+  if (memberIds.length > 0) {
+    const profilesResult = await supabase
+      .from("user_profiles")
+      .select("clerk_user_id,email,display_name")
+      .in("clerk_user_id", memberIds);
+    if (profilesResult.error) throw profilesResult.error;
+    profileRows = (profilesResult.data ?? []) as Array<{
+      clerk_user_id: string;
+      email: string | null;
+      display_name: string | null;
+    }>;
+  }
+
+  const profileByUserId = new Map(profileRows.map((profile) => [profile.clerk_user_id, profile]));
+  const members = membershipRows
+    .map((row) => {
+      const profile = profileByUserId.get(row.clerk_user_id);
+      return {
+        clerk_user_id: row.clerk_user_id,
+        role: row.role,
+        email: profile?.email ?? null,
+        display_name: profile?.display_name ?? null,
+      };
+    })
+    .sort((a, b) => {
+      const aLabel = a.display_name ?? a.email ?? a.clerk_user_id;
+      const bLabel = b.display_name ?? b.email ?? b.clerk_user_id;
+      return aLabel.localeCompare(bLabel);
+    });
+
+  const visibleCourses = ((visibleCoursesResult.data ?? []) as ParishAdminCourseRow[]) ?? [];
+  const visibleCourseIds = new Set(enrollments.map((enrollment) => enrollment.course_id));
+  const scopedVisibleCourses =
+    role === "instructor" ? visibleCourses.filter((course) => visibleCourseIds.has(course.id)) : visibleCourses;
+
+  const dioceseCourses =
+    role === "parish_admin"
+      ? sortCoursesByTitle(visibleCourses.filter((course) => course.scope === "DIOCESE"))
+      : [];
+  const allParishCourses = ((allParishCoursesResult.data ?? []) as ParishAdminCourseRow[]) ?? [];
+  const adoptedCourseIds = new Set(
+    (((adoptedCourseRowsResult.data ?? []) as Array<{ course_id: string }>).map((row) => row.course_id)) ?? [],
+  );
+  const adoptedParishCourses =
+    role === "parish_admin"
+      ? sortCoursesByTitle(allParishCourses.filter((course) => adoptedCourseIds.has(course.id)))
+      : [];
+  const availableParishCourses =
+    role === "parish_admin"
+      ? sortCoursesByTitle(allParishCourses.filter((course) => !adoptedCourseIds.has(course.id)))
+      : [];
+  let participationRows: ParishAdminParticipationRow[] = [];
+
+  if (enrollments.length > 0) {
+    const courseIds = Array.from(new Set(enrollments.map((enrollment) => enrollment.course_id)));
+    const enrollmentUserIds = Array.from(new Set(enrollments.map((enrollment) => enrollment.clerk_user_id)));
+    const modulesResult = await supabase.from("modules").select("course_id,lessons(id)").in("course_id", courseIds);
+    if (modulesResult.error) throw modulesResult.error;
+
+    const modules = (modulesResult.data ?? []) as Array<{ course_id: string; lessons: Array<{ id: string }> | null }>;
+    const lessonToCourseId = new Map<string, string>();
+    const lessonCountByCourseId = new Map<string, number>();
+    const lessonIds = new Set<string>();
+
+    for (const moduleRow of modules) {
+      const lessons = moduleRow.lessons ?? [];
+      lessonCountByCourseId.set(moduleRow.course_id, (lessonCountByCourseId.get(moduleRow.course_id) ?? 0) + lessons.length);
+      for (const lesson of lessons) {
+        lessonToCourseId.set(lesson.id, moduleRow.course_id);
+        lessonIds.add(lesson.id);
+      }
+    }
+
+    const progressByUserAndCourse = new Map<
+      string,
+      { completedLessonIds: Set<string>; startedLessonIds: Set<string>; lastActivityAt: string | null }
+    >();
+
+    if (lessonIds.size > 0 && enrollmentUserIds.length > 0) {
+      const progressResult = await supabase
+        .from("video_progress")
+        .select("clerk_user_id,lesson_id,completed,updated_at")
+        .eq("parish_id", parishId)
+        .in("clerk_user_id", enrollmentUserIds)
+        .in("lesson_id", Array.from(lessonIds));
+      if (progressResult.error) throw progressResult.error;
+
+      const progressRows =
+        (progressResult.data ?? []) as Array<{
+          clerk_user_id: string;
+          lesson_id: string;
+          completed: boolean;
+          updated_at: string;
+        }>;
+
+      for (const row of progressRows) {
+        const courseId = lessonToCourseId.get(row.lesson_id);
+        if (!courseId) continue;
+
+        const key = `${row.clerk_user_id}:${courseId}`;
+        const existing = progressByUserAndCourse.get(key) ?? {
+          completedLessonIds: new Set<string>(),
+          startedLessonIds: new Set<string>(),
+          lastActivityAt: null,
+        };
+
+        existing.startedLessonIds.add(row.lesson_id);
+        if (row.completed) {
+          existing.completedLessonIds.add(row.lesson_id);
+        }
+        if (!existing.lastActivityAt || row.updated_at > existing.lastActivityAt) {
+          existing.lastActivityAt = row.updated_at;
+        }
+
+        progressByUserAndCourse.set(key, existing);
+      }
+    }
+
+    participationRows = enrollments
+      .map((enrollment) => {
+        const key = `${enrollment.clerk_user_id}:${enrollment.course_id}`;
+        const progress = progressByUserAndCourse.get(key);
+        const completedLessons = progress?.completedLessonIds.size ?? 0;
+        const startedLessons = progress?.startedLessonIds.size ?? 0;
+        const totalLessons = lessonCountByCourseId.get(enrollment.course_id) ?? 0;
+        const progressPercent = totalLessons > 0 ? Math.round((completedLessons / totalLessons) * 100) : 0;
+        const lastActivityAt = progress?.lastActivityAt ?? null;
+
+        let status: ParishParticipationStatus = "not_started";
+        if (totalLessons > 0 && completedLessons >= totalLessons) {
+          status = "completed";
+        } else if (startedLessons === 0) {
+          status = "not_started";
+        } else if (lastActivityAt && lastActivityAt < stalledCutoff) {
+          status = "stalled";
+        } else {
+          status = "active";
+        }
+
+        return {
+          enrollment_id: enrollment.id,
+          clerk_user_id: enrollment.clerk_user_id,
+          course_id: enrollment.course_id,
+          cohort_id: enrollment.cohort_id,
+          enrolled_at: enrollment.created_at,
+          completed_lessons: completedLessons,
+          started_lessons: startedLessons,
+          total_lessons: totalLessons,
+          progress_percent: progressPercent,
+          last_activity_at: lastActivityAt,
+          status,
+        };
+      })
+      .sort((a, b) => {
+        const statusOrder: Record<ParishParticipationStatus, number> = {
+          stalled: 0,
+          not_started: 1,
+          active: 2,
+          completed: 3,
+        };
+        if (statusOrder[a.status] !== statusOrder[b.status]) {
+          return statusOrder[a.status] - statusOrder[b.status];
+        }
+        const aLast = a.last_activity_at ?? "";
+        const bLast = b.last_activity_at ?? "";
+        if (aLast !== bLast) return aLast.localeCompare(bLast);
+        return a.clerk_user_id.localeCompare(b.clerk_user_id);
+      });
+  }
+
+  let activeLearnerCount = 0;
+  let stalledLearnerCount = 0;
+  let completionRate = 0;
+  let communicationSends: ParishAdminCommunicationSendRow[] = [];
+
+  if (role === "parish_admin") {
+    const [activeLearnerRowsResult, stalledRowsResult, messageSendsResult] = await Promise.all([
+      supabase.from("video_progress").select("clerk_user_id").eq("parish_id", parishId),
+      supabase
+        .from("video_progress")
+        .select("clerk_user_id")
+        .eq("parish_id", parishId)
+        .eq("completed", false)
+        .lt("updated_at", stalledCutoff),
+      supabase
+        .from("parish_message_sends")
+        .select(
+          "id,audience_type,audience_value,subject,body,recipient_count,delivery_status,created_by_clerk_user_id,created_at",
+        )
+        .eq("parish_id", parishId)
+        .order("created_at", { ascending: false })
+        .limit(50),
+    ]);
+
+    if (activeLearnerRowsResult.error) throw activeLearnerRowsResult.error;
+    if (stalledRowsResult.error) throw stalledRowsResult.error;
+    if (messageSendsResult.error) throw messageSendsResult.error;
+
+    activeLearnerCount = new Set(
+      ((((activeLearnerRowsResult.data ?? []) as Array<{ clerk_user_id: string }>).map((row) => row.clerk_user_id)) ??
+        []),
+    ).size;
+    stalledLearnerCount = new Set(
+      ((((stalledRowsResult.data ?? []) as Array<{ clerk_user_id: string }>).map((row) => row.clerk_user_id)) ?? []),
+    ).size;
+
+    const metricRows = ((metricRowsResult.data ?? []) as ParishMetricRow[]) ?? [];
+    const learnersStarted = metricRows.reduce((sum, row) => sum + Number(row.learners_started ?? 0), 0);
+    const learnersCompleted = metricRows.reduce((sum, row) => sum + Number(row.learners_completed ?? 0), 0);
+    completionRate = learnersStarted > 0 ? Math.round((learnersCompleted / learnersStarted) * 100) : 0;
+    communicationSends = ((messageSendsResult.data ?? []) as ParishAdminCommunicationSendRow[]) ?? [];
+  } else if (scopedUserIds.length > 0) {
+    const progressRowsResult = await supabase
+      .from("video_progress")
+      .select("clerk_user_id,completed,updated_at")
+      .eq("parish_id", parishId)
+      .in("clerk_user_id", scopedUserIds);
+    if (progressRowsResult.error) throw progressRowsResult.error;
+
+    const progressRows =
+      ((progressRowsResult.data ?? []) as Array<{ clerk_user_id: string; completed: boolean; updated_at: string }>) ??
+      [];
+    const activeUserIds = new Set(progressRows.map((row) => row.clerk_user_id));
+    const completedUserIds = new Set(progressRows.filter((row) => row.completed).map((row) => row.clerk_user_id));
+    const stalledUserIds = new Set(
+      progressRows
+        .filter((row) => !row.completed && row.updated_at < stalledCutoff)
+        .map((row) => row.clerk_user_id),
+    );
+
+    activeLearnerCount = activeUserIds.size;
+    stalledLearnerCount = stalledUserIds.size;
+    completionRate = activeUserIds.size > 0 ? Math.round((completedUserIds.size / activeUserIds.size) * 100) : 0;
+  }
+
+
+  return {
+    role,
+    overview: {
+      memberCount: members.length,
+      enrollmentCount: enrollments.length,
+      activeLearnerCount,
+      stalledLearnerCount,
+      completionRate,
+    },
+    visibleCourses: sortCoursesByTitle(scopedVisibleCourses),
+    dioceseCourses,
+    adoptedParishCourses,
+    availableParishCourses,
+    enrollments,
+    members,
+    cohorts,
+    communicationSends,
+    participationRows,
+  };
+}

--- a/supabase/migrations/0005_cohorts.sql
+++ b/supabase/migrations/0005_cohorts.sql
@@ -1,0 +1,23 @@
+create table if not exists cohorts (
+  id uuid primary key default gen_random_uuid(),
+  parish_id uuid not null references parishes(id) on delete cascade,
+  name text not null,
+  facilitator_clerk_user_id text,
+  cadence text not null default 'weekly',
+  next_session_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (parish_id, name)
+);
+
+create index if not exists cohorts_parish_id_idx on cohorts (parish_id);
+create index if not exists cohorts_facilitator_idx on cohorts (facilitator_clerk_user_id);
+
+alter table cohorts enable row level security;
+
+create policy "deny all" on cohorts for all using (false) with check (false);
+
+alter table enrollments
+add column if not exists cohort_id uuid references cohorts(id) on delete set null;
+
+create index if not exists enrollments_cohort_id_idx on enrollments (cohort_id);

--- a/supabase/migrations/0006_parish_communications.sql
+++ b/supabase/migrations/0006_parish_communications.sql
@@ -1,0 +1,30 @@
+create table if not exists parish_message_sends (
+  id uuid primary key default gen_random_uuid(),
+  parish_id uuid not null references parishes(id) on delete cascade,
+  created_by_clerk_user_id text not null,
+  audience_type text not null check (audience_type in ('all_members','stalled_learners','cohort','course')),
+  audience_value text,
+  subject text not null,
+  body text not null,
+  recipient_count int not null default 0,
+  delivery_status text not null default 'not_configured' check (delivery_status in ('not_configured','queued','sent','failed')),
+  provider text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists parish_message_sends_parish_created_idx on parish_message_sends (parish_id, created_at desc);
+
+create table if not exists parish_message_recipients (
+  send_id uuid not null references parish_message_sends(id) on delete cascade,
+  parish_id uuid not null references parishes(id) on delete cascade,
+  clerk_user_id text not null,
+  primary key (send_id, clerk_user_id)
+);
+
+create index if not exists parish_message_recipients_parish_user_idx on parish_message_recipients (parish_id, clerk_user_id);
+
+alter table parish_message_sends enable row level security;
+alter table parish_message_recipients enable row level security;
+
+create policy "deny all" on parish_message_sends for all using (false) with check (false);
+create policy "deny all" on parish_message_recipients for all using (false) with check (false);

--- a/supabase/migrations/0007_parish_communication_delivery_jobs.sql
+++ b/supabase/migrations/0007_parish_communication_delivery_jobs.sql
@@ -1,0 +1,40 @@
+create table if not exists parish_message_delivery_jobs (
+  id uuid primary key default gen_random_uuid(),
+  send_id uuid not null unique references parish_message_sends(id) on delete cascade,
+  parish_id uuid not null references parishes(id) on delete cascade,
+  provider text not null,
+  status text not null default 'pending' check (status in ('pending','processing','sent','failed')),
+  attempts int not null default 0,
+  max_attempts int not null default 5 check (max_attempts >= 1),
+  next_attempt_at timestamptz not null default now(),
+  last_error text,
+  locked_at timestamptz,
+  locked_by text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists parish_message_delivery_jobs_pending_idx
+  on parish_message_delivery_jobs (status, next_attempt_at);
+
+create index if not exists parish_message_delivery_jobs_parish_idx
+  on parish_message_delivery_jobs (parish_id, created_at desc);
+
+alter table parish_message_delivery_jobs enable row level security;
+create policy "deny all" on parish_message_delivery_jobs for all using (false) with check (false);
+
+alter table parish_message_recipients
+  add column if not exists delivery_status text not null default 'pending'
+    check (delivery_status in ('not_configured','pending','sent','failed'));
+
+alter table parish_message_recipients
+  add column if not exists delivery_attempted_at timestamptz;
+
+alter table parish_message_recipients
+  add column if not exists provider_message_id text;
+
+alter table parish_message_recipients
+  add column if not exists delivery_error text;
+
+create index if not exists parish_message_recipients_send_status_idx
+  on parish_message_recipients (send_id, delivery_status);


### PR DESCRIPTION
## Summary
- build end-to-end parish admin management flows for people, course adoptions, enrollments, participation watchlists/export, cohorts, and cohort assignments
- add parish communications workflow support, including send creation/listing, delivery job tracking, and delivery drill-down endpoints
- wire the Parish Admin page to dedicated managers for each operational area and add e2e coverage for the participation watchlist flow
- include Supabase migrations for cohorts and parish communication delivery job infrastructure
- document parish-admin implementation notes in docs/parish-admin-notes.md

## Testing
- npm run typecheck
- npm run lint
- npm run test -- src/app/api/parish-admin
- CI=1 npm run test:e2e -- e2e/parish-admin.spec.ts

## Follow-up
- messaging/email provider integration remains intentionally deferred; current delivery plumbing is in place for later provider hookup