### PR TITLE
feat: lesson completion modal + course certificates (#11)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@react-pdf/renderer": "^4.5.1",
         "@supabase/supabase-js": "^2.95.3",
         "@tanstack/react-query": "^5.90.20",
         "@tanstack/react-query-devtools": "^5.91.3",
@@ -1304,7 +1305,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3026,6 +3026,30 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3748,6 +3772,183 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
+    },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.3.tgz",
+      "integrity": "sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.8.tgz",
+      "integrity": "sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/types": "^2.11.1",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.1.0.tgz",
+      "integrity": "sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/svg": "^1.1.0",
+        "jay-peg": "^1.1.1",
+        "png-js": "^2.0.0"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.6.1.tgz",
+      "integrity": "sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/image": "^3.1.0",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-5.1.1.tgz",
+      "integrity": "sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@noble/ciphers": "^1.0.0",
+        "@noble/hashes": "^1.6.0",
+        "browserify-zlib": "^0.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "js-md5": "^0.8.3",
+        "linebreak": "^1.1.0",
+        "png-js": "^2.0.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.3.0.tgz",
+      "integrity": "sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-2.0.0.tgz",
+      "integrity": "sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.5.1.tgz",
+      "integrity": "sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/textkit": "^6.3.0",
+        "@react-pdf/types": "^2.11.1",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^2.1.4",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.5.1.tgz",
+      "integrity": "sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/layout": "^4.6.1",
+        "@react-pdf/pdfkit": "^5.1.1",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/reconciler": "^2.0.0",
+        "@react-pdf/render": "^4.5.1",
+        "@react-pdf/types": "^2.11.1",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.2.1.tgz",
+      "integrity": "sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "@react-pdf/types": "^2.11.1",
+        "color-string": "^2.1.4",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/svg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/svg/-/svg-1.1.0.tgz",
+      "integrity": "sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/primitives": "^4.3.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.3.0.tgz",
+      "integrity": "sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.3",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.11.1.tgz",
+      "integrity": "sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.8",
+        "@react-pdf/primitives": "^4.3.0",
+        "@react-pdf/stylesheet": "^6.2.1"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
@@ -6219,6 +6420,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -6573,6 +6780,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -6586,7 +6813,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -6636,6 +6862,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -6806,6 +7050,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -6843,6 +7096,27 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -7103,6 +7377,12 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -7163,6 +7443,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -7875,6 +8161,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -7889,7 +8184,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -7993,6 +8287,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -8056,6 +8356,23 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -8420,6 +8737,21 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -8467,6 +8799,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/hyphen": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.14.1.tgz",
+      "integrity": "sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==",
+      "license": "ISC"
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
@@ -8523,6 +8861,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -8915,6 +9259,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -9032,6 +9382,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -9051,11 +9410,16 @@
         "node": ">=14"
       }
     },
+    "node_modules/js-md5": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.8.3.tgz",
+      "integrity": "sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -9478,6 +9842,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -9505,7 +9888,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -9611,6 +9993,12 @@
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -9863,6 +10251,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
     "node_modules/npm-normalize-package-bin": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
@@ -9876,7 +10273,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10074,6 +10470,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -10086,6 +10488,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -10199,6 +10607,14 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/png-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-2.0.0.tgz",
+      "integrity": "sha512-GdzJuUMc6ZSpxFJWVxtOH1bzYHym+TOnveqUjb+VJIbZWbZzyiRGFiKhbiielfpYbgMlhHVhsJ0FTazfuRFkMA==",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -10237,6 +10653,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -10299,7 +10721,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -10315,6 +10736,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -10379,7 +10809,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {
@@ -10532,7 +10961,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10578,6 +11006,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -10678,6 +11112,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -11027,6 +11481,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -11278,6 +11741,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
+    },
     "node_modules/swr": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
@@ -11353,6 +11822,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -12201,6 +12676,32 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -12329,6 +12830,12 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
@@ -12402,6 +12909,20 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/vite/node_modules/fdir": {
@@ -12784,6 +13305,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@react-pdf/renderer": "^4.5.1",
     "@supabase/supabase-js": "^2.95.3",
     "@tanstack/react-query": "^5.90.20",
     "@tanstack/react-query-devtools": "^5.91.3",

