### PR TITLE
Add document lessons and R2 PDF uploads

### DIFF
--- a/e2e/core-journey.spec.ts
+++ b/e2e/core-journey.spec.ts
@@ -8,9 +8,7 @@ test("student onboarding through quiz submission", async ({ page }) => {
   ).toBeVisible();
 
   await page.getByRole("textbox", { name: "Display name" }).fill("E2E Student");
-  await page
-    .getByRole("combobox", { name: "Parish" })
-    .selectOption("11111111-1111-4111-8111-111111111111");
+  await page.locator("form").getByLabel("Parish").selectOption("11111111-1111-4111-8111-111111111111");
   await page.getByRole("button", { name: "Continue" }).click();
 
   await expect(page).toHaveURL(/\/app\/courses$/);

--- a/e2e/parish-admin.spec.ts
+++ b/e2e/parish-admin.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { readFile } from "node:fs/promises";
 
-const E2E_BASE_URL = "http://127.0.0.1:3100";
+const E2E_BASE_URL = "http://localhost:3100";
 const E2E_PARISH_ID = "11111111-1111-4111-8111-111111111111";
 
 test("parish admin participation watchlist supports filtering and csv export", async ({ context, page }, testInfo) => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ const eslintConfig = defineConfig([
     ".next/**",
     "out/**",
     "build/**",
+    "coverage/**",
     "next-env.d.ts",
   ]),
 ]);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   reporter: [["list"]],
   outputDir: "output/playwright/test-results",
   use: {
-    baseURL: "http://127.0.0.1:3100",
+    baseURL: "http://localhost:3100",
     trace: "retain-on-failure",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
@@ -17,7 +17,7 @@ export default defineConfig({
     command: process.env.CI
       ? "E2E_SMOKE_MODE=1 npm run dev -- --port 3100"
       : "E2E_SMOKE_MODE=1 npm run build && E2E_SMOKE_MODE=1 npm run start -- --port 3100",
-    url: "http://127.0.0.1:3100",
+    url: "http://localhost:3100",
     reuseExistingServer: !process.env.CI,
     timeout: 240_000,
   },

--- a/src/app/api/admin/lessons/[lessonId]/__tests__/route.test.ts
+++ b/src/app/api/admin/lessons/[lessonId]/__tests__/route.test.ts
@@ -21,10 +21,111 @@ describe("/api/admin/lessons/[lessonId]", () => {
     vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: vi.fn(() => ({ update })) } as never);
 
     const res = await PATCH(
-      new Request("http://x", { method: "PATCH", body: JSON.stringify({ title: "L", youtubeVideoId: "id", sortOrder: 1, passingScore: 80 }) }),
+      new Request(
+        "http://x",
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            title: "L",
+            contentType: "VIDEO",
+            youtubeVideoId: "id",
+            sortOrder: 1,
+            passingScore: 80,
+          }),
+        },
+      ),
       { params: Promise.resolve({ lessonId: "11111111-1111-4111-8111-111111111111" }) },
     );
     expect(res.status).toBe(200);
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content_type: "VIDEO",
+        youtube_video_id: "id",
+        document_url: null,
+      }),
+    );
+  });
+
+  it("updates lesson to document content", async () => {
+    const single = vi.fn(async () => ({ data: { id: "l1" }, error: null }));
+    const select = vi.fn(() => ({ single }));
+    const eq = vi.fn(() => ({ select }));
+    const update = vi.fn(() => ({ eq }));
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: vi.fn(() => ({ update })) } as never);
+
+    const res = await PATCH(
+      new Request(
+        "http://x",
+        {
+          method: "PATCH",
+          body: JSON.stringify({
+            title: "Reading",
+            contentType: "DOCUMENT",
+            documentUrl: "/docs/reading.pdf",
+            documentPageStart: 5,
+            documentPageEnd: 7,
+            sortOrder: 1,
+            passingScore: 80,
+          }),
+        },
+      ),
+      { params: Promise.resolve({ lessonId: "11111111-1111-4111-8111-111111111111" }) },
+    );
+
+    expect(res.status).toBe(200);
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content_type: "DOCUMENT",
+        youtube_video_id: null,
+        document_url: "/docs/reading.pdf",
+        document_page_start: 5,
+        document_page_end: 7,
+      }),
+    );
+  });
+
+  it("rejects document lessons without a document url", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: vi.fn() } as never);
+
+    await expect(() =>
+      PATCH(
+        new Request(
+          "http://x",
+          {
+            method: "PATCH",
+            body: JSON.stringify({
+              title: "Reading",
+              contentType: "DOCUMENT",
+              sortOrder: 1,
+              passingScore: 80,
+            }),
+          },
+        ),
+        { params: Promise.resolve({ lessonId: "11111111-1111-4111-8111-111111111111" }) },
+      ),
+    ).rejects.toThrow("Document URL is required for document lessons.");
+  });
+
+  it("rejects video lessons without a video id", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: vi.fn() } as never);
+
+    await expect(() =>
+      PATCH(
+        new Request(
+          "http://x",
+          {
+            method: "PATCH",
+            body: JSON.stringify({
+              title: "Video",
+              contentType: "VIDEO",
+              sortOrder: 1,
+              passingScore: 80,
+            }),
+          },
+        ),
+        { params: Promise.resolve({ lessonId: "11111111-1111-4111-8111-111111111111" }) },
+      ),
+    ).rejects.toThrow("YouTube video ID is required for video lessons.");
   });
 
   it("deletes lesson", async () => {

--- a/src/app/api/admin/lessons/[lessonId]/route.ts
+++ b/src/app/api/admin/lessons/[lessonId]/route.ts
@@ -20,13 +20,63 @@ const optionalThumbnailSchema = z
   .nullish()
   .transform((value) => (value && value.length > 0 ? value : null));
 
+const optionalDocumentUrlSchema = z
+  .string()
+  .trim()
+  .max(2048)
+  .nullish()
+  .transform((value) => (value && value.length > 0 ? value : null));
+
+const optionalPageNumberSchema = z
+  .number()
+  .int()
+  .min(1)
+  .nullish()
+  .transform((value) => value ?? null);
+
 const updateLessonSchema = z.object({
   title: z.string().min(1),
   descriptor: optionalDescriptorSchema,
   thumbnailUrl: optionalThumbnailSchema,
-  youtubeVideoId: z.string().min(1),
+  contentType: z.enum(["VIDEO", "DOCUMENT"]),
+  youtubeVideoId: z
+    .string()
+    .trim()
+    .nullish()
+    .transform((value) => (value && value.length > 0 ? value : null)),
+  documentUrl: optionalDocumentUrlSchema,
+  documentPageStart: optionalPageNumberSchema,
+  documentPageEnd: optionalPageNumberSchema,
   sortOrder: z.number().int().min(0),
   passingScore: z.number().int().min(0).max(100),
+}).superRefine((value, ctx) => {
+  if (value.contentType === "VIDEO" && !value.youtubeVideoId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "YouTube video ID is required for video lessons.",
+      path: ["youtubeVideoId"],
+    });
+  }
+
+  if (value.contentType === "DOCUMENT" && !value.documentUrl) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Document URL is required for document lessons.",
+      path: ["documentUrl"],
+    });
+  }
+
+  if (
+    value.documentPageStart !== null &&
+    value.documentPageEnd !== null &&
+    value.documentPageEnd < value.documentPageStart
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Document end page must be greater than or equal to the start page.",
+      path: ["documentPageEnd"],
+    });
+  }
 });
 
 export async function PATCH(req: Request, ctx: { params: Promise<{ lessonId: string }> }) {
@@ -41,12 +91,16 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ lessonId: str
       title: payload.title,
       descriptor: payload.descriptor,
       thumbnail_url: payload.thumbnailUrl,
-      youtube_video_id: payload.youtubeVideoId,
+      content_type: payload.contentType,
+      youtube_video_id: payload.contentType === "VIDEO" ? payload.youtubeVideoId : null,
+      document_url: payload.contentType === "DOCUMENT" ? payload.documentUrl : null,
+      document_page_start: payload.contentType === "DOCUMENT" ? payload.documentPageStart : null,
+      document_page_end: payload.contentType === "DOCUMENT" ? payload.documentPageEnd : null,
       sort_order: payload.sortOrder,
       passing_score: payload.passingScore,
     })
     .eq("id", lessonId)
