### PR TITLE
feat: course discovery catalog

### DIFF
--- a/src/app/app/catalog/page.tsx
+++ b/src/app/app/catalog/page.tsx
@@ -1,0 +1,148 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { requireParishRole } from "@/lib/authz";
+import { getCatalogCourses } from "@/lib/repositories/catalog";
+import type { CatalogCourse } from "@/lib/repositories/catalog";
+
+function CourseCard({ course }: { course: CatalogCourse }) {
+  return (
+    <Card className="flex h-full flex-col transition-colors hover:bg-secondary/50">
+      <CardHeader className="pb-2">
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-base">{course.title}</CardTitle>
+          <span
+            className={[
+              "shrink-0 rounded-full px-2 py-0.5 text-xs font-medium",
+              course.scope === "DIOCESE"
+                ? "bg-primary/10 text-primary"
+                : "bg-secondary text-secondary-foreground",
+            ].join(" ")}
+          >
+            {course.scope === "DIOCESE" ? "Diocese-wide" : "Parish"}
+          </span>
+        </div>
+        {course.description && (
+          <CardDescription className="line-clamp-2">
+            {course.description}
+          </CardDescription>
+        )}
+      </CardHeader>
+      <CardContent className="mt-auto space-y-3 pt-0">
+        <p className="text-xs text-muted-foreground">
+          {course.lessonCount} lesson{course.lessonCount !== 1 ? "s" : ""}
+        </p>
+        {course.enrolled ? (
+          <Button asChild className="w-full" variant="outline">
+            <Link href={`/app/courses/${course.id}`}>Go to course</Link>
+          </Button>
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            Ask your parish admin to enroll you.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default async function CatalogPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ q?: string }>;
+}) {
+  const { parishId, clerkUserId } = await requireParishRole("student");
+  const allCourses = await getCatalogCourses(parishId, clerkUserId);
+  const params = (await searchParams) ?? {};
+  const query = params.q?.trim() ?? "";
+
+  const filtered =
+    query.length > 0
+      ? allCourses.filter(
+          (c) =>
+            c.title.toLowerCase().includes(query.toLowerCase()) ||
+            (c.description?.toLowerCase().includes(query.toLowerCase()) ?? false),
+        )
+      : allCourses;
+
+  const filteredEnrolled = filtered.filter((c) => c.enrolled);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">Course Catalog</h1>
+        <p className="text-sm text-muted-foreground">
+          Browse available courses and track your enrolled ones.
+        </p>
+      </header>
+
+      {/* Search */}
+      <form className="flex gap-2">
+        <Input
+          className="max-w-sm"
+          defaultValue={query}
+          name="q"
+          placeholder="Search courses..."
+          type="search"
+        />
+        <Button type="submit" variant="secondary">
+          Search
+        </Button>
+        {query && (
+          <Button asChild type="button" variant="ghost">
+            <Link href="/app/catalog">Clear</Link>
+          </Button>
+        )}
+      </form>
+
+      {/* Enrolled courses */}
+      {filteredEnrolled.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground">
+            My enrolled courses
+          </h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {filteredEnrolled.map((course) => (
+              <CourseCard course={course} key={course.id} />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Full catalog */}
+      <section>
+        <h2 className="mb-3 text-sm font-medium text-muted-foreground">
+          {query ? `Results for "${query}"` : "All available courses"}
+        </h2>
+
+        {filtered.length === 0 ? (
+          <Card>
+            <CardContent className="py-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                {allCourses.length === 0
+                  ? "No courses are available in the catalog yet."
+                  : "No courses match your search."}
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {filtered
+              .filter((c) => !c.enrolled)
+              .map((course) => (
+                <CourseCard course={course} key={course.id} />
+              ))}
+          </div>
+        )}
+      </section>
+
+      <div className="flex justify-end gap-2">
+        <Button asChild variant="outline">
+          <Link href="/app/dashboard">Back to dashboard</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/catalog/page.tsx
+++ b/src/app/app/catalog/page.tsx
@@ -51,23 +51,35 @@ function CourseCard({ course }: { course: CatalogCourse }) {
 export default async function CatalogPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ q?: string }>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { parishId, clerkUserId } = await requireParishRole("student");
   const allCourses = await getCatalogCourses(parishId, clerkUserId);
   const params = (await searchParams) ?? {};
-  const query = params.q?.trim() ?? "";
 
-  const filtered =
+  const rawQ = params.q;
+  const query = Array.isArray(rawQ) ? rawQ[0] : (rawQ?.trim() ?? "");
+
+  const enrolled = allCourses.filter((c) => c.enrolled);
+  const unenrolled = allCourses.filter((c) => !c.enrolled);
+
+  const filteredEnrolled =
     query.length > 0
-      ? allCourses.filter(
+      ? enrolled.filter(
           (c) =>
             c.title.toLowerCase().includes(query.toLowerCase()) ||
             (c.description?.toLowerCase().includes(query.toLowerCase()) ?? false),
         )
-      : allCourses;
+      : enrolled;
 
-  const filteredEnrolled = filtered.filter((c) => c.enrolled);
+  const filteredUnenrolled =
+    query.length > 0
+      ? unenrolled.filter(
+          (c) =>
+            c.title.toLowerCase().includes(query.toLowerCase()) ||
+            (c.description?.toLowerCase().includes(query.toLowerCase()) ?? false),
+        )
+      : unenrolled;
 
   return (
     <div className="space-y-6">
@@ -80,9 +92,13 @@ export default async function CatalogPage({
 
       {/* Search */}
       <form className="flex gap-2">
+        <label className="sr-only" htmlFor="catalog-search">
+          Search courses
+        </label>
         <Input
           className="max-w-sm"
           defaultValue={query}
+          id="catalog-search"
           name="q"
           placeholder="Search courses..."
           type="search"
@@ -111,32 +127,41 @@ export default async function CatalogPage({
         </section>
       )}
 
-      {/* Full catalog */}
-      <section>
-        <h2 className="mb-3 text-sm font-medium text-muted-foreground">
-          {query ? `Results for "${query}"` : "All available courses"}
-        </h2>
+      {/* Available courses */}
+      {filteredUnenrolled.length > 0 && (
+        <section>
+          <h2 className="mb-3 text-sm font-medium text-muted-foreground">
+            {query ? `Results for "${query}"` : "All available courses"}
+          </h2>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {filteredUnenrolled.map((course) => (
+              <CourseCard course={course} key={course.id} />
+            ))}
+          </div>
+        </section>
+      )}
 
-        {filtered.length === 0 ? (
+      {/* Empty states */}
+      {allCourses.length === 0 && (
+        <Card>
+          <CardContent className="py-8 text-center">
+            <p className="text-sm text-muted-foreground">
+              No courses are available in the catalog yet.
+            </p>
+          </CardContent>
+        </Card>
+      )}
+      {allCourses.length > 0 &&
+        filteredEnrolled.length === 0 &&
+        filteredUnenrolled.length === 0 && (
           <Card>
             <CardContent className="py-8 text-center">
               <p className="text-sm text-muted-foreground">
-                {allCourses.length === 0
-                  ? "No courses are available in the catalog yet."
-                  : "No courses match your search."}
+                No courses match your search.
               </p>
             </CardContent>
           </Card>
-        ) : (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {filtered
-              .filter((c) => !c.enrolled)
-              .map((course) => (
-                <CourseCard course={course} key={course.id} />
-              ))}
-          </div>
         )}
-      </section>
 
       <div className="flex justify-end gap-2">
         <Button asChild variant="outline">

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -57,6 +57,7 @@ export default async function AppLayout({
       ? [{ label: "Dashboard", href: "/app/dashboard" }]
       : []),
     { label: "Courses", href: "/app/courses" },
+    { label: "Catalog", href: "/app/catalog" },
     ...(showParishAdmin ? [{ label: "Parish Admin", href: "/app/parish-admin" }] : []),
     ...(showDioceseAdmin ? [{ label: "Diocese Admin", href: "/app/admin" }] : []),
   ];

--- a/src/lib/repositories/catalog.ts
+++ b/src/lib/repositories/catalog.ts
@@ -1,0 +1,85 @@
+import { E2E_COURSE } from "@/lib/e2e-fixtures";
+import { isE2ESmokeMode } from "@/lib/e2e-mode";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+export interface CatalogCourse {
+  id: string;
+  title: string;
+  description: string | null;
+  thumbnailUrl: string | null;
+  scope: "DIOCESE" | "PARISH";
+  lessonCount: number;
+  enrolled: boolean;
+}
+
+export async function getCatalogCourses(
+  parishId: string,
+  clerkUserId: string,
+): Promise<CatalogCourse[]> {
+  if (isE2ESmokeMode()) {
+    return [
+      {
+        ...E2E_COURSE,
+        thumbnailUrl: "/globe.svg",
+        lessonCount: 2,
+        enrolled: true,
+      },
+    ];
+  }
+
+  const supabase = getSupabaseAdminClient();
+
+  // Get published DIOCESE courses + parish-scoped courses adopted by this parish
+  const { data: courses, error } = await supabase
+    .from("courses")
+    .select("id, title, description, thumbnail_url, scope")
+    .eq("published", true)
+    .or(`scope.eq.DIOCESE,and(scope.eq.PARISH,id.in.(select course_id from course_parishes where parish_id.eq.${parishId}))`)
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+  if (!courses || courses.length === 0) return [];
+
+  // Get enrollment status for this user
+  const { data: enrollments } = await supabase
+    .from("enrollments")
+    .select("course_id")
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", clerkUserId);
+
+  const enrolledSet = new Set(
+    ((enrollments ?? []) as Array<{ course_id: string }>).map((e) => e.course_id),
+  );
+
+  // Get lesson counts
+  const courseIds = (courses as Array<{ id: string }>).map((c) => c.id);
+  const { data: lessonCounts } = await supabase
+    .from("modules")
+    .select("course_id, lessons(id)")
+    .in("course_id", courseIds);
+
+  const lessonCountByCourse = new Map<string, number>();
+  for (const mod of (lessonCounts ?? []) as Array<{
+    course_id: string;
+    lessons: Array<{ id: string }>;
+  }>) {
+    const current = lessonCountByCourse.get(mod.course_id) ?? 0;
+    lessonCountByCourse.set(mod.course_id, current + (mod.lessons?.length ?? 0));
+  }
+
+  return (courses as Array<{
+    id: string;
+    title: string;
+    description: string | null;
+    thumbnail_url: string | null;
+    scope: "DIOCESE" | "PARISH";
+  }>).map((course) => ({
+    id: course.id,
+    title: course.title,
+    description: course.description,
+    thumbnailUrl: course.thumbnail_url,
+    scope: course.scope,
+    lessonCount: lessonCountByCourse.get(course.id) ?? 0,
+    enrolled: enrolledSet.has(course.id),
+  }));
+}

--- a/src/lib/repositories/catalog.ts
+++ b/src/lib/repositories/catalog.ts
@@ -29,34 +29,58 @@ export async function getCatalogCourses(
 
   const supabase = getSupabaseAdminClient();
 
-  // Get published DIOCESE courses + parish-scoped courses adopted by this parish
-  const { data: courses, error } = await supabase
+  // Get parish-scoped course IDs adopted by this parish
+  const { data: adoptedCourses, error: adoptedError } = await supabase
+    .from("course_parishes")
+    .select("course_id")
+    .eq("parish_id", parishId);
+
+  if (adoptedError) throw adoptedError;
+
+  const adoptedIds = ((adoptedCourses ?? []) as Array<{ course_id: string }>).map(
+    (r) => r.course_id,
+  );
+
+  // Build the visibility filter: DIOCESE courses OR parish-adopted PARISH courses
+  let query = supabase
     .from("courses")
     .select("id, title, description, thumbnail_url, scope")
-    .eq("published", true)
-    .or(`scope.eq.DIOCESE,and(scope.eq.PARISH,id.in.(select course_id from course_parishes where parish_id.eq.${parishId}))`)
-    .order("created_at", { ascending: false });
+    .eq("published", true);
 
-  if (error) throw error;
+  if (adoptedIds.length > 0) {
+    query = query.or(`scope.eq.DIOCESE,and(scope.eq.PARISH,id.in.(${adoptedIds.join(",")}))`);
+  } else {
+    query = query.eq("scope", "DIOCESE");
+  }
+
+  const { data: courses, error: coursesError } = await query.order("created_at", {
+    ascending: false,
+  });
+
+  if (coursesError) throw coursesError;
   if (!courses || courses.length === 0) return [];
 
   // Get enrollment status for this user
-  const { data: enrollments } = await supabase
+  const { data: enrollments, error: enrollError } = await supabase
     .from("enrollments")
     .select("course_id")
     .eq("parish_id", parishId)
     .eq("clerk_user_id", clerkUserId);
 
+  if (enrollError) throw enrollError;
+
   const enrolledSet = new Set(
     ((enrollments ?? []) as Array<{ course_id: string }>).map((e) => e.course_id),
   );
 
-  // Get lesson counts
+  // Get lesson counts for visible courses
   const courseIds = (courses as Array<{ id: string }>).map((c) => c.id);
-  const { data: lessonCounts } = await supabase
+  const { data: lessonCounts, error: countError } = await supabase
     .from("modules")
     .select("course_id, lessons(id)")
     .in("course_id", courseIds);
+
+  if (countError) throw countError;
 
   const lessonCountByCourse = new Map<string, number>();
   for (const mod of (lessonCounts ?? []) as Array<{


### PR DESCRIPTION
Closes #12

## What this adds
A new `/app/catalog` page where learners can browse all available courses.

### Features
- **Browse all visible courses** — DIOCESE-wide + parish-adopted courses
- **Search** — filter by title or description
- **Enrollment status** — each card shows whether the learner is enrolled
- **Scope badges** — Diocese-wide vs Parish indicator per course
- **Lesson counts** — shows how many lessons each course has
- **"My enrolled courses"** section — enrolled courses shown first
- **Nav link** — Catalog added to the top navigation

### Files changed
- `src/app/app/catalog/page.tsx` — catalog page with search and course cards
- `src/lib/repositories/catalog.ts` — `getCatalogCourses()` queries visible courses + enrollment status + lesson counts
- `src/app/app/layout.tsx` — added Catalog nav item

### Testing
- Lint: ✅
- Typecheck: ✅
- E2E smoke mode returns E2E_COURSE data