--- a/src/app/api/certificates/[certId]/pdf/route.tsx
+++ b/src/app/api/certificates/[certId]/pdf/route.tsx
@@ -49,10 +49,8 @@ export async function GET(
 
   // Generate PDF
   const pdfBuffer = await renderToBuffer(<CertificateDocument data={data} />);
-  const pdfBase64 = Buffer.from(pdfBuffer).toString("base64");
-  const pdfDataUrl = `data:application/pdf;base64,${pdfBase64}`;
 
-  return new NextResponse(pdfBase64, {
+  return new NextResponse(pdfBuffer, {
     headers: {
       "Content-Type": "application/pdf",
       "Content-Disposition": `inline; filename="certificate-${certId}.pdf"`,

--- a/src/app/api/certificates/[certId]/pdf/route.tsx
+++ b/src/app/api/certificates/[certId]/pdf/route.tsx
@@ -1,0 +1,63 @@
+import { renderToBuffer } from "@react-pdf/renderer";
+import { NextResponse } from "next/server";
+
+import { requireAuth } from "@/lib/authz";
+import { getCertificatePdfData } from "@/lib/repositories/certificates";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import { CertificateDocument } from "@/lib/certificates/certificate-pdf";
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ certId: string }> },
+) {
+  const clerkUserId = await requireAuth();
+  const { certId } = await params;
+  const supabase = getSupabaseAdminClient();
+
+  // Verify the user owns this certificate
+  const { data: cert } = await supabase
+    .from("certificates")
+    .select("id, clerk_user_id, course_id, issued_at")
+    .eq("id", certId)
+    .single();
+
+  if (!cert || cert.clerk_user_id !== clerkUserId) {
+    return NextResponse.json({ error: "Certificate not found" }, { status: 404 });
+  }
+
+  const c = cert as { id: string; clerk_user_id: string; course_id: string; issued_at: string };
+
+  // Get full PDF data
+  const pdfData = await getCertificatePdfData(certId);
+  if (!pdfData) {
+    return NextResponse.json({ error: "Could not load certificate data" }, { status: 500 });
+  }
+
+  // Get lesson count for this course
+  const { data: modules } = await supabase
+    .from("modules")
+    .select("id")
+    .eq("course_id", c.course_id);
+  const moduleIds = ((modules ?? []) as Array<{ id: string }>).map((m) => m.id);
+  const { data: lessons } = await supabase
+    .from("lessons")
+    .select("id")
+    .in("module_id", moduleIds);
+  const lessonCount = (lessons ?? []).length;
+
+  const data = { ...pdfData, courseLessonCount: lessonCount };
+
+  // Generate PDF
+  const pdfBuffer = await renderToBuffer(<CertificateDocument data={data} />);
+  const pdfBase64 = Buffer.from(pdfBuffer).toString("base64");
+  const pdfDataUrl = `data:application/pdf;base64,${pdfBase64}`;
+
+  return new NextResponse(pdfBase64, {
+    headers: {
+      "Content-Type": "application/pdf",
+      "Content-Disposition": `inline; filename="certificate-${certId}.pdf"`,
+      "X-Content-Type-Options": "nosniff",
+      "Cache-Control": "private, max-age=3600",
+    },
+  });
+}

--- a/src/app/api/certificates/[certId]/pdf/route.tsx
+++ b/src/app/api/certificates/[certId]/pdf/route.tsx
@@ -50,7 +50,7 @@ export async function GET(
   // Generate PDF
   const pdfBuffer = await renderToBuffer(<CertificateDocument data={data} />);
 
-  return new NextResponse(pdfBuffer, {
+  return new NextResponse(new Uint8Array(pdfBuffer), {
     headers: {
       "Content-Type": "application/pdf",
       "Content-Disposition": `inline; filename="certificate-${certId}.pdf"`,

--- a/src/app/api/quiz-attempt/__tests__/route.test.ts
+++ b/src/app/api/quiz-attempt/__tests__/route.test.ts
@@ -13,10 +13,16 @@ vi.mock("@/lib/supabase/server", () => ({
 
 vi.mock("@/lib/repositories/lessons", () => ({
   isUserEnrolledForLesson: vi.fn(),
+  getCourseIdForLesson: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/certificates", () => ({
+  checkAndIssueCertificate: vi.fn(),
 }));
 
 import { requireAuth, requireParishRole } from "@/lib/authz";
-import { isUserEnrolledForLesson } from "@/lib/repositories/lessons";
+import { isUserEnrolledForLesson, getCourseIdForLesson } from "@/lib/repositories/lessons";
+import { checkAndIssueCertificate } from "@/lib/repositories/certificates";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import { POST } from "@/app/api/quiz-attempt/route";
 
@@ -30,6 +36,8 @@ describe("POST /api/quiz-attempt", () => {
       role: "student",
     });
     vi.mocked(isUserEnrolledForLesson).mockResolvedValue(true);
+    vi.mocked(getCourseIdForLesson).mockResolvedValue("22222222-2222-4222-8222-222222222222");
+    vi.mocked(checkAndIssueCertificate).mockResolvedValue(null);
   });
 
   it("grades and stores quiz attempts", async () => {
@@ -63,7 +71,8 @@ describe("POST /api/quiz-attempt", () => {
     );
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true, score: 50, total: 2 });
+    const json = await response.json();
+    expect(json).toMatchObject({ ok: true, score: 50, total: 2, certificateId: null });
     expect(insert).toHaveBeenCalledWith({
       parish_id: "11111111-1111-4111-8111-111111111111",
       clerk_user_id: "user-1",

--- a/src/app/api/quiz-attempt/route.ts
+++ b/src/app/api/quiz-attempt/route.ts
@@ -4,9 +4,10 @@ import { E2E_LESSON, E2E_QUESTIONS } from "@/lib/e2e-fixtures";
 import { requireAuth, requireParishRole } from "@/lib/authz";
 import { isE2ESmokeMode } from "@/lib/e2e-mode";
 import { gradeQuiz } from "@/lib/grading";
-import { isUserEnrolledForLesson } from "@/lib/repositories/lessons";
+import { getCourseIdForLesson, isUserEnrolledForLesson } from "@/lib/repositories/lessons";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import { quizSubmissionSchema } from "@/lib/validation/quiz";
+import { checkAndIssueCertificate } from "@/lib/repositories/certificates";
 
 export async function POST(req: Request) {
   const clerkUserId = await requireAuth();
@@ -67,5 +68,13 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: error.message }, { status: 400 });
   }
 
-  return NextResponse.json({ ok: true, score: grade.score, total: grade.total });
+  // Check for course completion and issue certificate if all lessons done
+  const courseId = await getCourseIdForLesson(payload.lessonId);
+  let certificateId: string | null = null;
+  if (courseId) {
+    const cert = await checkAndIssueCertificate({ clerkUserId, parishId, courseId });
+    certificateId = cert?.id ?? null;
+  }
+
+  return NextResponse.json({ ok: true, score: grade.score, total: grade.total, certificateId });
 }

--- a/src/app/app/certificates/[certId]/page.tsx
+++ b/src/app/app/certificates/[certId]/page.tsx
@@ -1,0 +1,63 @@
+import { notFound } from "next/navigation";
+
+import { requireParishRole } from "@/lib/authz";
+import { getCertificatePdfData } from "@/lib/repositories/certificates";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import { listStudentCertificates } from "@/lib/repositories/certificates";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import Link from "next/link";
+
+export default async function CertificateDetailPage({
+  params,
+}: {
+  params: Promise<{ certId: string }>;
+}) {
+  const { certId } = await params;
+  const { clerkUserId, parishId } = await requireParishRole("student");
+
+  // Verify ownership
+  const certs = await listStudentCertificates(clerkUserId, parishId);
+  const cert = certs.find((c) => c.id === certId);
+  if (!cert) notFound();
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">{cert.course_title}</h1>
+          <p className="text-sm text-muted-foreground">
+            Issued {cert.completion_date} · {cert.parish_name}
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button asChild variant="outline">
+            <a href={`/api/certificates/${certId}/pdf`} target="_blank" rel="noopener noreferrer">
+              Download PDF
+            </a>
+          </Button>
+          <Button asChild variant="ghost">
+            <Link href="/app/certificates">← All Certificates</Link>
+          </Button>
+        </div>
+      </div>
+
+      {/* Inline PDF preview */}
+      <Card className="overflow-hidden">
+        <div className="relative" style={{ minHeight: "500px" }}>
+          <iframe
+            src={`/api/certificates/${certId}/pdf`}
+            className="h-[700px] w-full"
+            title={`Certificate: ${cert.course_title}`}
+          />
+        </div>
+      </Card>
+
+      <div className="text-center">
+        <p className="text-xs text-muted-foreground">
+          {cert.lesson_count} lessons completed · Certificate ID: {certId.slice(0, 8).toUpperCase()}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/app/certificates/page.tsx
+++ b/src/app/app/certificates/page.tsx
@@ -1,0 +1,75 @@
+import Link from "next/link";
+
+import { requireParishRole } from "@/lib/authz";
+import { listStudentCertificates } from "@/lib/repositories/certificates";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default async function CertificatesPage() {
+  const { clerkUserId, parishId } = await requireParishRole("student");
+  const certs = await listStudentCertificates(clerkUserId, parishId);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">My Certificates</h1>
+        <p className="text-sm text-muted-foreground">
+          Download and print your course completion certificates.
+        </p>
+      </header>
+
+      {certs.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center">
+            <div className="mb-4 text-5xl">📜</div>
+            <p className="mb-1 font-medium">No certificates yet</p>
+            <p className="text-sm text-muted-foreground">
+              Complete all lessons in a course to earn your first certificate.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {certs.map((cert) => (
+            <Card key={cert.id} className="hover:bg-secondary/50 transition-colors">
+              <CardHeader className="pb-3">
+                <CardTitle className="text-base">{cert.course_title}</CardTitle>
+                <p className="text-xs text-muted-foreground">{cert.parish_name}</p>
+              </CardHeader>
+              <CardContent>
+                <p className="mb-3 text-xs text-muted-foreground">
+                  Issued {cert.completion_date}
+                </p>
+                <div className="flex gap-2">
+                  <Link
+                    className="flex-1"
+                    href={`/app/certificates/${cert.id}`}
+                  >
+                    <button
+                      className="w-full rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                      type="button"
+                    >
+                      View Certificate
+                    </button>
+                  </Link>
+                  <a
+                    className="flex-shrink-0"
+                    href={`/api/certificates/${cert.id}/pdf`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <button
+                      className="rounded-md border border-border px-3 py-2 text-xs font-medium text-foreground hover:bg-secondary"
+                      type="button"
+                    >
+                      ↓ PDF
+                    </button>
+                  </a>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/app/lessons/[lessonId]/page.tsx
+++ b/src/app/app/lessons/[lessonId]/page.tsx
@@ -150,6 +150,7 @@ export default async function LessonPage({
             <QuizForm
               courseTitle={courseTree?.course.title}
               lessonId={lesson.id}
+              lessonTitle={lesson.title}
               nextLesson={navContext?.nextLesson ?? null}
               parishId={parishId}
               questions={(lesson.questions ?? []).map((q: { id: string; prompt: string; options: unknown }) => ({

--- a/src/app/app/lessons/[lessonId]/page.tsx
+++ b/src/app/app/lessons/[lessonId]/page.tsx
@@ -148,6 +148,7 @@ export default async function LessonPage({
           {/* Quiz */}
           <div className="mt-6 px-8">
             <QuizForm
+              courseTitle={courseTree?.course.title}
               lessonId={lesson.id}
               nextLesson={navContext?.nextLesson ?? null}
               parishId={parishId}

--- a/src/components/completion-modal.tsx
+++ b/src/components/completion-modal.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import Link from "next/link";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface CompletionModalProps {
+  score: number;
+  courseTitle: string;
+  lessonTitle: string;
+  nextLesson: { id: string; title: string } | null;
+  courseComplete?: boolean;
+  certificateId?: string;
+}
+
+export function CompletionModal({
+  score,
+  courseTitle,
+  lessonTitle,
+  nextLesson,
+  courseComplete = false,
+  certificateId,
+}: CompletionModalProps) {
+  return (
+    <div className="space-y-4">
+      {/* Score card */}
+      <Card className="border-success/30 bg-success-subtle">
+        <CardContent className="py-6 text-center">
+          <div className="mb-2 text-5xl font-bold text-success">{score}%</div>
+          <p className="text-sm text-muted-foreground">
+            Quiz passed
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {lessonTitle} — {courseTitle}
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Course completion */}
+      {courseComplete && (
+        <Card className="border-primary/30 bg-brand-subtle">
+          <CardContent className="py-6 text-center">
+            <div className="mb-3 text-4xl">🎉</div>
+            <p className="mb-2 font-bold text-primary">Course Complete!</p>
+            <p className="mb-4 text-sm text-muted-foreground">
+              You have finished all lessons in {courseTitle}. A certificate has been issued.
+            </p>
+            {certificateId && (
+              <Button asChild>
+                <Link href={`/app/certificates/${certificateId}`}>
+                  View & Download Certificate
+                </Link>
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Next lesson / dashboard */}
+      <div className="flex gap-3">
+        {nextLesson ? (
+          <Button asChild className="flex-1">
+            <Link href={`/app/lessons/${nextLesson.id}`}>
+              Next: {nextLesson.title} →
+            </Link>
+          </Button>
+        ) : (
+          <Button asChild className="flex-1">
+            <Link href="/app/dashboard">Back to Dashboard</Link>
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/completion-modal.tsx
+++ b/src/components/completion-modal.tsx
@@ -22,14 +22,28 @@ export function CompletionModal({
   courseComplete = false,
   certificateId,
 }: CompletionModalProps) {
+  const passed = score >= 100;
+
   return (
     <div className="space-y-4">
       {/* Score card */}
-      <Card className="border-success/30 bg-success-subtle">
+      <Card
+        className={
+          passed
+            ? "border-success/30 bg-success-subtle"
+            : "border-destructive/30 bg-destructive-subtle"
+        }
+      >
         <CardContent className="py-6 text-center">
-          <div className="mb-2 text-5xl font-bold text-success">{score}%</div>
-          <p className="text-sm text-muted-foreground">
-            Quiz passed
+          <div
+            className={`mb-2 text-5xl font-bold ${passed ? "text-success" : "text-destructive"}`}
+          >
+            {score}%
+          </div>
+          <p
+            className={`text-sm ${passed ? "text-muted-foreground" : "text-destructive"}`}
+          >
+            {passed ? "Quiz passed" : "Review the questions above and try again."}
           </p>
           <p className="mt-1 text-xs text-muted-foreground">
             {lessonTitle} — {courseTitle}
@@ -38,7 +52,7 @@ export function CompletionModal({
       </Card>
 
       {/* Course completion */}
-      {courseComplete && (
+      {courseComplete && passed && (
         <Card className="border-primary/30 bg-brand-subtle">
           <CardContent className="py-6 text-center">
             <div className="mb-3 text-4xl">🎉</div>
@@ -59,7 +73,7 @@ export function CompletionModal({
 
       {/* Next lesson / dashboard */}
       <div className="flex gap-3">
-        {nextLesson ? (
+        {passed && nextLesson ? (
           <Button asChild className="flex-1">
             <Link href={`/app/lessons/${nextLesson.id}`}>
               Next: {nextLesson.title} →

--- a/src/components/quiz-form.tsx
+++ b/src/components/quiz-form.tsx
@@ -14,12 +14,14 @@ interface Question {
 
 export function QuizForm({
   lessonId,
+  lessonTitle,
   parishId,
   questions,
   nextLesson,
   courseTitle,
 }: {
   lessonId: string;
+  lessonTitle: string;
   parishId: string;
   questions: Question[];
   nextLesson: { id: string; title: string } | null;
@@ -60,15 +62,15 @@ export function QuizForm({
     }
   };
 
-  // Show completion modal after successful submission with course context
-  if (submitted && score !== null && courseTitle) {
+  // Show completion modal after a passing score with course context
+  if (submitted && score !== null && courseTitle && score >= 100) {
     return (
       <div className="space-y-6">
         <CompletionModal
           certificateId={certificateId ?? undefined}
           courseComplete={!!certificateId}
           courseTitle={courseTitle}
-          lessonTitle={questions[0]?.prompt?.slice(0, 50) ?? "Lesson"}
+          lessonTitle={lessonTitle}
           nextLesson={nextLesson}
           score={score}
         />
@@ -200,7 +202,7 @@ export function QuizForm({
               : "Answer all questions above, then submit."}
         </span>
         <div className="flex items-center gap-2">
-          {submitted && nextLesson ? (
+          {submitted && score !== null && score >= 100 && nextLesson ? (
             <Button asChild size="sm">
               <Link href={`/app/lessons/${nextLesson.id}`}>
                 {nextLesson.title} →

--- a/src/components/quiz-form.tsx
+++ b/src/components/quiz-form.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { CompletionModal } from "@/components/completion-modal";
 
 interface Question {
   id: string;
@@ -16,16 +17,19 @@ export function QuizForm({
   parishId,
   questions,
   nextLesson,
+  courseTitle,
 }: {
   lessonId: string;
   parishId: string;
   questions: Question[];
   nextLesson: { id: string; title: string } | null;
+  courseTitle?: string;
 }) {
   const [answers, setAnswers] = useState<Record<string, number>>({});
   const [score, setScore] = useState<number | null>(null);
   const [submitted, setSubmitted] = useState(false);
   const [correctIndices, setCorrectIndices] = useState<Record<string, number>>({});
+  const [certificateId, setCertificateId] = useState<string | null>(null);
 
   if (questions.length === 0) return null;
 
@@ -43,6 +47,9 @@ export function QuizForm({
     if (response.ok) {
       setScore(data.score);
       setSubmitted(true);
+      if (data.certificateId) {
+        setCertificateId(data.certificateId);
+      }
       if (data.correctIndices) {
         const map: Record<string, number> = {};
         questions.forEach((q, i) => {
@@ -52,6 +59,22 @@ export function QuizForm({
       }
     }
   };
+
+  // Show completion modal after successful submission with course context
+  if (submitted && score !== null && courseTitle) {
+    return (
+      <div className="space-y-6">
+        <CompletionModal
+          certificateId={certificateId ?? undefined}
+          courseComplete={!!certificateId}
+          courseTitle={courseTitle}
+          lessonTitle={questions[0]?.prompt?.slice(0, 50) ?? "Lesson"}
+          nextLesson={nextLesson}
+          score={score}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/src/lib/certificates/certificate-pdf.tsx
+++ b/src/lib/certificates/certificate-pdf.tsx
@@ -1,0 +1,178 @@
+import { Document, Page, Text, View, StyleSheet, Font } from "@react-pdf/renderer";
+import type { DocumentProps } from "@react-pdf/renderer";
+
+// Register fonts (use Helvetica built-ins for reliability)
+Font.register({
+  family: "Helvetica",
+  fonts: [
+    { src: "Helvetica" },
+    { src: "Helvetica-Bold", fontWeight: 700 },
+    { src: "Helvetica-Oblique", fontStyle: "italic" },
+  ],
+});
+
+const styles = StyleSheet.create({
+  page: {
+    padding: 48,
+    fontFamily: "Helvetica",
+    fontSize: 12,
+    color: "#1a1a2e",
+  },
+  header: {
+    marginBottom: 32,
+    borderBottom: "2pt solid #6B2D8B",
+    paddingBottom: 16,
+  },
+  title: {
+    fontSize: 22,
+    fontFamily: "Helvetica",
+    fontWeight: 700,
+    color: "#6B2D8B",
+    marginBottom: 4,
+  },
+  subtitle: {
+    fontSize: 10,
+    color: "#666",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+  body: {
+    marginTop: 24,
+  },
+  awardLine: {
+    fontSize: 28,
+    fontFamily: "Helvetica",
+    fontWeight: 700,
+    color: "#1a1a2e",
+    textAlign: "center",
+    marginBottom: 4,
+  },
+  awardSub: {
+    fontSize: 13,
+    color: "#555",
+    textAlign: "center",
+    marginBottom: 36,
+  },
+  certText: {
+    fontSize: 11,
+    color: "#333",
+    lineHeight: 1.8,
+    marginBottom: 6,
+  },
+  certLabel: {
+    fontSize: 9,
+    color: "#888",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginBottom: 2,
+  },
+  certValue: {
+    fontSize: 13,
+    color: "#1a1a2e",
+    marginBottom: 16,
+  },
+  certValueLarge: {
+    fontSize: 18,
+    fontFamily: "Helvetica",
+    fontWeight: 700,
+    color: "#1a1a2e",
+    marginBottom: 20,
+  },
+  divider: {
+    borderBottom: "0.5pt solid #ddd",
+    marginVertical: 24,
+  },
+  footer: {
+    position: "absolute",
+    bottom: 40,
+    left: 48,
+    right: 48,
+    borderTop: "0.5pt solid #ddd",
+    paddingTop: 12,
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  footerText: {
+    fontSize: 8,
+    color: "#aaa",
+  },
+  seal: {
+    position: "absolute",
+    right: 48,
+    bottom: 100,
+    width: 64,
+    height: 64,
+    borderRadius: 32,
+    border: "2pt solid #6B2D8B",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  sealText: {
+    fontSize: 8,
+    color: "#6B2D8B",
+    textAlign: "center",
+    fontFamily: "Helvetica",
+    fontWeight: 700,
+  },
+});
+
+export interface CertificateData {
+  studentName: string;
+  courseTitle: string;
+  parishName: string;
+  completionDate: string; // formatted date string
+  courseLessonCount: number;
+}
+
+type CertificateDocumentProps = DocumentProps & { data: CertificateData };
+
+export function CertificateDocument({ data }: CertificateDocumentProps) {
+  return (
+    <Document>
+      <Page size="A4" orientation="landscape" style={styles.page}>
+        {/* Header */}
+        <View style={styles.header} fixed>
+          <Text style={styles.subtitle}>Western Diocese of the Armenian Church</Text>
+          <Text style={styles.title}>Certificate of Completion</Text>
+        </View>
+
+        {/* Award body */}
+        <View style={styles.body}>
+          <Text style={styles.awardLine}>This certifies that</Text>
+          <Text style={styles.awardSub}>{data.studentName}</Text>
+
+          <Text style={styles.certText}>
+            has successfully completed all lessons in the course
+          </Text>
+          <Text style={styles.certValueLarge}>{data.courseTitle}</Text>
+
+          <View style={styles.divider} />
+
+          <Text style={styles.certLabel}>Parish</Text>
+          <Text style={styles.certValue}>{data.parishName}</Text>
+
+          <Text style={styles.certLabel}>Completion Date</Text>
+          <Text style={styles.certValue}>{data.completionDate}</Text>
+
+          <Text style={styles.certLabel}>Total Lessons Completed</Text>
+          <Text style={styles.certValue}>{data.courseLessonCount}</Text>
+        </View>
+
+        {/* Decorative seal */}
+        <View style={styles.seal}>
+          <Text style={styles.sealText}>WD{'\n'}CERTIFIED</Text>
+        </View>
+
+        {/* Footer */}
+        <View style={styles.footer} fixed>
+          <Text style={styles.footerText}>
+            St. John Armenian Apostolic Church Learning System
+          </Text>
+          <Text style={styles.footerText}>
+            Issued: {data.completionDate}
+          </Text>
+        </View>
+      </Page>
+    </Document>
+  );
+}

--- a/src/lib/repositories/certificates.ts
+++ b/src/lib/repositories/certificates.ts
@@ -76,7 +76,7 @@ export async function checkAndIssueCertificate({
   const { data: lessons } = await supabase
     .from("lessons")
     .select("id")
-    .eq("module_id", moduleIds);
+    .in("module_id", moduleIds);
 
   const lessonIds = ((lessons ?? []) as Array<{ id: string }>).map((l) => l.id);
   if (lessonIds.length === 0) return null;

--- a/src/lib/repositories/certificates.ts
+++ b/src/lib/repositories/certificates.ts
@@ -1,0 +1,213 @@
+import { E2E_COURSE } from "@/lib/e2e-fixtures";
+import { isE2ESmokeMode } from "@/lib/e2e-mode";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import type { CertificateData } from "@/lib/certificates/certificate-pdf";
+
+export interface CertificateRecord {
+  id: string;
+  clerk_user_id: string;
+  parish_id: string;
+  course_id: string;
+  issued_at: string;
+  download_url: string | null;
+}
+
+export interface CertificateWithDetails extends CertificateRecord {
+  course_title: string;
+  parish_name: string;
+  student_name: string;
+  completion_date: string;
+  lesson_count: number;
+}
+
+async function getParishName(parishId: string): Promise<string> {
+  const supabase = getSupabaseAdminClient();
+  const { data } = await supabase
+    .from("parishes")
+    .select("name")
+    .eq("id", parishId)
+    .single();
+  return (data as { name: string } | null)?.name ?? "Unknown Parish";
+}
+
+async function getStudentName(clerkUserId: string): Promise<string> {
+  const supabase = getSupabaseAdminClient();
+  const { data } = await supabase
+    .from("user_profiles")
+    .select("display_name")
+    .eq("clerk_user_id", clerkUserId)
+    .maybeSingle();
+  return (data as { display_name: string } | null)?.display_name ?? clerkUserId;
+}
+
+export async function checkAndIssueCertificate({
+  clerkUserId,
+  parishId,
+  courseId,
+}: {
+  clerkUserId: string;
+  parishId: string;
+  courseId: string;
+}): Promise<CertificateRecord | null> {
+  if (isE2ESmokeMode()) return null;
+
+  const supabase = getSupabaseAdminClient();
+
+  // Check if certificate already exists
+  const { data: existing } = await supabase
+    .from("certificates")
+    .select("id")
+    .eq("clerk_user_id", clerkUserId)
+    .eq("parish_id", parishId)
+    .eq("course_id", courseId)
+    .maybeSingle();
+
+  if (existing) return existing as CertificateRecord;
+
+  // Verify all lessons in course are completed
+  const { data: modules } = await supabase
+    .from("modules")
+    .select("id")
+    .eq("course_id", courseId);
+
+  const moduleIds = ((modules ?? []) as Array<{ id: string }>).map((m) => m.id);
+  if (moduleIds.length === 0) return null;
+
+  const { data: lessons } = await supabase
+    .from("lessons")
+    .select("id")
+    .eq("module_id", moduleIds);
+
+  const lessonIds = ((lessons ?? []) as Array<{ id: string }>).map((l) => l.id);
+  if (lessonIds.length === 0) return null;
+
+  const { data: progressRows } = await supabase
+    .from("video_progress")
+    .select("lesson_id, completed")
+    .eq("parish_id", parishId)
+    .eq("clerk_user_id", clerkUserId)
+    .in("lesson_id", lessonIds)
+    .eq("completed", true);
+
+  const completedLessonIds = new Set(((progressRows ?? []) as Array<{ lesson_id: string }>).map((p) => p.lesson_id));
+  const allDone = lessonIds.every((id) => completedLessonIds.has(id));
+
+  if (!allDone) return null;
+
+  // All lessons complete — issue certificate
+  const { data: cert, error } = await supabase
+    .from("certificates")
+    .insert({
+      clerk_user_id: clerkUserId,
+      parish_id: parishId,
+      course_id: courseId,
+      download_url: null, // URL set when PDF is generated
+    })
+    .select("id, clerk_user_id, parish_id, course_id, issued_at, download_url")
+    .single();
+
+  if (error) return null;
+  return cert as CertificateRecord;
+}
+
+export async function listStudentCertificates(
+  clerkUserId: string,
+  parishId: string,
+): Promise<CertificateWithDetails[]> {
+  if (isE2ESmokeMode()) return [];
+
+  const supabase = getSupabaseAdminClient();
+  const { data, error } = await supabase
+    .from("certificates")
+    .select("id, clerk_user_id, parish_id, course_id, issued_at, download_url")
+    .eq("clerk_user_id", clerkUserId)
+    .eq("parish_id", parishId)
+    .order("issued_at", { ascending: false });
+
+  if (error || !data) return [];
+
+  const certs = data as CertificateRecord[];
+
+  // Enrich with course title and parish name
+  const courseIds = [...new Set(certs.map((c) => c.course_id))];
+  const { data: courseRows } = await supabase
+    .from("courses")
+    .select("id, title")
+    .in("id", courseIds);
+  const courseMap = new Map(
+    ((courseRows ?? []) as Array<{ id: string; title: string }>).map((c) => [c.id, c.title]),
+  );
+
+  const parishName = await getParishName(parishId);
+  const studentName = await getStudentName(clerkUserId);
+
+  // Get lesson counts
+  const { data: allModules } = await supabase
+    .from("modules")
+    .select("id, course_id")
+    .in("course_id", courseIds);
+  const modulesByCourse = new Map<string, string[]>();
+  for (const m of (allModules ?? []) as Array<{ id: string; course_id: string }>) {
+    if (!modulesByCourse.has(m.course_id)) modulesByCourse.set(m.course_id, []);
+    modulesByCourse.get(m.course_id)!.push(m.id);
+  }
+  const { data: allLessons } = await supabase
+    .from("lessons")
+    .select("id, module_id")
+    .in("module_id", [...new Set(((allModules ?? []) as Array<{ id: string }>).map((m) => m.id))]);
+  const lessonCountByCourse = new Map<string, number>();
+  for (const [cid, mids] of modulesByCourse) {
+    const mLessons = ((allLessons ?? []) as Array<{ module_id: string }>).filter((l) => mids.includes(l.module_id));
+    lessonCountByCourse.set(cid, mLessons.length);
+  }
+
+  return certs.map((cert) => ({
+    ...cert,
+    course_title: courseMap.get(cert.course_id) ?? "Unknown Course",
+    parish_name: parishName,
+    student_name: studentName,
+    completion_date: new Date(cert.issued_at).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    }),
+    lesson_count: lessonCountByCourse.get(cert.course_id) ?? 0,
+  }));
+}
+
+export async function getCertificatePdfData(
+  certId: string,
+): Promise<CertificateData | null> {
+  if (isE2ESmokeMode()) return null;
+
+  const supabase = getSupabaseAdminClient();
+  const { data: cert } = await supabase
+    .from("certificates")
+    .select("clerk_user_id, parish_id, course_id, issued_at")
+    .eq("id", certId)
+    .single();
+
+  if (!cert) return null;
+  const c = cert as { clerk_user_id: string; parish_id: string; course_id: string; issued_at: string };
+
+  const [parishName, studentName, courseRow] = await Promise.all([
+    getParishName(c.parish_id),
+    getStudentName(c.clerk_user_id),
+    supabase.from("courses").select("title").eq("id", c.course_id).single(),
+  ]);
+
+  const courseTitle = (courseRow.data as { title: string } | null)?.title ?? "Unknown Course";
+  const completionDate = new Date(c.issued_at).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+  return {
+    studentName,
+    courseTitle,
+    parishName,
+    completionDate,
+    courseLessonCount: 0, // filled by caller or enriched via lesson count
+  };
+}

--- a/supabase/migrations/0011_certificates.sql
+++ b/supabase/migrations/0011_certificates.sql
@@ -1,0 +1,44 @@
+-- Migration: Course certificates
+-- Tracks issued certificates for course completions and serves as
+-- the record of completion for audit/verification purposes.
+
+create table if not exists certificates (
+  id uuid primary key default gen_random_uuid(),
+  clerk_user_id text not null,
+  parish_id uuid not null references parishes(id) on delete cascade,
+  course_id uuid not null references courses(id) on delete cascade,
+  issued_at timestamptz not null default now(),
+  download_url text,
+  unique (course_id, clerk_user_id, parish_id)
+);
+
+create index if not exists certificates_parish_id_idx on certificates (parish_id);
+create index if not exists certificates_clerk_user_id_idx on certificates (clerk_user_id);
+create index if not exists certificates_course_id_idx on certificates (course_id);
+
+alter table certificates enable row level security;
+
+-- Students and parish admins can see certificates for their own enrollments
+create policy "students_can_view_own_certificates" on certificates
+  for select using (
+    auth.uid() = clerk_user_id
+    or exists (
+      select 1 from parish_memberships
+      where parish_memberships.clerk_user_id = auth.uid()
+        and parish_memberships.parish_id = certificates.parish_id
+        and parish_memberships.role in ('parish_admin', 'diocesan_admin')
+    )
+  );
+
+create policy "parish_admins_can_manage_own_certificates" on certificates
+  for all using (
+    exists (
+      select 1 from parish_memberships
+      where parish_memberships.clerk_user_id = auth.uid()
+        and parish_memberships.parish_id = certificates.parish_id
+        and parish_memberships.role in ('parish_admin', 'diocesan_admin')
+    )
+  );
+
+-- Tracking column on enrollments to prevent duplicate completion emails
+alter table enrollments add column if not exists completion_email_sent_at timestamptz;


### PR DESCRIPTION
## Summary

Issue #11: Lesson completion modal + course certificate PDF generation

### What changed

**DB Migration (0011_certificates.sql)**
- New certificates table — unique per (course_id, clerk_user_id, parish_id)
- RLS policies: students can view own certs; parish admins can manage
- Added completion_email_sent_at column on enrollments (prep for phase 3)

**Certificate issuance** (lib/repositories/certificates.ts)
- checkAndIssueCertificate() — checks all lessons in course complete via video_progress, inserts certificate record if not already issued

**Quiz completion flow** (api/quiz-attempt/route.ts)
- After quiz grading, call checkAndIssueCertificate() with (clerkUserId, parishId, courseId)
- Return certificateId in JSON response when certificate was issued

**PDF generation** (api/certificates/[certId]/pdf/route.tsx)
- @react-pdf/renderer renderToBuffer for server-side PDF generation
- Returns application/pdf with Content-Disposition: inline
- Verified: student owns the certificate via RLS check

**UI pages**
- /app/certificates — card grid of all student certificates with PDF download button
- /app/certificates/[certId] — iframe PDF preview + download button
- CompletionModal component replaces quiz feedback summary with score + next lesson + certificate link when course completed

**Migration to apply:** supabase db push

## Testing
- npm run typecheck — clean
- npm run lint — 0 errors, 28 warnings (pre-existing)
- npm test — 173 passed

Closes #11

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new certificate issuance and PDF-serving endpoints backed by a new `certificates` table with RLS, which touches persistence and authorization paths. Risk is mainly around correctness of completion checks and access control for viewing/downloading certificates.
> 
> **Overview**
> Adds course completion **certificates**: a new `certificates` table + RLS policies, and repository logic to issue a certificate once all lessons in a course are marked completed.
> 
> Updates the quiz submission API to opportunistically call `checkAndIssueCertificate()` after storing an attempt and return a `certificateId` in the response when a certificate exists/was created.
> 
> Introduces server-side PDF generation via `@react-pdf/renderer` with a new `/api/certificates/[certId]/pdf` route (ownership-checked) plus new `/app/certificates` pages and a `CompletionModal` shown after a passing quiz to link users to their certificate download/preview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 801b7a67d73506fd71df32de9b403bd10c827243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->