-    .select("id,module_id,title,descriptor,thumbnail_url,youtube_video_id,sort_order,passing_score")
+    .select("id,module_id,title,descriptor,thumbnail_url,content_type,youtube_video_id,document_url,document_page_start,document_page_end,sort_order,passing_score")
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/app/api/admin/modules/[moduleId]/lessons/__tests__/route.test.ts
+++ b/src/app/api/admin/modules/[moduleId]/lessons/__tests__/route.test.ts
@@ -20,9 +20,112 @@ describe("POST /api/admin/modules/[moduleId]/lessons", () => {
     vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: vi.fn(() => ({ insert })) } as never);
 
     const res = await POST(
-      new Request("http://x", { method: "POST", body: JSON.stringify({ title: "L", youtubeVideoId: "abc", sortOrder: 1, passingScore: 80 }) }),
+      new Request(
+        "http://x",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            title: "L",
+            contentType: "VIDEO",
+            youtubeVideoId: "abc",
+            sortOrder: 1,
+            passingScore: 80,
+          }),
+        },
+      ),
       { params: Promise.resolve({ moduleId: "11111111-1111-4111-8111-111111111111" }) },
     );
     expect(res.status).toBe(201);
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content_type: "VIDEO",
+        youtube_video_id: "abc",
+        document_url: null,
+      }),
+    );
+  });
+
+  it("creates document lesson", async () => {
+    const single = vi.fn(async () => ({ data: { id: "l2" }, error: null }));
+    const select = vi.fn(() => ({ single }));
+    const insert = vi.fn(() => ({ select }));
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: vi.fn(() => ({ insert })) } as never);
+
+    const res = await POST(
+      new Request(
+        "http://x",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            title: "Reading",
+            contentType: "DOCUMENT",
+            documentUrl: "/docs/reading.pdf",
+            documentPageStart: 2,
+            documentPageEnd: 4,
+            sortOrder: 0,
+            passingScore: 90,
+          }),
+        },
+      ),
+      { params: Promise.resolve({ moduleId: "11111111-1111-4111-8111-111111111111" }) },
+    );
+
+    expect(res.status).toBe(201);
+    expect(insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content_type: "DOCUMENT",
+        youtube_video_id: null,
+        document_url: "/docs/reading.pdf",
+        document_page_start: 2,
+        document_page_end: 4,
+      }),
+    );
+  });
+
+  it("rejects video lessons without a video id", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: vi.fn() } as never);
+
+    await expect(() =>
+      POST(
+        new Request(
+          "http://x",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              title: "Broken video",
+              contentType: "VIDEO",
+              sortOrder: 0,
+              passingScore: 80,
+            }),
+          },
+        ),
+        { params: Promise.resolve({ moduleId: "11111111-1111-4111-8111-111111111111" }) },
+      ),
+    ).rejects.toThrow("YouTube video ID is required for video lessons.");
+  });
+
+  it("rejects document lessons with an invalid page range", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: vi.fn() } as never);
+
+    await expect(() =>
+      POST(
+        new Request(
+          "http://x",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              title: "Broken reading",
+              contentType: "DOCUMENT",
+              documentUrl: "/docs/reading.pdf",
+              documentPageStart: 5,
+              documentPageEnd: 3,
+              sortOrder: 0,
+              passingScore: 80,
+            }),
+          },
+        ),
+        { params: Promise.resolve({ moduleId: "11111111-1111-4111-8111-111111111111" }) },
+      ),
+    ).rejects.toThrow("Document end page must be greater than or equal to the start page.");
   });
 });

--- a/src/app/api/admin/modules/[moduleId]/lessons/route.ts
+++ b/src/app/api/admin/modules/[moduleId]/lessons/route.ts
@@ -20,13 +20,63 @@ const optionalThumbnailSchema = z
   .nullish()
   .transform((value) => (value && value.length > 0 ? value : null));
 
