### PR TITLE
feat(mobile): collapsible course sidebar, hamburger nav, responsive fixes

### DIFF
--- a/src/app/app/catalog/page.tsx
+++ b/src/app/app/catalog/page.tsx
@@ -17,7 +17,7 @@ function CourseCard({
   hasPendingRequest: boolean;
 }) {
   return (
-    <Card className="flex h-full flex-col transition-colors hover:bg-secondary/50">
+    <Card className="flex h-full flex-col overflow-hidden transition-colors hover:bg-secondary/50">
       <div className="flex gap-3 p-4 pb-0">
         {/* Thumbnail */}
         <div className="h-20 w-20 shrink-0 overflow-hidden rounded-md border bg-muted">
@@ -153,7 +153,7 @@ export default async function CatalogPage({
           <h2 className="mb-3 text-sm font-medium text-muted-foreground">
             My enrolled courses
           </h2>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
             {filteredEnrolled.map((course) => (
               <CourseCard course={course} hasPendingRequest={pendingCourseIds.has(course.id)} key={course.id} />
             ))}
@@ -167,7 +167,7 @@ export default async function CatalogPage({
           <h2 className="mb-3 text-sm font-medium text-muted-foreground">
             {query ? `Results for "${query}"` : "All available courses"}
           </h2>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
             {filteredUnenrolled.map((course) => (
               <CourseCard course={course} hasPendingRequest={pendingCourseIds.has(course.id)} key={course.id} />
             ))}

--- a/src/app/app/courses/page.tsx
+++ b/src/app/app/courses/page.tsx
@@ -39,10 +39,10 @@ export default async function CoursesPage({
         ) : null}
         {(courses as VisibleCourse[]).map((course) => (
           <Link key={course.id} href={`/app/courses/${course.id}`}>
-            <Card className="transition-colors hover:bg-secondary">
-              <CardContent className="flex items-center gap-4 py-4">
+            <Card className="transition-colors hover:bg-secondary overflow-hidden">
+              <CardContent className="flex items-center gap-3 py-3 sm:py-4">
                 {/* Thumbnail */}
-                <div className="h-14 w-14 shrink-0 overflow-hidden rounded-md border bg-muted">
+                <div className="h-12 w-12 sm:h-14 sm:w-14 shrink-0 overflow-hidden rounded-md border bg-muted">
                   {course.thumbnailUrl ? (
                     // eslint-disable-next-line @next/next/no-img-element
                     <img
@@ -52,16 +52,16 @@ export default async function CoursesPage({
                     />
                   ) : (
                     <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-                      <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <svg className="h-5 w-5 sm:h-6 sm:w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} />
                       </svg>
                     </div>
                   )}
                 </div>
                 <div className="min-w-0 flex-1">
-                  <p className="truncate font-medium">{course.title}</p>
+                  <p className="truncate text-sm sm:text-base font-medium">{course.title}</p>
                   {course.description && (
-                    <p className="truncate text-sm text-muted-foreground">
+                    <p className="hidden sm:block truncate text-xs sm:text-sm text-muted-foreground">
                       {course.description}
                     </p>
                   )}

--- a/src/app/app/dashboard/page.tsx
+++ b/src/app/app/dashboard/page.tsx
@@ -163,9 +163,17 @@ export default async function DashboardPage() {
 
       {/* Course progress */}
       <section>
-        <h2 className="mb-3 text-sm font-medium text-muted-foreground">
-          Your courses
-        </h2>
+        <div className="mb-3 flex items-center justify-between">
+          <h2 className="text-sm font-medium text-muted-foreground">
+            Your courses
+          </h2>
+          <Link
+            className="text-xs font-medium text-primary hover:underline"
+            href="/app/courses"
+          >
+            View all
+          </Link>
+        </div>
         <div className="grid gap-3 sm:grid-cols-1 lg:grid-cols-2">
           {progress.map((course) => (
             <Link

--- a/src/app/app/dashboard/page.tsx
+++ b/src/app/app/dashboard/page.tsx
@@ -122,8 +122,9 @@ export default async function DashboardPage() {
               <Link
                 href={`/app/lessons/${course.lastLessonId}`}
                 key={`resume-${course.courseId}`}
+                className="min-w-0"
               >
-                <Card className="h-full transition-colors hover:bg-secondary">
+                <Card className="h-full overflow-hidden transition-colors hover:bg-secondary">
                   <CardContent className="flex items-center gap-3 py-3">
                     {/* Course thumbnail */}
                     <div className="h-12 w-12 shrink-0 overflow-hidden rounded-md border bg-muted">
@@ -179,8 +180,9 @@ export default async function DashboardPage() {
             <Link
               href={`/app/courses/${course.courseId}`}
               key={course.courseId}
+              className="min-w-0"
             >
-              <Card className="h-full transition-colors hover:bg-secondary">
+              <Card className="h-full overflow-hidden transition-colors hover:bg-secondary">
                 <CardContent className="flex items-center gap-4 py-4">
                   {/* Thumbnail */}
                   <div className="h-14 w-14 shrink-0 overflow-hidden rounded-md border bg-muted">

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { UserButton } from "@clerk/nextjs";
 import { cookies } from "next/headers";
 
+import { AppHeaderClient } from "@/components/app-header-client";
 import { ParishSwitcher } from "@/components/parish-switcher";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
@@ -62,38 +63,13 @@ export default async function AppLayout({
 
   return (
     <div className="min-h-screen">
-      <header className="sticky top-0 z-50 border-b border-nav-border bg-nav-bg shadow-sm transition-colors duration-250">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 h-[52px]">
-          <div className="flex items-center gap-2 mr-6">
-            <div className="flex h-[26px] w-[26px] items-center justify-center rounded-[5px] bg-primary">
-              <svg viewBox="0 0 20 20" width="14" height="14" xmlns="http://www.w3.org/2000/svg">
-                <path d="M10 1v18M1 10h18M6 6l-3-3M14 6l3-3M6 14l-3 3M14 14l3 3" stroke="white" strokeWidth="2" strokeLinecap="round" fill="none"/>
-              </svg>
-            </div>
-            <span className="text-[13px] font-bold text-foreground tracking-tight">WD Learning</span>
-          </div>
-          <nav className="flex flex-wrap items-center gap-0.5">
-            {navItems.map((item) => (
-              <Button
-                asChild
-                className="text-muted-foreground hover:text-foreground"
-                key={item.href}
-                size="sm"
-                variant="ghost"
-              >
-                <Link href={item.href}>{item.label}</Link>
-              </Button>
-            ))}
-          </nav>
-          <div className="ml-auto flex items-center gap-2">
-            {parishOptions.length > 1 && activeParishId ? (
-              <ParishSwitcher activeParishId={activeParishId} parishes={parishOptions} />
-            ) : null}
-            <ThemeToggle />
-            {showUserButton ? <UserButton /> : null}
-          </div>
-        </div>
-      </header>
+      <AppHeaderClient
+        navItems={navItems}
+        parishes={parishOptions}
+        showParishSwitcher={parishOptions.length > 1}
+        showUserButton={showUserButton}
+        activeParishId={activeParishId}
+      />
       <main className="mx-auto max-w-6xl px-6 py-7">{children}</main>
     </div>
   );

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -55,7 +55,6 @@ export default async function AppLayout({
 
   const navItems = [
     { label: "Dashboard", href: "/app/dashboard" },
-    { label: "Courses", href: "/app/courses" },
     { label: "Catalog", href: "/app/catalog" },
     ...(showParishAdmin ? [{ label: "Parish Admin", href: "/app/parish-admin" }] : []),
     ...(showDioceseAdmin ? [{ label: "Diocese Admin", href: "/app/admin" }] : []),

--- a/src/app/app/lessons/[lessonId]/page.tsx
+++ b/src/app/app/lessons/[lessonId]/page.tsx
@@ -72,7 +72,7 @@ export default async function LessonPage({
         : "Assigned document";
 
   return (
-    <div className="flex h-screen">
+    <div className="flex" style={{ height: "calc(100vh - 52px)" }}>
       {/* Sidebar */}
       {courseTree && (
         <CourseSidebarClient

--- a/src/app/app/lessons/[lessonId]/page.tsx
+++ b/src/app/app/lessons/[lessonId]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound, redirect } from "next/navigation";
 
-import { CourseSidebar } from "@/components/course-sidebar";
+import { CourseSidebarClient } from "@/components/course-sidebar-client";
 import { DocumentReviewCard } from "@/components/document-review-card";
 import { LessonNav } from "@/components/lesson-nav";
 import { YoutubePlayer } from "@/components/player/youtube-player";
@@ -72,10 +72,10 @@ export default async function LessonPage({
         : "Assigned document";
 
   return (
-    <div className="-mx-6 -mt-7 flex" style={{ height: "calc(100vh - 52px)" }}>
+    <div className="flex h-screen">
       {/* Sidebar */}
       {courseTree && (
-        <CourseSidebar
+        <CourseSidebarClient
           courseId={courseTree.course.id}
           courseTitle={courseTree.course.title}
           currentLessonId={lessonId}

--- a/src/components/app-header-client.tsx
+++ b/src/components/app-header-client.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { UserButton } from "@clerk/nextjs";
+
+import { ParishSwitcher } from "@/components/parish-switcher";
+import { ThemeToggle } from "@/components/theme-toggle";
+import { Button } from "@/components/ui/button";
+
+interface NavItem {
+  label: string;
+  href: string;
+}
+
+interface AppHeaderClientProps {
+  navItems: NavItem[];
+  showParishSwitcher?: boolean;
+  showUserButton?: boolean;
+  activeParishId?: string;
+  parishes?: Array<{ id: string; name: string; slug: string }>;
+}
+
+export function AppHeaderClient({
+  navItems,
+  showParishSwitcher = false,
+  showUserButton = false,
+  activeParishId,
+  parishes = [],
+}: AppHeaderClientProps) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-nav-border bg-nav-bg shadow-sm transition-colors duration-250">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 h-[52px]">
+        {/* Logo */}
+        <div className="flex items-center gap-2">
+          <div className="flex h-[26px] w-[26px] items-center justify-center rounded-[5px] bg-primary">
+            <svg viewBox="0 0 20 20" width="14" height="14" xmlns="http://www.w3.org/2000/svg">
+              <path d="M10 1v18M1 10h18M6 6l-3-3M14 6l3-3M6 14l-3 3M14 14l3 3" stroke="white" strokeWidth="2" strokeLinecap="round" fill="none"/>
+            </svg>
+          </div>
+          <span className="text-[13px] font-bold text-foreground tracking-tight hidden sm:block">WD Learning</span>
+        </div>
+
+        {/* Desktop nav */}
+        <nav className="hidden md:flex flex-wrap items-center gap-0.5">
+          {navItems.map((item) => (
+            <Button
+              asChild
+              className="text-muted-foreground hover:text-foreground"
+              key={item.href}
+              size="sm"
+              variant="ghost"
+            >
+              <Link href={item.href}>{item.label}</Link>
+            </Button>
+          ))}
+        </nav>
+
+        {/* Right side controls */}
+        <div className="ml-auto flex items-center gap-2">
+          {showParishSwitcher && activeParishId && parishes.length > 1 && (
+            <div className="hidden sm:block">
+              <ParishSwitcher activeParishId={activeParishId} parishes={parishes} />
+            </div>
+          )}
+          <ThemeToggle />
+          {showUserButton && <UserButton />}
+          {/* Mobile hamburger */}
+          <button
+            className="flex md:hidden h-9 w-9 items-center justify-center rounded-md text-muted-foreground hover:text-foreground"
+            onClick={() => setMobileOpen(true)}
+            aria-label="Open menu"
+          >
+            <svg fill="none" height="20" stroke="currentColor" viewBox="0 0 24 24" width="20">
+              <path d="M4 6h16M4 12h16M4 18h16" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      {/* Mobile menu overlay */}
+      {mobileOpen && (
+        <div className="fixed inset-0 z-50 flex flex-col md:hidden">
+          {/* Backdrop */}
+          <div
+            className="fixed inset-0 bg-foreground/40 backdrop-blur-sm"
+            onClick={() => setMobileOpen(false)}
+          />
+          {/* Menu panel */}
+          <div className="fixed inset-y-0 right-0 w-[260px] flex flex-col bg-card shadow-xl">
+            <div className="flex items-center justify-between border-b border-border px-4 h-[52px]">
+              <span className="text-sm font-bold">Menu</span>
+              <button
+                className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:text-foreground"
+                onClick={() => setMobileOpen(false)}
+                aria-label="Close menu"
+              >
+                <svg fill="none" height="18" stroke="currentColor" viewBox="0 0 24 24" width="18">
+                  <path d="M6 6l12 12M6 18L18 6" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+                </svg>
+              </button>
+            </div>
+            <nav className="flex-1 overflow-y-auto px-3 py-2">
+              {navItems.map((item) => (
+                <Button
+                  asChild
+                  className="w-full justify-start text-muted-foreground hover:text-foreground"
+                  key={item.href}
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setMobileOpen(false)}
+                >
+                  <Link href={item.href}>{item.label}</Link>
+                </Button>
+              ))}
+            </nav>
+            {showParishSwitcher && activeParishId && parishes.length > 1 && (
+              <div className="border-t border-border p-3">
+                <p className="mb-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">Parish</p>
+                <ParishSwitcher activeParishId={activeParishId} parishes={parishes} />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </header>
+  );
+}

--- a/src/components/course-sidebar-client.tsx
+++ b/src/components/course-sidebar-client.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 
 import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { SheetTitle } from "@/components/ui/sheet";
 import { CourseSidebar } from "@/components/course-sidebar";
 import type { CourseModuleWithProgress } from "@/lib/repositories/courses";
 
@@ -47,6 +48,7 @@ export function CourseSidebarClient({
       {/* Mobile sheet (slide-out) */}
       <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
         <SheetContent side="right">
+          <SheetTitle className="mb-2">{courseTitle}</SheetTitle>
           <CourseSidebar
             courseTitle={courseTitle}
             courseId={courseId}

--- a/src/components/course-sidebar-client.tsx
+++ b/src/components/course-sidebar-client.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useState } from "react";
+
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { CourseSidebar } from "@/components/course-sidebar";
+import type { CourseModuleWithProgress } from "@/lib/repositories/courses";
+
+interface CourseSidebarClientProps {
+  courseTitle: string;
+  courseId: string;
+  modules: CourseModuleWithProgress[];
+  currentLessonId: string;
+}
+
+export function CourseSidebarClient({
+  courseTitle,
+  courseId,
+  modules,
+  currentLessonId,
+}: CourseSidebarClientProps) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  return (
+    <>
+      {/* Mobile toggle button */}
+      <button
+        className="fixed right-3 bottom-3 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg md:hidden"
+        onClick={() => setMobileOpen(true)}
+        aria-label="Open course outline"
+      >
+        <svg fill="none" height="18" stroke="currentColor" viewBox="0 0 24 24" width="18">
+          <path d="M4 6h16M4 12h16M4 18h16" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
+        </svg>
+      </button>
+
+      {/* Desktop sidebar (always visible) */}
+      <div className="hidden md:block">
+        <CourseSidebar
+          courseTitle={courseTitle}
+          courseId={courseId}
+          modules={modules}
+          currentLessonId={currentLessonId}
+        />
+      </div>
+
+      {/* Mobile sheet (slide-out) */}
+      <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+        <SheetContent side="right">
+          <CourseSidebar
+            courseTitle={courseTitle}
+            courseId={courseId}
+            modules={modules}
+            currentLessonId={currentLessonId}
+          />
+        </SheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/src/components/course-sidebar-client.tsx
+++ b/src/components/course-sidebar-client.tsx
@@ -48,13 +48,18 @@ export function CourseSidebarClient({
       {/* Mobile sheet (slide-out) */}
       <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
         <SheetContent side="right">
-          <SheetTitle className="mb-2">{courseTitle}</SheetTitle>
-          <CourseSidebar
-            courseTitle={courseTitle}
-            courseId={courseId}
-            modules={modules}
-            currentLessonId={currentLessonId}
-          />
+          {/* SheetTitle is required for Radix Dialog accessibility; sr-only since CourseSidebar renders its own header */}
+          <SheetTitle className="sr-only">{courseTitle}</SheetTitle>
+          {/* Scrollable container prevents clipping when lesson list is long */}
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <CourseSidebar
+              courseTitle={courseTitle}
+              courseId={courseId}
+              modules={modules}
+              currentLessonId={currentLessonId}
+              showHeader={false}
+            />
+          </div>
         </SheetContent>
       </Sheet>
     </>

--- a/src/components/course-sidebar.tsx
+++ b/src/components/course-sidebar.tsx
@@ -10,6 +10,7 @@ interface CourseSidebarProps {
   courseId: string;
   modules: CourseModuleWithProgress[];
   currentLessonId: string;
+  showHeader?: boolean;
 }
 
 function lessonTypeIcon(contentType: CourseLesson["content_type"], isActive: boolean) {
@@ -20,7 +21,7 @@ function lessonTypeIcon(contentType: CourseLesson["content_type"], isActive: boo
   return <span className={`text-[12px] ${color}`}>▶</span>;
 }
 
-export function CourseSidebar({ courseTitle, courseId, modules, currentLessonId }: CourseSidebarProps) {
+export function CourseSidebar({ courseTitle, courseId, modules, currentLessonId, showHeader = true }: CourseSidebarProps) {
   const allLessons = modules.flatMap((m) => m.lessons);
   const completedCount = allLessons.filter((l) => l.status === "completed").length;
   const progressPercent = allLessons.length > 0
@@ -29,22 +30,23 @@ export function CourseSidebar({ courseTitle, courseId, modules, currentLessonId 
 
   return (
     <aside className="flex w-[280px] shrink-0 flex-col overflow-hidden border-r border-border bg-sidebar-bg transition-colors duration-250">
-      {/* Header */}
-      <div className="shrink-0 border-b border-border px-[18px] pt-4 pb-3">
-        <Link
-          className="mb-2 block font-display text-[13.5px] font-bold leading-tight tracking-tight text-foreground hover:text-primary transition-colors"
-          href={`/app/courses/${courseId}`}
-        >
-          {courseTitle}
-        </Link>
-        <div className="flex flex-col gap-1">
-          <div className="flex justify-between text-[11px] text-muted-foreground">
-            <span>{completedCount} of {allLessons.length} lessons complete</span>
-            <span className="font-bold text-primary">{progressPercent}%</span>
+      {showHeader ? (
+        <div className="shrink-0 border-b border-border px-[18px] pt-4 pb-3">
+          <Link
+            className="mb-2 block font-display text-[13.5px] font-bold leading-tight tracking-tight text-foreground hover:text-primary transition-colors"
+            href={`/app/courses/${courseId}`}
+          >
+            {courseTitle}
+          </Link>
+          <div className="flex flex-col gap-1">
+            <div className="flex justify-between text-[11px] text-muted-foreground">
+              <span>{completedCount} of {allLessons.length} lessons complete</span>
+              <span className="font-bold text-primary">{progressPercent}%</span>
+            </div>
+            <ProgressBar value={progressPercent} />
           </div>
-          <ProgressBar value={progressPercent} />
         </div>
-      </div>
+      ) : null}
 
       {/* Scrollable lesson list */}
       <div className="flex-1 overflow-y-auto py-2">

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -24,21 +24,20 @@ export const SheetTrigger = DialogPrimitive.Trigger;
 
 export function SheetContent({
   className,
+  side = "left",
   children,
   ...props
 }: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { side?: "left" | "right" }) {
-  const { side = "left" } = props as { side?: "left" | "right" };
   return (
     <DialogPrimitive.Portal>
       <DialogPrimitive.Overlay
         className={cn(
-          "fixed inset-0 z-50 bg-foreground/40 backdrop-blur-[1px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-          className,
+          "fixed inset-0 z-50 bg-foreground/40 backdrop-blur-[1px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
         )}
       />
       <DialogPrimitive.Content
         className={cn(
-          "fixed z-50 flex flex-col bg-card shadow-lg transition-all duration-300 ease-in-out",
+          "fixed z-50 flex flex-col bg-card shadow-lg transition-all duration-300 ease-in-out overflow-hidden",
           "inset-y-0 w-[280px] max-w-full",
           side === "left"
             ? "left-0 data-[state=open]:slide-in-from-left-full data-[state=closed]:slide-out-to-left-full"

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface SheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+export function Sheet({ open, onOpenChange, children }: SheetProps) {
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      {children}
+    </DialogPrimitive.Root>
+  );
+}
+
+export const SheetTrigger = DialogPrimitive.Trigger;
+
+export function SheetContent({
+  className,
+  children,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> & { side?: "left" | "right" }) {
+  const { side = "left" } = props as { side?: "left" | "right" };
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay
+        className={cn(
+          "fixed inset-0 z-50 bg-foreground/40 backdrop-blur-[1px] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          className,
+        )}
+      />
+      <DialogPrimitive.Content
+        className={cn(
+          "fixed z-50 flex flex-col bg-card shadow-lg transition-all duration-300 ease-in-out",
+          "inset-y-0 w-[280px] max-w-full",
+          side === "left"
+            ? "left-0 data-[state=open]:slide-in-from-left-full data-[state=closed]:slide-out-to-left-full"
+            : "right-0 data-[state=open]:slide-in-from-right-full data-[state=closed]:slide-out-to-right-full",
+          className,
+        )}
+        style={{ maxHeight: "100vh" }}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-3 top-3 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  );
+}
+
+export function SheetHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("shrink-0 border-b border-border px-[18px] pt-4 pb-3", className)}
+      {...props}
+    />
+  );
+}
+
+export function SheetTitle({
+  className,
+  ...props
+}: React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      className={cn("font-display text-[13.5px] font-bold leading-tight tracking-tight text-foreground", className)}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Makes the student-facing UI mobile-friendly.

### Changes

**Course sidebar (lesson pages)**
- Desktop: always visible on the left (unchanged)
- Mobile: FAB button (bottom-right) opens slide-out sheet from right
- Sheet uses Radix Dialog portal with slide animation
- Close via X button, backdrop tap, or nav to lesson

**Header nav**
- Desktop: horizontal links (unchanged)
- Mobile: hamburger icon opens right-side panel with all nav items
- Parish switcher shown in mobile menu footer
- Logo text hidden on mobile
- "Courses" nav link removed (replaced by "View all" on dashboard)

**Courses page** ()
- Thumbnail and text sizes scale down on mobile
- Description hidden on xs screens, shown on sm+

**Dashboard**
- "View all" link next to "Your courses" section → 

### New files
-  — client component for responsive header
-  — wraps sidebar with mobile FAB + sheet
-  — Radix Dialog-based sheet primitive

### Tests
- typecheck: ✅
- lint: ✅ (24 pre-existing warnings, 0 new)
- tests: ✅ 173/173 passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared navigation/layout and lesson-page sidebar behavior; regressions could impact navigation usability on both desktop and mobile, though changes are mostly UI-level.
> 
> **Overview**
> Makes the student app UI more mobile-friendly by moving the app header into a new client component (`AppHeaderClient`) that adds a hamburger-driven mobile menu, hides the logo text on small screens, and drops the top-level `Courses` nav link.
> 
> Updates lesson pages to use a new `CourseSidebarClient` wrapper that keeps the sidebar visible on desktop but exposes it on mobile via a floating action button and a slide-out `Sheet` (new Radix Dialog-based primitive). Also includes responsive/layout tweaks across catalog, courses list, and dashboard cards (e.g., `overflow-hidden`, single-column grids on mobile, adjusted spacing/typography) and adds a dashboard "View all" link to `/app/courses`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03c264d8278bad4ad8222f76b6c90dc110eff15a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->