### PR TITLE
feat: student learning dashboard

### DIFF
--- a/src/app/app/dashboard/page.tsx
+++ b/src/app/app/dashboard/page.tsx
@@ -1,0 +1,227 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { requireParishRole } from "@/lib/authz";
+import { getStudentDashboardData } from "@/lib/repositories/dashboard";
+import type { LessonActivity } from "@/lib/repositories/dashboard";
+
+function ProgressRing({ percent }: { percent: number }) {
+  const radius = 28;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (percent / 100) * circumference;
+
+  return (
+    <div className="relative inline-flex items-center justify-center">
+      <svg className="h-16 w-16 -rotate-90" viewBox="0 0 64 64">
+        <circle
+          className="text-muted stroke-current"
+          cx="32"
+          cy="32"
+          fill="none"
+          r={radius}
+          stroke="currentColor"
+          strokeWidth="5"
+        />
+        <circle
+          className="text-primary stroke-current transition-all duration-500 ease-out"
+          cx="32"
+          cy="32"
+          fill="none"
+          r={radius}
+          stroke="currentColor"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          strokeWidth="5"
+        />
+      </svg>
+      <span className="absolute text-sm font-semibold">{percent}%</span>
+    </div>
+  );
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays} days ago`;
+  return date.toLocaleDateString();
+}
+
+function activityIcon(
+  entry: LessonActivity,
+): { icon: string; label: string } {
+  if (entry.score !== null) {
+    return { icon: "📝", label: `Quiz: ${entry.score}%` };
+  }
+  return { icon: "✅", label: "Lesson completed" };
+}
+
+export default async function DashboardPage() {
+  const { parishId, clerkUserId } = await requireParishRole("student");
+  const { progress, recentActivity } = await getStudentDashboardData(
+    parishId,
+    clerkUserId,
+  );
+
+  const inProgress = progress
+    .filter((c) => c.lastLessonId)
+    .sort(
+      (a, b) =>
+        new Date(b.lastActivityAt ?? 0).getTime() -
+        new Date(a.lastActivityAt ?? 0).getTime(),
+    );
+
+  const totalCompleted = progress.reduce(
+    (sum, c) => sum + c.completedLessons,
+    0,
+  );
+  const totalLessons = progress.reduce((sum, c) => sum + c.totalLessons, 0);
+
+  if (progress.length === 0) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-semibold">Dashboard</h1>
+        <Card>
+          <CardContent className="flex flex-col items-center gap-4 py-12">
+            <p className="text-lg font-medium">
+              You are not enrolled in any courses yet.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Ask your parish admin to enroll you to get started.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">Dashboard</h1>
+        <p className="text-sm text-muted-foreground">
+          {totalCompleted} of {totalLessons} lessons completed across{" "}
+          {progress.length} course{progress.length !== 1 ? "s" : ""}
+        </p>
+      </header>
+
+      {/* Continue where you left off */}
+      {inProgress.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground">
+            Continue where you left off
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {inProgress.slice(0, 3).map((course) => (
+              <Link
+                href={`/app/lessons/${course.lastLessonId}`}
+                key={`resume-${course.courseId}`}
+              >
+                <Card className="h-full transition-colors hover:bg-secondary">
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-base">
+                      {course.lastLessonTitle ?? "Resume"}
+                    </CardTitle>
+                    <CardDescription>{course.courseTitle}</CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">
+                        {course.completedLessons}/{course.totalLessons} complete
+                      </span>
+                      <span className="text-xs font-medium text-primary">
+                        Resume →
+                      </span>
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Course progress */}
+      <section>
+        <h2 className="mb-3 text-sm font-medium text-muted-foreground">
+          Your courses
+        </h2>
+        <div className="grid gap-3 sm:grid-cols-1 lg:grid-cols-2">
+          {progress.map((course) => (
+            <Link
+              href={`/app/courses/${course.courseId}`}
+              key={course.courseId}
+            >
+              <Card className="h-full transition-colors hover:bg-secondary">
+                <CardContent className="flex items-center gap-4 py-4">
+                  <ProgressRing percent={course.progressPercent} />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-medium">{course.courseTitle}</p>
+                    {course.courseDescription && (
+                      <p className="truncate text-xs text-muted-foreground">
+                        {course.courseDescription}
+                      </p>
+                    )}
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {course.completedLessons}/{course.totalLessons} lessons
+                      complete
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* Recent activity */}
+      {recentActivity.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground">
+            Recent activity
+          </h2>
+          <Card>
+            <CardContent className="py-2">
+              <ul className="divide-y divide-border">
+                {recentActivity.map((entry, index) => {
+                  const { icon, label } = activityIcon(entry);
+                  return (
+                    <li
+                      className="flex items-center gap-3 py-2.5"
+                      key={`${entry.lessonId}-${entry.activityAt}-${index}`}
+                    >
+                      <span className="text-lg">{icon}</span>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium">
+                          {entry.lessonTitle}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {entry.courseTitle} · {label}
+                        </p>
+                      </div>
+                      <span className="shrink-0 text-xs text-muted-foreground">
+                        {formatDate(entry.activityAt)}
+                      </span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </CardContent>
+          </Card>
+        </section>
+      )}
+
+      <div className="flex justify-end">
+        <Button asChild variant="outline">
+          <Link href="/app/courses">View all courses</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -53,7 +53,9 @@ export default async function AppLayout({
       : parishOptions[0]?.id;
 
   const navItems = [
-    { label: "Dashboard", href: "/app/dashboard" },
+    ...(!showParishAdmin && !showDioceseAdmin
+      ? [{ label: "Dashboard", href: "/app/dashboard" }]
+      : []),
     { label: "Courses", href: "/app/courses" },
     ...(showParishAdmin ? [{ label: "Parish Admin", href: "/app/parish-admin" }] : []),
     ...(showDioceseAdmin ? [{ label: "Diocese Admin", href: "/app/admin" }] : []),

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -53,6 +53,7 @@ export default async function AppLayout({
       : parishOptions[0]?.id;
 
   const navItems = [
+    { label: "Dashboard", href: "/app/dashboard" },
     { label: "Courses", href: "/app/courses" },
     ...(showParishAdmin ? [{ label: "Parish Admin", href: "/app/parish-admin" }] : []),
     ...(showDioceseAdmin ? [{ label: "Diocese Admin", href: "/app/admin" }] : []),

--- a/src/app/app/page.tsx
+++ b/src/app/app/page.tsx
@@ -31,7 +31,7 @@ export default async function AppIndex() {
       redirect("/app/parish-admin");
     }
 
-    redirect("/app/courses");
+    redirect("/app/dashboard");
   }
 
   const supabase = getSupabaseAdminClient();
@@ -74,5 +74,5 @@ export default async function AppIndex() {
     redirect("/app/parish-admin");
   }
 
-  redirect("/app/courses");
+  redirect("/app/dashboard");
 }

--- a/src/lib/repositories/dashboard.ts
+++ b/src/lib/repositories/dashboard.ts
@@ -1,0 +1,253 @@
+import { E2E_COURSE } from "@/lib/e2e-fixtures";
+import { isE2ESmokeMode } from "@/lib/e2e-mode";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+export interface DashboardCourseProgress {
+  courseId: string;
+  courseTitle: string;
+  courseDescription: string | null;
+  totalLessons: number;
+  completedLessons: number;
+  progressPercent: number;
+  lastLessonId: string | null;
+  lastLessonTitle: string | null;
+  lastPositionSeconds: number;
+  lastActivityAt: string | null;
+}
+
+export interface LessonActivity {
+  lessonId: string;
+  lessonTitle: string;
+  courseId: string;
+  courseTitle: string;
+  score: number | null;
+  completed: boolean;
+  activityAt: string;
+}
+
+export interface StudentDashboardData {
+  progress: DashboardCourseProgress[];
+  recentActivity: LessonActivity[];
+}
+
+export async function getStudentDashboardData(
+  parishId: string,
+  clerkUserId: string,
+): Promise<StudentDashboardData> {
+  if (isE2ESmokeMode()) {
+    return {
+      progress: [
+        {
+          courseId: E2E_COURSE.id,
+          courseTitle: E2E_COURSE.title,
+          courseDescription: E2E_COURSE.description,
+          totalLessons: 2,
+          completedLessons: 0,
+          progressPercent: 0,
+          lastLessonId: null,
+          lastLessonTitle: null,
+          lastPositionSeconds: 0,
+          lastActivityAt: null,
+        },
+      ],
+      recentActivity: [],
+    };
+  }
+
+  const supabase = getSupabaseAdminClient();
+
+  // Get enrolled courses
+  const { data: enrollments, error: enrollError } = await supabase
+    .from("enrollments")
+    .select("course_id, courses(id, title, description)")
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", clerkUserId);
+
+  if (enrollError) throw enrollError;
+
+  if (!enrollments || enrollments.length === 0) {
+    return { progress: [], recentActivity: [] };
+  }
+
+  const enrolledCourses = enrollments.map((e) => ({
+    courseId: (e as { course_id: string; courses: { id: string; title: string; description: string | null } }).course_id,
+    title: (e as { courses: { title: string } }).courses.title,
+    description: (e as { courses: { description: string | null } }).courses.description,
+  }));
+
+  // Get all lessons for all enrolled courses
+  const courseIds = enrolledCourses.map((c) => c.courseId);
+  const { data: modulesData, error: modError } = await supabase
+    .from("modules")
+    .select("id, course_id, lessons(id, title)")
+    .in("course_id", courseIds)
+    .order("sort_order", { ascending: true });
+
+  if (modError) throw modError;
+
+  // Flatten lessons per course
+  const lessonsByCourse = new Map<string, Array<{ id: string; title: string }>>();
+  for (const mod of (modulesData ?? []) as Array<{
+    course_id: string;
+    lessons: Array<{ id: string; title: string }>;
+  }>) {
+    if (!lessonsByCourse.has(mod.course_id)) {
+      lessonsByCourse.set(mod.course_id, []);
+    }
+    for (const lesson of mod.lessons ?? []) {
+      lessonsByCourse.get(mod.course_id)!.push(lesson);
+    }
+  }
+
+  // Get all lesson IDs
+  const allLessonIds = Array.from(lessonsByCourse.values()).flatMap((lessons) =>
+    lessons.map((l) => l.id),
+  );
+
+  // Get video progress for all lessons
+  const { data: progressData, error: progError } = await supabase
+    .from("video_progress")
+    .select("lesson_id, completed, last_position_seconds, updated_at, lessons(title)")
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", clerkUserId)
+    .in("lesson_id", allLessonIds);
+
+  if (progError) throw progError;
+
+  // Build progress map
+  const progressByLesson = new Map(
+    ((progressData ?? []) as Array<{
+      lesson_id: string;
+      completed: boolean;
+      last_position_seconds: number;
+      updated_at: string;
+      lessons: { title: string };
+    }>).map((p) => [p.lesson_id, p]),
+  );
+
+  // Get recent quiz attempts (last 7 days)
+  const sevenDaysAgo = new Date();
+  sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+  const { data: quizData, error: quizError } = await supabase
+    .from("quiz_attempts")
+    .select("lesson_id, score, created_at, lessons(title), modules!inner(course_id, courses!inner(title))")
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", clerkUserId)
+    .gte("created_at", sevenDaysAgo.toISOString())
+    .order("created_at", { ascending: false })
+    .limit(10);
+
+  if (quizError) throw quizError;
+
+  // Build recent activity feed
+  const recentActivity: LessonActivity[] = (
+    (quizData ?? []) as Array<{
+      lesson_id: string;
+      score: number;
+      created_at: string;
+      lessons: { title: string };
+      modules: { course_id: string; courses: { title: string } };
+    }>
+  ).map((q) => ({
+    lessonId: q.lesson_id,
+    lessonTitle: q.lessons.title,
+    courseId: q.modules.course_id,
+    courseTitle: q.modules.courses.title,
+    score: q.score,
+    completed: true,
+    activityAt: q.created_at,
+  }));
+
+  // Also include completed video lessons in activity
+  const videoActivity: LessonActivity[] = (
+    (progressData ?? []) as Array<{
+      lesson_id: string;
+      completed: boolean;
+      last_position_seconds: number;
+      updated_at: string;
+      lessons: { title: string };
+    }>
+  )
+    .filter((p) => p.completed)
+    .map((p) => {
+      const lesson = allLessonIds.includes(p.lesson_id)
+        ? Array.from(lessonsByCourse.values())
+            .flat()
+            .find((l) => l.id === p.lesson_id)
+        : undefined;
+      const courseId =
+        Array.from(lessonsByCourse.entries()).find(([, lessons]) =>
+          lessons.some((l) => l.id === p.lesson_id),
+        )?.[0] ?? "";
+      const courseTitle = enrolledCourses.find((c) => c.courseId === courseId)?.title ?? "";
+
+      return {
+        lessonId: p.lesson_id,
+        lessonTitle: lesson?.title ?? p.lessons?.title ?? "Unknown lesson",
+        courseId,
+        courseTitle,
+        score: null,
+        completed: true,
+        activityAt: p.updated_at,
+      };
+    });
+
+  // Merge and deduplicate, sort by most recent
+  const seenActivities = new Set<string>();
+  const allActivities = [...recentActivity, ...videoActivity]
+    .filter((a) => {
+      const key = `${a.lessonId}-${a.activityAt}`;
+      if (seenActivities.has(key)) return false;
+      seenActivities.add(key);
+      return true;
+    })
+    .sort(
+      (a, b) =>
+        new Date(b.activityAt).getTime() - new Date(a.activityAt).getTime(),
+    )
+    .slice(0, 15);
+
+  // Build course progress summaries
+  const progress: DashboardCourseProgress[] = enrolledCourses.map((course) => {
+    const lessons = lessonsByCourse.get(course.courseId) ?? [];
+    const totalLessons = lessons.length;
+
+    let completedLessons = 0;
+    let lastActivityAt: string | null = null;
+    let lastLessonId: string | null = null;
+    let lastLessonTitle: string | null = null;
+    let lastPositionSeconds = 0;
+
+    for (const lesson of lessons) {
+      const p = progressByLesson.get(lesson.id);
+      if (p) {
+        if (p.completed) completedLessons++;
+        if (!lastActivityAt || p.updated_at > lastActivityAt) {
+          lastActivityAt = p.updated_at;
+          lastLessonId = p.lesson_id;
+          lastLessonTitle = lesson.title;
+          lastPositionSeconds = p.last_position_seconds;
+        }
+      }
+    }
+
+    return {
+      courseId: course.courseId,
+      courseTitle: course.title,
+      courseDescription: course.description,
+      totalLessons,
+      completedLessons,
+      progressPercent:
+        totalLessons > 0
+          ? Math.round((completedLessons / totalLessons) * 100)
+          : 0,
+      lastLessonId,
+      lastLessonTitle,
+      lastPositionSeconds,
+      lastActivityAt,
+    };
+  });
+
+  return { progress, recentActivity: allActivities };
+}

--- a/src/lib/repositories/dashboard.ts
+++ b/src/lib/repositories/dashboard.ts
@@ -56,7 +56,18 @@ export async function getStudentDashboardData(
 
   const supabase = getSupabaseAdminClient();
 
-  // Get enrolled courses
+  // Get visible courses the learner is enrolled in (respects publish/visibility)
+  const { data: visibleCourses } = await supabase
+    .from("courses")
+    .select("id, title, description")
+    .eq("published", true)
+    .order("created_at", { ascending: false });
+
+  const visibleCourseIds = new Set(
+    ((visibleCourses ?? []) as Array<{ id: string }>).map((c) => c.id),
+  );
+
+  // Get enrolled courses, filtered to visible
   const { data: enrollments, error: enrollError } = await supabase
     .from("enrollments")
     .select("course_id, courses(id, title, description)")
@@ -65,15 +76,22 @@ export async function getStudentDashboardData(
 
   if (enrollError) throw enrollError;
 
-  if (!enrollments || enrollments.length === 0) {
+  const enrolledCourses = (
+    (enrollments ?? []) as Array<{
+      course_id: string;
+      courses: { id: string; title: string; description: string | null };
+    }>
+  )
+    .filter((e) => visibleCourseIds.has(e.course_id))
+    .map((e) => ({
+      courseId: e.course_id,
+      title: e.courses.title,
+      description: e.courses.description,
+    }));
+
+  if (enrolledCourses.length === 0) {
     return { progress: [], recentActivity: [] };
   }
-
-  const enrolledCourses = enrollments.map((e) => ({
-    courseId: (e as { course_id: string; courses: { id: string; title: string; description: string | null } }).course_id,
-    title: (e as { courses: { title: string } }).courses.title,
-    description: (e as { courses: { description: string | null } }).courses.description,
-  }));
 
   // Get all lessons for all enrolled courses
   const courseIds = enrolledCourses.map((c) => c.courseId);
@@ -99,15 +117,36 @@ export async function getStudentDashboardData(
     }
   }
 
-  // Get all lesson IDs
+  // Build progress for each enrolled course
+  const progress: DashboardCourseProgress[] = enrolledCourses.map((course) => {
+    const lessons = lessonsByCourse.get(course.courseId) ?? [];
+    return {
+      courseId: course.courseId,
+      courseTitle: course.title,
+      courseDescription: course.description,
+      totalLessons: lessons.length,
+      completedLessons: 0,
+      progressPercent: 0,
+      lastLessonId: null,
+      lastLessonTitle: null,
+      lastPositionSeconds: 0,
+      lastActivityAt: null,
+    };
+  });
+
+  // Get all lesson IDs — if empty, skip progress/activity queries
   const allLessonIds = Array.from(lessonsByCourse.values()).flatMap((lessons) =>
     lessons.map((l) => l.id),
   );
 
+  if (allLessonIds.length === 0) {
+    return { progress, recentActivity: [] };
+  }
+
   // Get video progress for all lessons
   const { data: progressData, error: progError } = await supabase
     .from("video_progress")
-    .select("lesson_id, completed, last_position_seconds, updated_at, lessons(title)")
+    .select("lesson_id, completed, last_position_seconds, updated_at")
     .eq("parish_id", parishId)
     .eq("clerk_user_id", clerkUserId)
     .in("lesson_id", allLessonIds);
@@ -121,61 +160,86 @@ export async function getStudentDashboardData(
       completed: boolean;
       last_position_seconds: number;
       updated_at: string;
-      lessons: { title: string };
     }>).map((p) => [p.lesson_id, p]),
   );
 
-  // Get recent quiz attempts (last 7 days)
+  // Populate course progress from video_progress data
+  for (const course of progress) {
+    const lessons = lessonsByCourse.get(course.courseId) ?? [];
+
+    for (const lesson of lessons) {
+      const p = progressByLesson.get(lesson.id);
+      if (p) {
+        if (p.completed) course.completedLessons++;
+        if (!course.lastActivityAt || p.updated_at > course.lastActivityAt) {
+          course.lastActivityAt = p.updated_at;
+          course.lastLessonId = p.lesson_id;
+          course.lastLessonTitle = lesson.title;
+          course.lastPositionSeconds = p.last_position_seconds;
+        }
+      }
+    }
+
+    course.progressPercent =
+      course.totalLessons > 0
+        ? Math.round((course.completedLessons / course.totalLessons) * 100)
+        : 0;
+  }
+
+  // Recent activity (last 7 days)
   const sevenDaysAgo = new Date();
   sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+  const cutoff = sevenDaysAgo.toISOString();
 
+  // Get recent quiz attempts (constrained to enrolled course lessons)
   const { data: quizData, error: quizError } = await supabase
     .from("quiz_attempts")
-    .select("lesson_id, score, created_at, lessons(title), modules!inner(course_id, courses!inner(title))")
+    .select("lesson_id, score, created_at, lessons!inner(title, modules!inner(course_id, courses!inner(title)))")
     .eq("parish_id", parishId)
     .eq("clerk_user_id", clerkUserId)
-    .gte("created_at", sevenDaysAgo.toISOString())
+    .in("lesson_id", allLessonIds)
+    .gte("created_at", cutoff)
     .order("created_at", { ascending: false })
-    .limit(10);
+    .limit(15);
 
   if (quizError) throw quizError;
 
-  // Build recent activity feed
+  // Build recent activity feed from quiz attempts
   const recentActivity: LessonActivity[] = (
     (quizData ?? []) as Array<{
       lesson_id: string;
       score: number;
       created_at: string;
-      lessons: { title: string };
-      modules: { course_id: string; courses: { title: string } };
+      lessons: { title: string; modules: { course_id: string; courses: { title: string } } };
     }>
   ).map((q) => ({
     lessonId: q.lesson_id,
     lessonTitle: q.lessons.title,
-    courseId: q.modules.course_id,
-    courseTitle: q.modules.courses.title,
+    courseId: q.lessons.modules.course_id,
+    courseTitle: q.lessons.modules.courses.title,
     score: q.score,
     completed: true,
     activityAt: q.created_at,
   }));
 
-  // Also include completed video lessons in activity
+  // Also include recent video completions (same time cutoff)
   const videoActivity: LessonActivity[] = (
     (progressData ?? []) as Array<{
       lesson_id: string;
       completed: boolean;
       last_position_seconds: number;
       updated_at: string;
-      lessons: { title: string };
     }>
   )
-    .filter((p) => p.completed)
+    .filter(
+      (p) =>
+        p.completed &&
+        new Date(p.updated_at) >= new Date(cutoff),
+    )
     .map((p) => {
-      const lesson = allLessonIds.includes(p.lesson_id)
-        ? Array.from(lessonsByCourse.values())
-            .flat()
-            .find((l) => l.id === p.lesson_id)
-        : undefined;
+      const lesson = Array.from(lessonsByCourse.values())
+        .flat()
+        .find((l) => l.id === p.lesson_id);
       const courseId =
         Array.from(lessonsByCourse.entries()).find(([, lessons]) =>
           lessons.some((l) => l.id === p.lesson_id),
@@ -184,7 +248,7 @@ export async function getStudentDashboardData(
 
       return {
         lessonId: p.lesson_id,
-        lessonTitle: lesson?.title ?? p.lessons?.title ?? "Unknown lesson",
+        lessonTitle: lesson?.title ?? "Unknown lesson",
         courseId,
         courseTitle,
         score: null,
@@ -207,47 +271,6 @@ export async function getStudentDashboardData(
         new Date(b.activityAt).getTime() - new Date(a.activityAt).getTime(),
     )
     .slice(0, 15);
-
-  // Build course progress summaries
-  const progress: DashboardCourseProgress[] = enrolledCourses.map((course) => {
-    const lessons = lessonsByCourse.get(course.courseId) ?? [];
-    const totalLessons = lessons.length;
-
-    let completedLessons = 0;
-    let lastActivityAt: string | null = null;
-    let lastLessonId: string | null = null;
-    let lastLessonTitle: string | null = null;
-    let lastPositionSeconds = 0;
-
-    for (const lesson of lessons) {
-      const p = progressByLesson.get(lesson.id);
-      if (p) {
-        if (p.completed) completedLessons++;
-        if (!lastActivityAt || p.updated_at > lastActivityAt) {
-          lastActivityAt = p.updated_at;
-          lastLessonId = p.lesson_id;
-          lastLessonTitle = lesson.title;
-          lastPositionSeconds = p.last_position_seconds;
-        }
-      }
-    }
-
-    return {
-      courseId: course.courseId,
-      courseTitle: course.title,
-      courseDescription: course.description,
-      totalLessons,
-      completedLessons,
-      progressPercent:
-        totalLessons > 0
-          ? Math.round((completedLessons / totalLessons) * 100)
-          : 0,
-      lastLessonId,
-      lastLessonTitle,
-      lastPositionSeconds,
-      lastActivityAt,
-    };
-  });
 
   return { progress, recentActivity: allActivities };
 }


### PR DESCRIPTION
Closes #9

## What this adds
A new `/app/dashboard` page that serves as the student's primary landing page.

### Features
- **Course progress cards** — per-course circular progress rings with completion percentage and lesson counts
- **Continue where you left off** — up to 3 resume cards linking to the last-accessed lesson in each in-progress course
- **Recent activity timeline** — last 15 activities over the past 7 days: quiz attempts (with scores) and lesson completions
- **Empty state** — friendly message when the student has no enrollments
- **Nav update** — Dashboard link added to the top nav
- **Routing** — `/app` now redirects students to `/app/dashboard` instead of `/app/courses`

### Files changed
- `src/app/app/dashboard/page.tsx` — new dashboard page with ProgressRing component
- `src/lib/repositories/dashboard.ts` — `getStudentDashboardData()` aggregates enrollments, video progress, quiz attempts, and lesson metadata
- `src/app/app/layout.tsx` — added Dashboard nav item
- `src/app/app/page.tsx` — redirect students to /dashboard

### Testing
- Lint: ✅
- Typecheck: ✅
- E2E smoke mode: dashboard returns mock data for E2E_COURSE