+const optionalDocumentUrlSchema = z
+  .string()
+  .trim()
+  .max(2048)
+  .nullish()
+  .transform((value) => (value && value.length > 0 ? value : null));
+
+const optionalPageNumberSchema = z
+  .number()
+  .int()
+  .min(1)
+  .nullish()
+  .transform((value) => value ?? null);
+
 const createLessonSchema = z.object({
   title: z.string().min(1),
   descriptor: optionalDescriptorSchema,
   thumbnailUrl: optionalThumbnailSchema,
-  youtubeVideoId: z.string().min(1),
+  contentType: z.enum(["VIDEO", "DOCUMENT"]).default("VIDEO"),
+  youtubeVideoId: z
+    .string()
+    .trim()
+    .nullish()
+    .transform((value) => (value && value.length > 0 ? value : null)),
+  documentUrl: optionalDocumentUrlSchema,
+  documentPageStart: optionalPageNumberSchema,
+  documentPageEnd: optionalPageNumberSchema,
   sortOrder: z.number().int().min(0).default(0),
   passingScore: z.number().int().min(0).max(100).default(80),
+}).superRefine((value, ctx) => {
+  if (value.contentType === "VIDEO" && !value.youtubeVideoId) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "YouTube video ID is required for video lessons.",
+      path: ["youtubeVideoId"],
+    });
+  }
+
+  if (value.contentType === "DOCUMENT" && !value.documentUrl) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Document URL is required for document lessons.",
+      path: ["documentUrl"],
+    });
+  }
+
+  if (
+    value.documentPageStart !== null &&
+    value.documentPageEnd !== null &&
+    value.documentPageEnd < value.documentPageStart
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Document end page must be greater than or equal to the start page.",
+      path: ["documentPageEnd"],
+    });
+  }
 });
 
 export async function POST(req: Request, ctx: { params: Promise<{ moduleId: string }> }) {
@@ -42,11 +92,15 @@ export async function POST(req: Request, ctx: { params: Promise<{ moduleId: stri
       title: payload.title,
       descriptor: payload.descriptor,
       thumbnail_url: payload.thumbnailUrl,
-      youtube_video_id: payload.youtubeVideoId,
+      content_type: payload.contentType,
+      youtube_video_id: payload.contentType === "VIDEO" ? payload.youtubeVideoId : null,
+      document_url: payload.contentType === "DOCUMENT" ? payload.documentUrl : null,
+      document_page_start: payload.contentType === "DOCUMENT" ? payload.documentPageStart : null,
+      document_page_end: payload.contentType === "DOCUMENT" ? payload.documentPageEnd : null,
       sort_order: payload.sortOrder,
       passing_score: payload.passingScore,
     })
-    .select("id,module_id,title,descriptor,thumbnail_url,youtube_video_id,sort_order,passing_score")
+    .select("id,module_id,title,descriptor,thumbnail_url,content_type,youtube_video_id,document_url,document_page_start,document_page_end,sort_order,passing_score")
     .single();
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/app/api/admin/uploads/documents/__tests__/route.test.ts
+++ b/src/app/api/admin/uploads/documents/__tests__/route.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({ requireDioceseAdmin: vi.fn() }));
+vi.mock("@/lib/r2", () => ({
+  getDocumentUploadMaxBytes: vi.fn(),
+  uploadDocumentToR2: vi.fn(),
+}));
+
+import { POST } from "@/app/api/admin/uploads/documents/route";
+import { requireDioceseAdmin } from "@/lib/authz";
+import { getDocumentUploadMaxBytes, uploadDocumentToR2 } from "@/lib/r2";
+
+describe("POST /api/admin/uploads/documents", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireDioceseAdmin).mockResolvedValue("admin");
+    vi.mocked(getDocumentUploadMaxBytes).mockReturnValue(5 * 1024 * 1024);
+  });
+
+  function buildRequest(file: { arrayBuffer: () => Promise<ArrayBuffer>; name: string; size: number; type: string } | string | null) {
+    return {
+      formData: vi.fn().mockResolvedValue({
+        get: vi.fn((key: string) => (key === "file" ? file : null)),
+      }),
+    } as unknown as Request;
+  }
+
+  it("uploads a pdf to r2", async () => {
+    vi.mocked(uploadDocumentToR2).mockResolvedValue({
+      key: "documents/2026/03/test.pdf",
+      url: "https://cdn.example.com/documents/2026/03/test.pdf",
+    });
+
+    const file = {
+      arrayBuffer: vi.fn().mockResolvedValue(new TextEncoder().encode("pdf").buffer),
+      name: "reading.pdf",
+      size: 3,
+      type: "application/pdf",
+    };
+
+    const response = await POST(buildRequest(file));
+
+    expect(response.status).toBe(201);
+    expect(uploadDocumentToR2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        contentType: "application/pdf",
+        fileName: "reading.pdf",
+      }),
+    );
+    await expect(response.json()).resolves.toEqual({
+      key: "documents/2026/03/test.pdf",
+      url: "https://cdn.example.com/documents/2026/03/test.pdf",
+    });
+  });
+
+  it("rejects non-pdf uploads", async () => {
+    const file = {
+      arrayBuffer: vi.fn().mockResolvedValue(new TextEncoder().encode("text").buffer),
+      name: "notes.txt",
+      size: 4,
+      type: "text/plain",
+    };
+
+    const response = await POST(buildRequest(file));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Only PDF uploads are supported.",
+    });
+  });
+
+  it("rejects oversized uploads", async () => {
+    vi.mocked(getDocumentUploadMaxBytes).mockReturnValue(3);
+
+    const file = {
+      arrayBuffer: vi.fn().mockResolvedValue(new TextEncoder().encode("large-pdf").buffer),
+      name: "reading.pdf",
+      size: 9,
+      type: "application/pdf",
+    };
+
+    const response = await POST(buildRequest(file));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "PDF exceeds the 1 MB upload limit.",
+    });
+  });
+});

--- a/src/app/api/admin/uploads/documents/route.ts
+++ b/src/app/api/admin/uploads/documents/route.ts
@@ -1,0 +1,71 @@
+import { Buffer } from "node:buffer";
+
+import { NextResponse } from "next/server";
+
+import { requireDioceseAdmin } from "@/lib/authz";
+import { getDocumentUploadMaxBytes, uploadDocumentToR2 } from "@/lib/r2";
+
+export const runtime = "nodejs";
+
+type UploadFile = FormDataEntryValue & {
+  arrayBuffer: () => Promise<ArrayBuffer>;
+  name: string;
+  size: number;
+  type: string;
+};
+
+function isUploadFile(value: FormDataEntryValue | null): value is UploadFile {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "arrayBuffer" in value &&
+    "name" in value &&
+    "size" in value &&
+    "type" in value
+  );
+}
+
+function isPdfFile(file: UploadFile) {
+  return file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf");
+}
+
+export async function POST(req: Request) {
+  await requireDioceseAdmin();
+
+  const formData = await req.formData();
+  const entry = formData.get("file");
+
+  if (!isUploadFile(entry)) {
+    return NextResponse.json({ error: "PDF file is required." }, { status: 400 });
+  }
+
+  if (!isPdfFile(entry)) {
+    return NextResponse.json({ error: "Only PDF uploads are supported." }, { status: 400 });
+  }
+
+  if (entry.size === 0) {
+    return NextResponse.json({ error: "Uploaded PDF is empty." }, { status: 400 });
+  }
+
+  const maxBytes = getDocumentUploadMaxBytes();
+  if (entry.size > maxBytes) {
+    const maxMegabytes = Math.max(1, Math.ceil(maxBytes / (1024 * 1024)));
+    return NextResponse.json(
+      { error: `PDF exceeds the ${maxMegabytes} MB upload limit.` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const uploaded = await uploadDocumentToR2({
+      body: Buffer.from(await entry.arrayBuffer()),
+      contentType: "application/pdf",
+      fileName: entry.name,
+    });
+
+    return NextResponse.json(uploaded, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to upload PDF.";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/app/lessons/[lessonId]/__tests__/page.test.tsx
+++ b/src/app/app/lessons/[lessonId]/__tests__/page.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigationMocks = vi.hoisted(() => ({
+  redirect: vi.fn(),
+  notFound: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: navigationMocks.redirect,
+  notFound: navigationMocks.notFound,
+}));
+
+vi.mock("@/components/player/youtube-player", () => ({
+  YoutubePlayer: ({ videoId }: { videoId: string }) => <div>Video player: {videoId}</div>,
+}));
+
+vi.mock("@/components/quiz-form", () => ({
+  QuizForm: ({ questions }: { questions: Array<{ prompt: string }> }) => (
+    <div>Quiz questions: {questions.length}</div>
+  ),
+}));
+
+vi.mock("@/components/document-review-card", () => ({
+  DocumentReviewCard: ({ documentLabel }: { documentLabel: string }) => <div>Document review: {documentLabel}</div>,
+}));
+
+vi.mock("@/lib/authz", () => ({
+  requireParishRole: vi.fn(),
+}));
+
+vi.mock("@/lib/e2e-mode", () => ({
+  isE2ESmokeMode: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/repositories/lessons", () => ({
+  getBestScore: vi.fn(),
+  getLessonProgress: vi.fn(),
+  getLessonWithQuestions: vi.fn(),
+  isUserEnrolledForLesson: vi.fn(),
+}));
+
+import LessonPage from "@/app/app/lessons/[lessonId]/page";
+import { requireParishRole } from "@/lib/authz";
+import {
+  getBestScore,
+  getLessonProgress,
+  getLessonWithQuestions,
+  isUserEnrolledForLesson,
+} from "@/lib/repositories/lessons";
+
+describe("LessonPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      role: "student",
+    });
+    vi.mocked(isUserEnrolledForLesson).mockResolvedValue(true);
+    vi.mocked(getLessonProgress).mockResolvedValue({
+      percent_watched: 100,
+      last_position_seconds: 0,
+      completed: true,
+    });
+    vi.mocked(getBestScore).mockResolvedValue(100);
+  });
+
+  it("renders document lessons with review status and iframe", async () => {
+    vi.mocked(getLessonWithQuestions).mockResolvedValue({
+      id: "lesson-1",
+      title: "Reading lesson",
+      descriptor: "Read the assigned section.",
+      content_type: "DOCUMENT",
+      youtube_video_id: null,
+      document_url: "/docs/reading.pdf",
+      document_page_start: 2,
+      document_page_end: 4,
+      passing_score: 80,
+      module_id: "module-1",
+      questions: [{ id: "q1", prompt: "What did you read?", options: ["A"], sort_order: 0 }],
+    });
+
+    render(await LessonPage({ params: Promise.resolve({ lessonId: "lesson-1" }) }));
+
+    expect(screen.getByText("Reading lesson")).toBeInTheDocument();
+    expect(screen.getByText("Review status: Reviewed · Pages 2-4")).toBeInTheDocument();
+    expect(screen.getByText("Document review: Pages 2-4")).toBeInTheDocument();
+    expect(screen.getByTitle("Reading lesson document")).toHaveAttribute("src", "/docs/reading.pdf#page=2");
+    expect(screen.getByText("Quiz questions: 1")).toBeInTheDocument();
+  });
+
+  it("renders video lessons with the video player", async () => {
+    vi.mocked(getLessonWithQuestions).mockResolvedValue({
+      id: "lesson-1",
+      title: "Video lesson",
+      descriptor: null,
+      content_type: "VIDEO",
+      youtube_video_id: "abc123",
+      document_url: null,
+      document_page_start: null,
+      document_page_end: null,
+      passing_score: 80,
+      module_id: "module-1",
+      questions: [],
+    });
+
+    render(await LessonPage({ params: Promise.resolve({ lessonId: "lesson-1" }) }));
+
+    expect(screen.getByText("Video player: abc123")).toBeInTheDocument();
+    expect(screen.getByText("Quiz questions: 0")).toBeInTheDocument();
+  });
+});

