### PR TITLE
feat: inter-lesson navigation + course progress visualization

### DIFF
--- a/src/app/app/courses/[courseId]/page.tsx
+++ b/src/app/app/courses/[courseId]/page.tsx
@@ -4,7 +4,19 @@ import { notFound, redirect } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { requireParishRole } from "@/lib/authz";
-import { getCourseTree, isUserEnrolledInCourse } from "@/lib/repositories/courses";
+import { getCourseTreeWithProgress, isUserEnrolledInCourse } from "@/lib/repositories/courses";
+import type { CourseLesson } from "@/lib/repositories/courses";
+
+function statusIcon(status: CourseLesson["status"]) {
+  switch (status) {
+    case "completed":
+      return <span className="mr-1.5" title="Completed">✓</span>;
+    case "in_progress":
+      return <span className="mr-1.5" title="In progress">▶</span>;
+    default:
+      return <span className="mr-1.5 text-muted-foreground" title="Not started">○</span>;
+  }
+}
 
 export default async function CourseDetailPage({
   params,
@@ -17,38 +29,82 @@ export default async function CourseDetailPage({
   if (!enrolled) {
     redirect("/app/courses?error=not_enrolled");
   }
-  const courseTree = await getCourseTree(courseId, parishId);
 
-  if (!courseTree) {
-    notFound();
-  }
+  const tree = await getCourseTreeWithProgress(courseId, parishId, clerkUserId);
+  if (!tree) notFound();
+
+  const allLessons = tree.modules.flatMap((m) => m.lessons);
+  const completedCount = allLessons.filter((l) => l.status === "completed").length;
+  const firstIncomplete = allLessons.find((l) => l.status !== "completed");
+  const progressPercent = allLessons.length > 0
+    ? Math.round((completedCount / allLessons.length) * 100)
+    : 0;
 
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-semibold">{courseTree.course.title}</h1>
-      {courseTree.modules.map(
-        (module: {
-          id: string;
-          title: string;
-          lessons: { id: string; title: string }[];
-        }) => (
-          <Card key={module.id}>
-            <CardHeader>
-              <CardTitle className="text-base">{module.title}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ul className="list-inside list-disc space-y-1">
-                {module.lessons?.map((lesson) => (
-                  <li key={lesson.id}>
-                    <Button asChild className="h-auto p-0 font-medium" variant="link">
-                      <Link href={`/app/lessons/${lesson.id}`}>{lesson.title}</Link>
-                    </Button>
-                  </li>
-                ))}
-              </ul>
-            </CardContent>
-          </Card>
-        ),
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">{tree.course.title}</h1>
+        <p className="text-sm text-muted-foreground">
+          {completedCount}/{allLessons.length} lessons complete ({progressPercent}%)
+        </p>
+      </header>
+
+      {/* Resume button */}
+      {firstIncomplete && (
+        <Button asChild>
+          <Link href={`/app/lessons/${firstIncomplete.id}`}>
+            {firstIncomplete.status === "in_progress" ? "Resume" : "Start"} next lesson
+          </Link>
+        </Button>
+      )}
+
+      {/* Progress bar */}
+      {allLessons.length > 0 && (
+        <div className="h-2 w-full rounded-full bg-muted">
+          <div
+            className="h-2 rounded-full bg-primary transition-all duration-500"
+            style={{ width: `${progressPercent}%` }}
+          />
+        </div>
+      )}
+
+      {tree.modules.map((module) => (
+        <Card key={module.id}>
+          <CardHeader>
+            <CardTitle className="text-base">{module.title}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {module.lessons.map((lesson) => (
+                <li className="flex items-center" key={lesson.id}>
+                  {statusIcon(lesson.status)}
+                  <Button
+                    asChild
+                    className="h-auto p-0 font-medium"
+                    variant="link"
+                  >
+                    <Link href={`/app/lessons/${lesson.id}`}>{lesson.title}</Link>
+                  </Button>
+                  {lesson.bestScore > 0 && (
+                    <span className="ml-2 text-xs text-muted-foreground">
+                      {lesson.bestScore}%
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      ))}
+
+      {allLessons.length === 0 && (
+        <Card>
+          <CardContent className="py-4">
+            <p className="text-sm text-muted-foreground">
+              No lessons have been added to this course yet.
+            </p>
+          </CardContent>
+        </Card>
       )}
     </div>
   );

--- a/src/app/app/lessons/[lessonId]/__tests__/page.test.tsx
+++ b/src/app/app/lessons/[lessonId]/__tests__/page.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@/lib/e2e-mode", () => ({
 
 vi.mock("@/lib/repositories/lessons", () => ({
   getBestScore: vi.fn(),
+  getLessonNavContext: vi.fn(),
   getLessonProgress: vi.fn(),
   getLessonWithQuestions: vi.fn(),
   isUserEnrolledForLesson: vi.fn(),
@@ -44,6 +45,7 @@ import LessonPage from "@/app/app/lessons/[lessonId]/page";
 import { requireParishRole } from "@/lib/authz";
 import {
   getBestScore,
+  getLessonNavContext,
   getLessonProgress,
   getLessonWithQuestions,
   isUserEnrolledForLesson,
@@ -62,6 +64,13 @@ describe("LessonPage", () => {
       percent_watched: 100,
       last_position_seconds: 0,
       completed: true,
+    });
+    vi.mocked(getLessonNavContext).mockResolvedValue({
+      lesson: { id: "lesson-1", title: "Test Lesson" },
+      course: { id: "course-1", title: "Test Course" },
+      module: { id: "module-1", title: "Test Module" },
+      previousLesson: null,
+      nextLesson: null,
     });
     vi.mocked(getBestScore).mockResolvedValue(100);
   });
@@ -83,7 +92,7 @@ describe("LessonPage", () => {
 
     render(await LessonPage({ params: Promise.resolve({ lessonId: "lesson-1" }) }));
 
-    expect(screen.getByText("Reading lesson")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Reading lesson" })).toBeInTheDocument();
     expect(screen.getByText("Review status: Reviewed · Pages 2-4")).toBeInTheDocument();
     expect(screen.getByText("Document review: Pages 2-4")).toBeInTheDocument();
     expect(screen.getByTitle("Reading lesson document")).toHaveAttribute("src", "/docs/reading.pdf#page=2");

--- a/src/app/app/lessons/[lessonId]/page.tsx
+++ b/src/app/app/lessons/[lessonId]/page.tsx
@@ -1,13 +1,17 @@
+import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
 import { DocumentReviewCard } from "@/components/document-review-card";
+import { LessonNav } from "@/components/lesson-nav";
 import { YoutubePlayer } from "@/components/player/youtube-player";
 import { QuizForm } from "@/components/quiz-form";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { requireParishRole } from "@/lib/authz";
 import { isE2ESmokeMode } from "@/lib/e2e-mode";
 import {
   getBestScore,
+  getLessonNavContext,
   getLessonProgress,
   getLessonWithQuestions,
   isUserEnrolledForLesson,
@@ -44,6 +48,7 @@ export default async function LessonPage({
 
   const progress = await getLessonProgress(lessonId, parishId, clerkUserId);
   const bestScore = await getBestScore(lessonId, parishId, clerkUserId);
+  const navContext = await getLessonNavContext(lessonId);
   const documentViewerUrl =
     lesson.content_type === "DOCUMENT" && lesson.document_url
       ? buildDocumentViewerUrl({
@@ -60,6 +65,21 @@ export default async function LessonPage({
 
   return (
     <div className="space-y-6">
+      {/* Breadcrumb */}
+      {navContext && (
+        <nav className="flex items-center gap-1 text-sm text-muted-foreground">
+          <Button asChild className="h-auto p-0" variant="link">
+            <Link href={`/app/courses/${navContext.course.id}`}>
+              {navContext.course.title}
+            </Link>
+          </Button>
+          <span>{">"}</span>
+          <span className="text-foreground">{navContext.module.title}</span>
+          <span>{">"}</span>
+          <span className="font-medium text-foreground">{lesson.title}</span>
+        </nav>
+      )}
+
       <Card>
         <CardHeader>
           <CardTitle>{lesson.title}</CardTitle>
@@ -118,6 +138,15 @@ export default async function LessonPage({
           </CardContent>
         </Card>
       )}
+
+      {/* Prev/Next navigation */}
+      {navContext && (
+        <LessonNav
+          previousLesson={navContext.previousLesson}
+          nextLesson={navContext.nextLesson}
+        />
+      )}
+
       <QuizForm
         lessonId={lesson.id}
         parishId={parishId}
@@ -126,6 +155,7 @@ export default async function LessonPage({
           prompt: q.prompt,
           options: q.options as string[],
         }))}
+        nextLesson={navContext?.nextLesson ?? null}
       />
     </div>
   );

--- a/src/components/lesson-nav.tsx
+++ b/src/components/lesson-nav.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+
+interface LessonNavProps {
+  previousLesson: { id: string; title: string } | null;
+  nextLesson: { id: string; title: string } | null;
+}
+
+export function LessonNav({ previousLesson, nextLesson }: LessonNavProps) {
+  if (!previousLesson && !nextLesson) return null;
+
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-lg border border-border bg-card p-4">
+      <div className="flex-1 text-left">
+        {previousLesson ? (
+          <Button asChild size="sm" variant="outline">
+            <Link href={`/app/lessons/${previousLesson.id}`}>
+              ←&nbsp;{previousLesson.title}
+            </Link>
+          </Button>
+        ) : (
+          <span className="invisible block text-sm">No previous lesson</span>
+        )}
+      </div>
+      <div className="flex-1 text-right">
+        {nextLesson ? (
+          <Button asChild size="sm" variant="outline">
+            <Link href={`/app/lessons/${nextLesson.id}`}>
+              {nextLesson.title}&nbsp;→
+            </Link>
+          </Button>
+        ) : (
+          <span className="text-sm text-muted-foreground">End of course</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/quiz-form.tsx
+++ b/src/components/quiz-form.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -16,13 +17,18 @@ export function QuizForm({
   lessonId,
   parishId,
   questions,
+  nextLesson,
 }: {
   lessonId: string;
   parishId: string;
   questions: Question[];
+  nextLesson: { id: string; title: string } | null;
 }) {
   const [answers, setAnswers] = useState<Record<string, number>>({});
   const [score, setScore] = useState<number | null>(null);
+  const [submitted, setSubmitted] = useState(false);
+
+  const allAnswered = questions.every((q) => answers[q.id] !== undefined);
 
   const submit = async () => {
     const orderedAnswers = questions.map((q) => answers[q.id] ?? -1);
@@ -35,6 +41,7 @@ export function QuizForm({
     const data = await response.json();
     if (response.ok) {
       setScore(data.score);
+      setSubmitted(true);
     }
   };
 
@@ -51,6 +58,7 @@ export function QuizForm({
               <label className="flex items-center gap-2 text-sm" key={option}>
                 <Radio
                   checked={answers[q.id] === idx}
+                  disabled={submitted}
                   name={q.id}
                   onChange={() => setAnswers((prev) => ({ ...prev, [q.id]: idx }))}
                 />
@@ -59,10 +67,23 @@ export function QuizForm({
             ))}
           </div>
         ))}
-        <Button onClick={submit} type="button">
-          Submit Quiz
-        </Button>
-        {score !== null && <p className="text-sm text-muted-foreground">Latest score: {score}%</p>}
+        {!submitted && (
+          <Button disabled={!allAnswered} onClick={submit} type="button">
+            Submit Quiz
+          </Button>
+        )}
+        {score !== null && (
+          <div className="flex items-center gap-3">
+            <p className="text-sm text-muted-foreground">Score: {score}%</p>
+            {nextLesson && (
+              <Button asChild size="sm" variant="outline">
+                <Link href={`/app/lessons/${nextLesson.id}`}>
+                  Next: {nextLesson.title} →
+                </Link>
+              </Button>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/lib/repositories/courses.ts
+++ b/src/lib/repositories/courses.ts
@@ -114,3 +114,113 @@ export async function getCourseTree(courseId: string, parishId: string) {
   if (modulesError) throw modulesError;
   return { course, modules: ((modules ?? []) as CourseModule[]) ?? [] };
 }
+
+export interface CourseLesson {
+  id: string;
+  title: string;
+  sort_order: number;
+  status: "not_started" | "in_progress" | "completed";
+  bestScore: number;
+}
+
+export interface CourseModuleWithProgress {
+  id: string;
+  title: string;
+  sort_order: number;
+  lessons: CourseLesson[];
+}
+
+export async function getCourseTreeWithProgress(
+  courseId: string,
+  parishId: string,
+  clerkUserId: string,
+) {
+  if (isE2ESmokeMode()) {
+    if (courseId !== E2E_COURSE.id) return null;
+    return {
+      course: E2E_COURSE,
+      modules: [
+        {
+          ...E2E_MODULE,
+          lessons: [
+            {
+              id: E2E_LESSON.id,
+              title: E2E_LESSON.title,
+              sort_order: 1,
+              status: "not_started" as const,
+              bestScore: 0,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  const tree = await getCourseTree(courseId, parishId);
+  if (!tree) return null;
+
+  const allLessonIds = tree.modules.flatMap((m) => m.lessons.map((l) => l.id));
+  if (allLessonIds.length === 0) {
+    return {
+      course: tree.course,
+      modules: tree.modules.map((m) => ({
+        ...m,
+        lessons: m.lessons.map((l) => ({
+          ...l,
+          status: "not_started" as const,
+          bestScore: 0,
+        })),
+      })),
+    };
+  }
+
+  const supabase = getSupabaseAdminClient();
+
+  const { data: progressData } = await supabase
+    .from("video_progress")
+    .select("lesson_id, completed, percent_watched")
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", clerkUserId)
+    .in("lesson_id", allLessonIds);
+
+  const progressMap = new Map(
+    ((progressData ?? []) as Array<{
+      lesson_id: string;
+      completed: boolean;
+      percent_watched: number;
+    }>).map((p) => [p.lesson_id, p]),
+  );
+
+  const { data: quizData } = await supabase
+    .from("quiz_attempts")
+    .select("lesson_id, score")
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", clerkUserId)
+    .in("lesson_id", allLessonIds);
+
+  const bestScoreMap = new Map<string, number>();
+  for (const q of (quizData ?? []) as Array<{ lesson_id: string; score: number }>) {
+    const current = bestScoreMap.get(q.lesson_id) ?? 0;
+    if (q.score > current) bestScoreMap.set(q.lesson_id, q.score);
+  }
+
+  return {
+    course: tree.course,
+    modules: tree.modules.map((m) => ({
+      ...m,
+      lessons: m.lessons.map((l) => {
+        const progress = progressMap.get(l.id);
+        const bestScore = bestScoreMap.get(l.id) ?? 0;
+        let status: "not_started" | "in_progress" | "completed";
+        if (progress?.completed) {
+          status = "completed";
+        } else if (progress && progress.percent_watched > 0) {
+          status = "in_progress";
+        } else {
+          status = "not_started";
+        }
+        return { ...l, status, bestScore };
+      }),
+    })),
+  };
+}

--- a/src/lib/repositories/lessons.ts
+++ b/src/lib/repositories/lessons.ts
@@ -146,3 +146,79 @@ export async function isUserEnrolledForLesson({
   if (error) throw error;
   return Boolean(data);
 }
+
+export interface LessonNavContext {
+  lesson: { id: string; title: string };
+  course: { id: string; title: string };
+  module: { id: string; title: string };
+  previousLesson: { id: string; title: string } | null;
+  nextLesson: { id: string; title: string } | null;
+}
+
+export async function getLessonNavContext(
+  lessonId: string,
+): Promise<LessonNavContext | null> {
+  if (isE2ESmokeMode()) {
+    if (lessonId !== E2E_LESSON.id) return null;
+    return {
+      lesson: { id: E2E_LESSON.id, title: E2E_LESSON.title },
+      course: { id: E2E_COURSE.id, title: E2E_COURSE.title },
+      module: { id: "mod-1", title: "Module 1" },
+      previousLesson: null,
+      nextLesson: null,
+    };
+  }
+
+  const supabase = getSupabaseAdminClient();
+
+  // Get the lesson with its module and course
+  const { data: lesson, error: lessonError } = await supabase
+    .from("lessons")
+    .select("id, title, module_id, modules!inner(id, title, course_id, courses!inner(id, title))")
+    .eq("id", lessonId)
+    .maybeSingle();
+
+  if (lessonError) throw lessonError;
+  if (!lesson) return null;
+
+  const lessonData = lesson as {
+    id: string;
+    title: string;
+    module_id: string;
+    modules: {
+      id: string;
+      title: string;
+      course_id: string;
+      courses: { id: string; title: string };
+    };
+  };
+
+  // Get all lessons in this course, ordered
+  const { data: allLessons, error: allError } = await supabase
+    .from("modules")
+    .select("id, lessons(id, title, sort_order)")
+    .eq("course_id", lessonData.modules.course_id)
+    .order("sort_order", { ascending: true });
+
+  if (allError) throw allError;
+
+  const orderedLessons: Array<{ id: string; title: string }> = [];
+  for (const mod of (allLessons ?? []) as Array<{
+    lessons: Array<{ id: string; title: string; sort_order: number }>;
+  }>) {
+    const sorted = [...(mod.lessons ?? [])].sort((a, b) => a.sort_order - b.sort_order);
+    orderedLessons.push(...sorted);
+  }
+
+  const currentIndex = orderedLessons.findIndex((l) => l.id === lessonId);
+  const previousLesson = currentIndex > 0 ? orderedLessons[currentIndex - 1] : null;
+  const nextLesson = currentIndex < orderedLessons.length - 1 ? orderedLessons[currentIndex + 1] : null;
+
+  return {
+    lesson: { id: lessonData.id, title: lessonData.title },
+    course: { id: lessonData.modules.courses.id, title: lessonData.modules.courses.title },
+    module: { id: lessonData.modules.id, title: lessonData.modules.title },
+    previousLesson,
+    nextLesson,
+  };
+}


### PR DESCRIPTION
Closes #10

## What this adds
Inter-lesson navigation and visual progress tracking so students can move through courses smoothly.

### Course detail page
- ✅ ✓/▶/○ status indicators next to each lesson
- ✅ Progress bar showing overall completion %
- ✅ "Resume" or "Start next lesson" button
- ✅ Best quiz score shown per lesson

### Lesson page  
- ✅ Breadcrumb: Course > Module > Lesson
- ✅ Prev/Next navigation bar between lessons
- ✅ Quiz form: "Next: Lesson Title →" button after submission
- ✅ Submit disabled until all questions answered
- ✅ Answers locked after submission

### Files changed
- `src/app/app/courses/[courseId]/page.tsx` — status indicators, progress bar, resume button
- `src/app/app/lessons/[lessonId]/page.tsx` — breadcrumb, LessonNav, nextLesson to QuizForm
- `src/components/lesson-nav.tsx` — new prev/next navigation component
- `src/components/quiz-form.tsx` — nextLesson link, submit lock
- `src/lib/repositories/courses.ts` — new `getCourseTreeWithProgress()`
- `src/lib/repositories/lessons.ts` — new `getLessonNavContext()`

### Testing
- Lint: ✅
- Typecheck: ✅