--- a/src/app/app/lessons/[lessonId]/page.tsx
+++ b/src/app/app/lessons/[lessonId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound, redirect } from "next/navigation";
 
+import { DocumentReviewCard } from "@/components/document-review-card";
 import { YoutubePlayer } from "@/components/player/youtube-player";
 import { QuizForm } from "@/components/quiz-form";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -7,10 +8,24 @@ import { requireParishRole } from "@/lib/authz";
 import { isE2ESmokeMode } from "@/lib/e2e-mode";
 import {
   getBestScore,
+  getLessonProgress,
   getLessonWithQuestions,
-  getVideoProgress,
   isUserEnrolledForLesson,
 } from "@/lib/repositories/lessons";
+
+function buildDocumentViewerUrl({
+  documentUrl,
+  pageStart,
+}: {
+  documentUrl: string;
+  pageStart: number | null;
+}) {
+  if (!pageStart || documentUrl.includes("#")) {
+    return documentUrl;
+  }
+
+  return `${documentUrl}#page=${pageStart}`;
+}
 
 export default async function LessonPage({
   params,
@@ -27,8 +42,21 @@ export default async function LessonPage({
   const lesson = await getLessonWithQuestions(lessonId);
   if (!lesson) notFound();
 
-  const progress = await getVideoProgress(lessonId, parishId, clerkUserId);
+  const progress = await getLessonProgress(lessonId, parishId, clerkUserId);
   const bestScore = await getBestScore(lessonId, parishId, clerkUserId);
+  const documentViewerUrl =
+    lesson.content_type === "DOCUMENT" && lesson.document_url
+      ? buildDocumentViewerUrl({
+          documentUrl: lesson.document_url,
+          pageStart: lesson.document_page_start,
+        })
+      : null;
+  const pageRangeLabel =
+    lesson.document_page_start && lesson.document_page_end
+      ? `Pages ${lesson.document_page_start}-${lesson.document_page_end}`
+      : lesson.document_page_start
+        ? `Page ${lesson.document_page_start}`
+        : "Assigned document";
 
   return (
     <div className="space-y-6">
@@ -37,22 +65,58 @@ export default async function LessonPage({
           <CardTitle>{lesson.title}</CardTitle>
         </CardHeader>
         <CardContent>
+          {lesson.descriptor ? <p className="mb-2 text-sm text-muted-foreground">{lesson.descriptor}</p> : null}
+          {lesson.content_type === "DOCUMENT" ? (
+            <p className="text-sm text-muted-foreground">
+              Review status: {progress?.completed ? "Reviewed" : "Pending"} · {pageRangeLabel}
+            </p>
+          ) : null}
           <p className="text-sm text-muted-foreground">Best score: {bestScore}%</p>
         </CardContent>
       </Card>
-      {isE2ESmokeMode() ? (
+      {lesson.content_type === "VIDEO" && lesson.youtube_video_id ? (
+        isE2ESmokeMode() ? (
+          <Card>
+            <CardContent className="pt-4">
+              <p className="text-sm text-muted-foreground">Video player placeholder (e2e mode).</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <YoutubePlayer
+            lessonId={lesson.id}
+            parishId={parishId}
+            resumeSeconds={progress?.last_position_seconds ?? 0}
+            videoId={lesson.youtube_video_id}
+          />
+        )
+      ) : lesson.content_type === "DOCUMENT" && lesson.document_url && documentViewerUrl ? (
+        <>
+          <DocumentReviewCard
+            documentLabel={pageRangeLabel}
+            documentUrl={documentViewerUrl}
+            initiallyCompleted={Boolean(progress?.completed)}
+            lessonId={lesson.id}
+            parishId={parishId}
+          />
+          <Card>
+            <CardHeader>
+              <CardTitle>Assigned reading</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <iframe
+                className="h-[720px] w-full rounded-md border border-border"
+                src={documentViewerUrl}
+                title={`${lesson.title} document`}
+              />
+            </CardContent>
+          </Card>
+        </>
+      ) : (
         <Card>
           <CardContent className="pt-4">
-            <p className="text-sm text-muted-foreground">Video player placeholder (e2e mode).</p>
+            <p className="text-sm text-muted-foreground">This lesson is missing its content configuration.</p>
           </CardContent>
         </Card>
-      ) : (
-        <YoutubePlayer
-          lessonId={lesson.id}
-          parishId={parishId}
-          resumeSeconds={progress?.last_position_seconds ?? 0}
-          videoId={lesson.youtube_video_id}
-        />
       )}
       <QuizForm
         lessonId={lesson.id}

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -1,7 +1,9 @@
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
 
-import { hasCompletedOnboarding, isDioceseAdmin, requireAuth } from "@/lib/authz";
+import { getActiveParishRole, hasCompletedOnboarding, isDioceseAdmin, requireAuth } from "@/lib/authz";
+import { E2E_PARISHES } from "@/lib/e2e-fixtures";
+import { isE2ESmokeMode } from "@/lib/e2e-mode";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 
 export default async function AppIndex() {
@@ -17,6 +19,21 @@ export default async function AppIndex() {
 
   const store = await cookies();
   const activeParishId = store.get("active_parish_id")?.value;
+
+  if (isE2ESmokeMode()) {
+    const resolvedParishId = activeParishId ?? E2E_PARISHES[0]?.id;
+    if (!resolvedParishId) {
+      redirect("/app/select-parish");
+    }
+
+    const role = await getActiveParishRole(userId);
+    if (role === "parish_admin" || role === "instructor") {
+      redirect("/app/parish-admin");
+    }
+
+    redirect("/app/courses");
+  }
+
   const supabase = getSupabaseAdminClient();
 
   const { data: memberships, error: membershipsError } = await supabase

--- a/src/components/__tests__/document-review-card.test.tsx
+++ b/src/components/__tests__/document-review-card.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DocumentReviewCard } from "@/components/document-review-card";
+
+describe("DocumentReviewCard", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("marks a document section as reviewed", async () => {
+    const fetchMock = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+
+    render(
+      <DocumentReviewCard
+        documentLabel="Pages 2-4"
+        documentUrl="/docs/reading.pdf#page=2"
+        initiallyCompleted={false}
+        lessonId="11111111-1111-4111-8111-111111111111"
+        parishId="22222222-2222-4222-8222-222222222222"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark section reviewed" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/progress",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            lessonId: "11111111-1111-4111-8111-111111111111",
+            parishId: "22222222-2222-4222-8222-222222222222",
+            percentWatched: 100,
+            lastPositionSeconds: 0,
+            completed: true,
+          }),
+        }),
+      ),
+    );
+
+    expect(await screen.findByText("Section marked as reviewed.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Section reviewed" })).toBeDisabled();
+  });
+
+  it("shows an error when progress saving fails", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "db error" }),
+    } as Response);
+
+    render(
+      <DocumentReviewCard
+        documentLabel="Assigned document"
+        documentUrl="/docs/reading.pdf"
+        initiallyCompleted={false}
+        lessonId="11111111-1111-4111-8111-111111111111"
+        parishId="22222222-2222-4222-8222-222222222222"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark section reviewed" }));
+
+    expect(await screen.findByText("db error")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Mark section reviewed" })).toBeEnabled();
+  });
+});

--- a/src/components/__tests__/document-upload-field.test.tsx
+++ b/src/components/__tests__/document-upload-field.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DocumentUploadField } from "@/components/document-upload-field";
+
+describe("DocumentUploadField", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uploads a pdf and reports the returned url", async () => {
+    const onMessage = vi.fn();
+    const onUploaded = vi.fn();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ url: "https://cdn.example.com/documents/reading.pdf" }),
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<DocumentUploadField onMessage={onMessage} onUploaded={onUploaded} />);
+
+    const input = screen.getByLabelText("Upload PDF");
+    fireEvent.change(input, {
+      target: {
+        files: [new File(["pdf"], "reading.pdf", { type: "application/pdf" })],
+      },
+    });
+
+    await waitFor(() =>
+      expect(onUploaded).toHaveBeenCalledWith("https://cdn.example.com/documents/reading.pdf"),
+    );
+    expect(onMessage).toHaveBeenCalledWith("PDF uploaded. Save lesson to keep the document link.");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/admin/uploads/documents",
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(await screen.findByText("Uploaded: reading.pdf")).toBeInTheDocument();
+  });
+
+  it("reports upload failures", async () => {
+    const onMessage = vi.fn();
+    const onUploaded = vi.fn();
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        json: async () => ({ error: "Only PDF uploads are supported." }),
+      }),
+    );
+
+    render(<DocumentUploadField onMessage={onMessage} onUploaded={onUploaded} />);
+
+    fireEvent.change(screen.getByLabelText("Upload PDF"), {
+      target: {
+        files: [new File(["text"], "notes.txt", { type: "text/plain" })],
+      },
+    });
+
+    await waitFor(() => expect(onMessage).toHaveBeenCalledWith("Only PDF uploads are supported."));
+    expect(onUploaded).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/admin-course-content-manager.tsx
+++ b/src/components/admin-course-content-manager.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 
+import { DocumentUploadField } from "@/components/document-upload-field";
 import type { DioceseModuleRow } from "@/lib/repositories/diocese-admin";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -21,7 +22,11 @@ interface LessonDraft {
   title: string;
   descriptor: string;
   thumbnailUrl: string;
+  contentType: "VIDEO" | "DOCUMENT";
   youtubeVideoId: string;
+  documentUrl: string;
+  documentPageStart: string;
+  documentPageEnd: string;
   passingScore: string;
 }
 
@@ -50,7 +55,11 @@ function buildLessonDrafts(modules: DioceseModuleRow[]) {
           title: lesson.title,
           descriptor: lesson.descriptor ?? "",
           thumbnailUrl: lesson.thumbnail_url ?? "",
-          youtubeVideoId: lesson.youtube_video_id,
+          contentType: lesson.content_type,
+          youtubeVideoId: lesson.youtube_video_id ?? "",
+          documentUrl: lesson.document_url ?? "",
+          documentPageStart: lesson.document_page_start ? String(lesson.document_page_start) : "",
+          documentPageEnd: lesson.document_page_end ? String(lesson.document_page_end) : "",
           passingScore: String(lesson.passing_score),
         },
       ]),
@@ -234,7 +243,11 @@ export function AdminCourseContentManager({
         title: "New lesson",
         descriptor: null,
         thumbnailUrl: null,
+        contentType: "VIDEO",
         youtubeVideoId: "dQw4w9WgXcQ",
+        documentUrl: null,
+        documentPageStart: null,
+        documentPageEnd: null,
         sortOrder: selectedModule?.lessons.length ?? 0,
         passingScore: 80,
       }),
@@ -256,6 +269,8 @@ export function AdminCourseContentManager({
 
     const parsedScore = Number.parseInt(draft.passingScore, 10);
     const passingScore = Number.isFinite(parsedScore) ? Math.min(100, Math.max(0, parsedScore)) : 80;
+    const parsedPageStart = Number.parseInt(draft.documentPageStart, 10);
+    const parsedPageEnd = Number.parseInt(draft.documentPageEnd, 10);
 
     const response = await fetch(`/api/admin/lessons/${lessonId}`, {
       method: "PATCH",
@@ -264,7 +279,11 @@ export function AdminCourseContentManager({
         title,
         descriptor: draft.descriptor || null,
         thumbnailUrl: draft.thumbnailUrl || null,
-        youtubeVideoId: draft.youtubeVideoId,
+        contentType: draft.contentType,
+        youtubeVideoId: draft.youtubeVideoId || null,
+        documentUrl: draft.documentUrl || null,
+        documentPageStart: Number.isFinite(parsedPageStart) ? parsedPageStart : null,
+        documentPageEnd: Number.isFinite(parsedPageEnd) ? parsedPageEnd : null,
         sortOrder,
         passingScore,
       }),
@@ -443,7 +462,11 @@ export function AdminCourseContentManager({
                         title: lesson.title,
                         descriptor: lesson.descriptor ?? "",
                         thumbnailUrl: lesson.thumbnail_url ?? "",
-                        youtubeVideoId: lesson.youtube_video_id,
+                        contentType: lesson.content_type,
+                        youtubeVideoId: lesson.youtube_video_id ?? "",
+                        documentUrl: lesson.document_url ?? "",
+                        documentPageStart: lesson.document_page_start ? String(lesson.document_page_start) : "",
+                        documentPageEnd: lesson.document_page_end ? String(lesson.document_page_end) : "",
                         passingScore: String(lesson.passing_score),
                       };
 
@@ -520,16 +543,83 @@ export function AdminCourseContentManager({
                               placeholder="Lesson descriptor (optional)"
                               value={lessonDraft.descriptor}
                             />
-                            <Input
+                            <Select
                               onChange={(event) =>
                                 setLessonDrafts((prev) => ({
                                   ...prev,
-                                  [lesson.id]: { ...lessonDraft, youtubeVideoId: event.target.value },
+                                  [lesson.id]: { ...lessonDraft, contentType: event.target.value as "VIDEO" | "DOCUMENT" },
                                 }))
                               }
-                              placeholder="YouTube video ID"
-                              value={lessonDraft.youtubeVideoId}
-                            />
+                              value={lessonDraft.contentType}
+                            >
+                              <option value="VIDEO">Video lesson</option>
+                              <option value="DOCUMENT">Document lesson</option>
+                            </Select>
+                            {lessonDraft.contentType === "VIDEO" ? (
+                              <Input
+                                onChange={(event) =>
+                                  setLessonDrafts((prev) => ({
+                                    ...prev,
+                                    [lesson.id]: { ...lessonDraft, youtubeVideoId: event.target.value },
+                                  }))
+                                }
+                                placeholder="YouTube video ID"
+                                value={lessonDraft.youtubeVideoId}
+                              />
+                            ) : (
+                              <>
+                                <Input
+                                  onChange={(event) =>
+                                    setLessonDrafts((prev) => ({
+                                      ...prev,
+                                      [lesson.id]: { ...lessonDraft, documentUrl: event.target.value },
+                                    }))
+                                  }
+                                  placeholder="Document URL"
+                                  value={lessonDraft.documentUrl}
+                                />
+                                <DocumentUploadField
+                                  onMessage={setMessage}
+                                  onUploaded={(url) =>
+                                    setLessonDrafts((prev) => ({
+                                      ...prev,
+                                      [lesson.id]: {
+                                        ...(prev[lesson.id] ?? lessonDraft),
+                                        documentUrl: url,
+                                      },
+                                    }))
+                                  }
+                                />
+                              </>
+                            )}
+                            {lessonDraft.contentType === "DOCUMENT" ? (
+                              <>
+                                <Input
+                                  min={1}
+                                  onChange={(event) =>
+                                    setLessonDrafts((prev) => ({
+                                      ...prev,
+                                      [lesson.id]: { ...lessonDraft, documentPageStart: event.target.value },
+                                    }))
+                                  }
+                                  placeholder="Start page (optional)"
+                                  type="number"
+                                  value={lessonDraft.documentPageStart}
+                                />
+                                <Input
+                                  min={1}
+                                  onChange={(event) =>
+                                    setLessonDrafts((prev) => ({
+                                      ...prev,
+                                      [lesson.id]: { ...lessonDraft, documentPageEnd: event.target.value },
+                                    }))
+                                  }
+                                  placeholder="End page (optional)"
+                                  type="number"
+                                  value={lessonDraft.documentPageEnd}
+                                />
+                              </>
+                            ) : null}
                             <Input
                               max={100}
                               min={0}

--- a/src/components/document-review-card.tsx
+++ b/src/components/document-review-card.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+export function DocumentReviewCard({
+  lessonId,
+  parishId,
+  documentUrl,
+  documentLabel,
+  initiallyCompleted,
+}: {
+  lessonId: string;
+  parishId: string;
+  documentUrl: string;
+  documentLabel: string;
+  initiallyCompleted: boolean;
+}) {
+  const [completed, setCompleted] = useState(initiallyCompleted);
+  const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function markReviewed() {
+    setSubmitting(true);
+    setMessage("");
+
+    const response = await fetch("/api/progress", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        lessonId,
+        parishId,
+        percentWatched: 100,
+        lastPositionSeconds: 0,
+        completed: true,
+      }),
+    });
+
+    const data = await response.json();
+
+    if (response.ok) {
+      setCompleted(true);
+      setMessage("Section marked as reviewed.");
+    } else {
+      setMessage(data.error ?? "Unable to update review status.");
+    }
+
+    setSubmitting(false);
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Document review</CardTitle>
+        <CardDescription>Open the assigned section, review it, then mark the section as complete.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex flex-wrap gap-2">
+          <Button asChild type="button" variant="outline">
+            <a href={documentUrl} rel="noreferrer" target="_blank">
+              Open {documentLabel}
+            </a>
+          </Button>
+          <Button disabled={completed || submitting} onClick={markReviewed} type="button">
+            {completed ? "Section reviewed" : submitting ? "Saving..." : "Mark section reviewed"}
+          </Button>
+        </div>
+        {message ? <p className="text-sm text-muted-foreground">{message}</p> : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/document-upload-field.tsx
+++ b/src/components/document-upload-field.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState, type ChangeEvent } from "react";
+
+import { Input } from "@/components/ui/input";
+
+export function DocumentUploadField({
+  onMessage,
+  onUploaded,
+}: {
+  onMessage: (message: string) => void;
+  onUploaded: (url: string) => void;
+}) {
+  const [isUploading, setIsUploading] = useState(false);
+  const [status, setStatus] = useState<string | null>(null);
+
+  async function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+
+    if (!file) {
+      return;
+    }
+
+    const formData = new FormData();
+    formData.set("file", file);
+    setIsUploading(true);
+    setStatus(null);
+
+    try {
+      const response = await fetch("/api/admin/uploads/documents", {
+        method: "POST",
+        body: formData,
+      });
+      const payload = (await response.json()) as { error?: string; url?: string };
+
+      if (!response.ok || !payload.url) {
+        throw new Error(payload.error ?? "Failed to upload PDF.");
+      }
+
+      onUploaded(payload.url);
+      onMessage("PDF uploaded. Save lesson to keep the document link.");
+      setStatus(file.name);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to upload PDF.";
+      onMessage(message);
+      setStatus(null);
+    } finally {
+      setIsUploading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2 md:col-span-2">
+      <Input
+        accept="application/pdf,.pdf"
+        aria-label="Upload PDF"
+        disabled={isUploading}
+        onChange={handleChange}
+        type="file"
+      />
+      <p className="text-xs text-muted-foreground">
+        Uploads the PDF to Cloudflare R2 and fills the document URL automatically.
+      </p>
+      {status ? <p className="text-xs text-muted-foreground">Uploaded: {status}</p> : null}
+    </div>
+  );
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -24,8 +24,12 @@ export function ThemeToggle() {
 
   useEffect(() => {
     const savedTheme = localStorage.getItem(THEME_KEY);
-    setTheme(savedTheme === "light" || savedTheme === "dark" ? savedTheme : getSystemTheme());
-    setMounted(true);
+    const nextTheme = savedTheme === "light" || savedTheme === "dark" ? savedTheme : getSystemTheme();
+
+    queueMicrotask(() => {
+      setTheme(nextTheme);
+      setMounted(true);
+    });
   }, []);
 
   useEffect(() => {

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -19,16 +19,20 @@ function applyTheme(theme: Theme) {
 }
 
 export function ThemeToggle() {
-  const [theme, setTheme] = useState<Theme>(() => {
-    if (typeof window === "undefined") return "light";
-    const savedTheme = localStorage.getItem(THEME_KEY);
-    return savedTheme === "light" || savedTheme === "dark" ? savedTheme : getSystemTheme();
-  });
+  const [theme, setTheme] = useState<Theme>("light");
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
+    const savedTheme = localStorage.getItem(THEME_KEY);
+    setTheme(savedTheme === "light" || savedTheme === "dark" ? savedTheme : getSystemTheme());
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
     applyTheme(theme);
     localStorage.setItem(THEME_KEY, theme);
-  }, [theme]);
+  }, [mounted, theme]);
 
   const toggleTheme = () => {
     setTheme((currentTheme) => (currentTheme === "light" ? "dark" : "light"));
@@ -36,7 +40,11 @@ export function ThemeToggle() {
 
   return (
     <Button aria-label="Toggle theme" onClick={toggleTheme} size="icon" variant="outline">
-      {theme === "dark" ? <Sun aria-hidden="true" className="h-4 w-4" /> : <Moon aria-hidden="true" className="h-4 w-4" />}
+      {mounted ? (
+        theme === "dark" ? <Sun aria-hidden="true" className="h-4 w-4" /> : <Moon aria-hidden="true" className="h-4 w-4" />
+      ) : (
+        <span aria-hidden="true" className="block h-4 w-4" />
+      )}
       <span className="sr-only">Toggle theme</span>
     </Button>
   );

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Moon, Sun } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 
 import { Button } from "@/components/ui/button";
 
@@ -18,19 +18,67 @@ function applyTheme(theme: Theme) {
   document.documentElement.dataset.theme = theme;
 }
 
+const themeListeners = new Set<() => void>();
+
+function emitThemeChange() {
+  themeListeners.forEach((listener) => listener());
+}
+
+function getStoredTheme(): Theme {
+  if (typeof window === "undefined") return "light";
+
+  const savedTheme = localStorage.getItem(THEME_KEY);
+  return savedTheme === "light" || savedTheme === "dark" ? savedTheme : getSystemTheme();
+}
+
+function subscribeToTheme(callback: () => void) {
+  themeListeners.add(callback);
+
+  if (typeof window === "undefined") {
+    return () => {
+      themeListeners.delete(callback);
+    };
+  }
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === THEME_KEY || event.key === null) {
+      callback();
+    }
+  };
+
+  window.addEventListener("storage", handleStorage);
+
+  if (typeof window.matchMedia !== "function") {
+    return () => {
+      themeListeners.delete(callback);
+      window.removeEventListener("storage", handleStorage);
+    };
+  }
+
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+  const handleSystemThemeChange = () => {
+    if (!localStorage.getItem(THEME_KEY)) {
+      callback();
+    }
+  };
+
+  mediaQuery.addEventListener("change", handleSystemThemeChange);
+
+  return () => {
+    themeListeners.delete(callback);
+    window.removeEventListener("storage", handleStorage);
+    mediaQuery.removeEventListener("change", handleSystemThemeChange);
+  };
+}
+
+function subscribeToHydration() {
+  return () => {};
+}
+
 export function ThemeToggle() {
-  const [theme, setTheme] = useState<Theme>("light");
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    const savedTheme = localStorage.getItem(THEME_KEY);
-    const nextTheme = savedTheme === "light" || savedTheme === "dark" ? savedTheme : getSystemTheme();
-
-    queueMicrotask(() => {
-      setTheme(nextTheme);
-      setMounted(true);
-    });
-  }, []);
+  const theme = useSyncExternalStore(subscribeToTheme, getStoredTheme, () => "light");
+  const mounted = useSyncExternalStore(subscribeToHydration, () => true, () => false);
 
   useEffect(() => {
     if (!mounted) return;
@@ -39,7 +87,10 @@ export function ThemeToggle() {
   }, [mounted, theme]);
 
   const toggleTheme = () => {
-    setTheme((currentTheme) => (currentTheme === "light" ? "dark" : "light"));
+    const nextTheme = theme === "light" ? "dark" : "light";
+    localStorage.setItem(THEME_KEY, nextTheme);
+    applyTheme(nextTheme);
+    emitThemeChange();
   };
 
   return (

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -77,7 +77,7 @@ function subscribeToHydration() {
 }
 
 export function ThemeToggle() {
-  const theme = useSyncExternalStore(subscribeToTheme, getStoredTheme, () => "light");
+  const theme = useSyncExternalStore<Theme>(subscribeToTheme, getStoredTheme, () => "light");
   const mounted = useSyncExternalStore(subscribeToHydration, () => true, () => false);
 
   useEffect(() => {

--- a/src/lib/__tests__/grading.test.ts
+++ b/src/lib/__tests__/grading.test.ts
@@ -16,12 +16,12 @@ describe("gradeQuiz", () => {
 });
 
 describe("isLessonComplete", () => {
-  it("requires both video completion and passing quiz score", () => {
+  it("requires both content completion and passing quiz score", () => {
     expect(
-      isLessonComplete({ videoCompleted: true, bestScore: 80, passingScore: 80 }),
+      isLessonComplete({ contentCompleted: true, bestScore: 80, passingScore: 80 }),
     ).toBe(true);
     expect(
-      isLessonComplete({ videoCompleted: false, bestScore: 100, passingScore: 80 }),
+      isLessonComplete({ contentCompleted: false, bestScore: 100, passingScore: 80 }),
     ).toBe(false);
   });
 });

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -159,7 +159,8 @@ export async function isDioceseAdmin(clerkUserId?: string) {
   const userId = clerkUserId ?? (await requireAuth());
 
   if (isE2ESmokeMode()) {
-    return true;
+    const store = await cookies();
+    return store.get("e2e_diocese_admin")?.value === "1";
   }
 
   const supabase = getSupabaseAdminClient();

--- a/src/lib/e2e-fixtures.ts
+++ b/src/lib/e2e-fixtures.ts
@@ -33,7 +33,12 @@ export const E2E_MODULE = {
 export const E2E_LESSON = {
   id: "44444444-4444-4444-8444-444444444444",
   title: "Welcome Lesson",
+  descriptor: "Orientation lesson for smoke tests.",
+  content_type: "VIDEO" as const,
   youtube_video_id: "dQw4w9WgXcQ",
+  document_url: null,
+  document_page_start: null,
+  document_page_end: null,
   passing_score: 80,
   module_id: E2E_MODULE.id,
 };

--- a/src/lib/grading.ts
+++ b/src/lib/grading.ts
@@ -15,9 +15,9 @@ export function gradeQuiz(
 }
 
 export function isLessonComplete(params: {
-  videoCompleted: boolean;
+  contentCompleted: boolean;
   bestScore: number;
   passingScore: number;
 }) {
-  return params.videoCompleted && params.bestScore >= params.passingScore;
+  return params.contentCompleted && params.bestScore >= params.passingScore;
 }

--- a/src/lib/r2.ts
+++ b/src/lib/r2.ts
@@ -1,0 +1,105 @@
+import { randomUUID } from "node:crypto";
+
+import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+
+const DEFAULT_MAX_DOCUMENT_BYTES = 25 * 1024 * 1024;
+
+let r2Client: S3Client | null = null;
+
+function getRequiredEnv(name: string) {
+  const value = process.env[name]?.trim();
+
+  if (!value) {
+    throw new Error(`${name} is required for R2 uploads.`);
+  }
+
+  return value;
+}
+
+function getForcePathStyle() {
+  return process.env.R2_FORCE_PATH_STYLE === "true";
+}
+
+function getR2Client() {
+  if (r2Client) {
+    return r2Client;
+  }
+
+  r2Client = new S3Client({
+    region: process.env.R2_REGION?.trim() || "auto",
+    endpoint: getRequiredEnv("R2_ENDPOINT"),
+    forcePathStyle: getForcePathStyle(),
+    credentials: {
+      accessKeyId: getRequiredEnv("R2_ACCESS_KEY_ID"),
+      secretAccessKey: getRequiredEnv("R2_SECRET_ACCESS_KEY"),
+    },
+  });
+
+  return r2Client;
+}
+
+function sanitizeFileBaseName(fileName: string) {
+  const withoutExtension = fileName.replace(/\.pdf$/i, "");
+  const normalized = withoutExtension
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 80);
+
+  return normalized || "document";
+}
+
+function buildObjectKey(fileName: string) {
+  const now = new Date();
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const safeBaseName = sanitizeFileBaseName(fileName);
+
+  return `documents/${year}/${month}/${randomUUID()}-${safeBaseName}.pdf`;
+}
+
+function buildPublicUrl(key: string) {
+  const baseUrl = getRequiredEnv("R2_PUBLIC_BASE_URL").replace(/\/+$/, "");
+  const encodedKey = key.split("/").map(encodeURIComponent).join("/");
+
+  return `${baseUrl}/${encodedKey}`;
+}
+
+export function getDocumentUploadMaxBytes() {
+  const rawValue = process.env.UPLOAD_MAX_DOCUMENT_BYTES?.trim();
+  const parsed = Number.parseInt(rawValue ?? "", 10);
+
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_MAX_DOCUMENT_BYTES;
+  }
+
+  return parsed;
+}
+
+export async function uploadDocumentToR2({
+  body,
+  contentType,
+  fileName,
+}: {
+  body: Buffer;
+  contentType: string;
+  fileName: string;
+}) {
+  const bucket = getRequiredEnv("R2_BUCKET");
+  const key = buildObjectKey(fileName);
+
+  await getR2Client().send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+      ContentDisposition: "inline",
+    }),
+  );
+
+  return {
+    key,
+    url: buildPublicUrl(key),
+  };
+}

--- a/src/lib/repositories/diocese-admin.ts
+++ b/src/lib/repositories/diocese-admin.ts
@@ -62,7 +62,11 @@ export interface DioceseLessonRow {
   title: string;
   descriptor: string | null;
   thumbnail_url: string | null;
-  youtube_video_id: string;
+  content_type: "VIDEO" | "DOCUMENT";
+  youtube_video_id: string | null;
+  document_url: string | null;
+  document_page_start: number | null;
+  document_page_end: number | null;
   sort_order: number;
   passing_score: number;
   questions: DioceseQuestionRow[];
@@ -290,7 +294,7 @@ export async function getCourseContentForAdmin(courseId: string) {
   const { data: modules, error: modulesError } = await supabase
     .from("modules")
     .select(
-      "id,course_id,title,descriptor,thumbnail_url,sort_order, lessons(id,module_id,title,descriptor,thumbnail_url,youtube_video_id,sort_order,passing_score, questions(id,lesson_id,prompt,options,correct_option_index,sort_order))",
+      "id,course_id,title,descriptor,thumbnail_url,sort_order, lessons(id,module_id,title,descriptor,thumbnail_url,content_type,youtube_video_id,document_url,document_page_start,document_page_end,sort_order,passing_score, questions(id,lesson_id,prompt,options,correct_option_index,sort_order))",
     )
     .eq("course_id", courseId)
     .order("sort_order", { ascending: true });

--- a/src/lib/repositories/lessons.ts
+++ b/src/lib/repositories/lessons.ts
@@ -12,7 +12,12 @@ interface LessonQuestion {
 export interface LessonWithQuestions {
   id: string;
   title: string;
-  youtube_video_id: string;
+  descriptor: string | null;
+  content_type: "VIDEO" | "DOCUMENT";
+  youtube_video_id: string | null;
+  document_url: string | null;
+  document_page_start: number | null;
+  document_page_end: number | null;
   passing_score: number;
   module_id: string;
   questions: LessonQuestion[];
@@ -38,7 +43,7 @@ export async function getLessonWithQuestions(
   const { data, error } = await supabase
     .from("lessons")
     .select(
-      "id,title,youtube_video_id,passing_score,module_id, questions(id,prompt,options,sort_order)",
+      "id,title,descriptor,content_type,youtube_video_id,document_url,document_page_start,document_page_end,passing_score,module_id, questions(id,prompt,options,sort_order)",
     )
     .eq("id", lessonId)
     .order("sort_order", { referencedTable: "questions", ascending: true })
@@ -48,7 +53,7 @@ export async function getLessonWithQuestions(
   return (data as LessonWithQuestions | null) ?? null;
 }
 
-export async function getVideoProgress(
+export async function getLessonProgress(
   lessonId: string,
   parishId: string,
   clerkUserId: string,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,7 @@
 export type ParishRole = "parish_admin" | "instructor" | "student";
 
 export type CourseScope = "DIOCESE" | "PARISH";
+export type LessonContentType = "VIDEO" | "DOCUMENT";
 
 export interface Parish {
   id: string;
@@ -21,7 +22,11 @@ export interface Lesson {
   title: string;
   descriptor: string | null;
   thumbnail_url: string | null;
-  youtube_video_id: string;
+  content_type: LessonContentType;
+  youtube_video_id: string | null;
+  document_url: string | null;
+  document_page_start: number | null;
+  document_page_end: number | null;
   passing_score: number;
   module_id: string;
 }

--- a/supabase/migrations/0009_document_lessons.sql
+++ b/supabase/migrations/0009_document_lessons.sql
@@ -1,0 +1,54 @@
+alter table lessons
+  alter column youtube_video_id drop not null;
+
+alter table lessons
+  add column if not exists content_type text not null default 'VIDEO',
+  add column if not exists document_url text,
+  add column if not exists document_page_start int,
+  add column if not exists document_page_end int;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'lessons_content_type_check'
+  ) then
+    alter table lessons
+      add constraint lessons_content_type_check
+      check (content_type in ('VIDEO', 'DOCUMENT'));
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'lessons_content_source_check'
+  ) then
+    alter table lessons
+      add constraint lessons_content_source_check
+      check (
+        (content_type = 'VIDEO' and youtube_video_id is not null and document_url is null)
+        or (content_type = 'DOCUMENT' and document_url is not null)
+      );
+  end if;
+end $$;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'lessons_document_page_range_check'
+  ) then
+    alter table lessons
+      add constraint lessons_document_page_range_check
+      check (
+        document_page_start is null
+        or document_page_end is null
+        or document_page_end >= document_page_start
+      );
+  end if;
+end $$;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -27,8 +33,10 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts",
-    "**/*.mts"
+    "**/*.mts",
+    ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- add dual-mode lessons so courses can use video or document content
- add Cloudflare R2-backed PDF upload support for document lessons in the admin builder
- update learner/admin flows, smoke-mode behavior, and tests for the new document lesson path

## Affected areas
- admin lesson and course content management
- learner lesson rendering and completion flow
- Supabase migration for document lesson fields
- R2 upload route and admin upload UI

## Verification
- npm run typecheck
- npx vitest run 'src/app/api/admin/uploads/documents/__tests__/route.test.ts' 'src/components/__tests__/document-upload-field.test.tsx' 'src/app/api/admin/modules/[moduleId]/lessons/__tests__/route.test.ts' 'src/app/api/admin/lessons/[lessonId]/__tests__/route.test.ts'
- earlier on this branch: npm run build, npm run test:coverage, npm run test:e2e, remote npm run db:push