### PR TITLE
feat: Resend email provider + all transactional email triggers (#26)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-hook-form": "^7.71.1",
+        "resend": "^6.12.2",
         "supabase": "^2.95.6",
         "tailwind-merge": "^3.4.0",
         "zod": "^4.3.6"
@@ -10625,6 +10626,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -10964,6 +10971,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.2.tgz",
+      "integrity": "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {
@@ -11746,6 +11774,16 @@
       "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
       "license": "ISC"
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
+      }
     },
     "node_modules/swr": {
       "version": "2.3.4",
@@ -12835,6 +12873,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/vite": {
       "version": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.1",
+    "resend": "^6.12.2",
     "supabase": "^2.95.6",
     "tailwind-merge": "^3.4.0",
     "zod": "^4.3.6"

--- a/src/app/api/admin/enrollments/route.ts
+++ b/src/app/api/admin/enrollments/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { requireDioceseAdmin } from "@/lib/authz";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import { notifyEnrollmentConfirmed } from "@/lib/parish-communications/notifications";
 
 const createEnrollmentSchema = z.object({
   parishId: z.string().uuid(),
@@ -63,6 +64,13 @@ export async function POST(req: Request) {
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 400 });
   }
+
+  // Send enrollment confirmation email (non-blocking)
+  notifyEnrollmentConfirmed({
+    clerkUserId: payload.clerkUserId,
+    parishId: payload.parishId,
+    courseId: payload.courseId,
+  }).catch((err) => console.error("[notifications] diocese enrollment confirmed email failed:", err));
 
   return NextResponse.json({ enrollment: data }, { status: 201 });
 }

--- a/src/app/api/parish-admin/course-join-requests/[requestId]/approve/route.ts
+++ b/src/app/api/parish-admin/course-join-requests/[requestId]/approve/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { requireParishRole } from "@/lib/authz";
 import { approveJoinRequest } from "@/lib/repositories/course-join-requests";
+import { notifyJoinRequestApproved } from "@/lib/parish-communications/notifications";
 
 const paramsSchema = z.object({
   requestId: z.string().uuid(),
@@ -12,11 +13,32 @@ export async function POST(
   _req: Request,
   { params }: { params: Promise<{ requestId: string }> }
 ) {
-  const { clerkUserId, parishId: _parishId } = await requireParishRole("parish_admin");
+  const { clerkUserId, parishId } = await requireParishRole("parish_admin");
   const { requestId } = paramsSchema.parse(await params);
+
+  // Get request details before approving (need course_id for notification)
+  const { getSupabaseAdminClient } = await import("@/lib/supabase/server");
+  const supabase = getSupabaseAdminClient();
+  const { data: requestRow } = await supabase
+    .from("course_join_requests")
+    .select("clerk_user_id, course_id")
+    .eq("id", requestId)
+    .eq("status", "PENDING")
+    .single();
 
   try {
     await approveJoinRequest({ requestId, actorClerkUserId: clerkUserId });
+
+    // Send notification email (non-blocking - don't fail the request if email fails)
+    if (requestRow) {
+      const req = requestRow as { clerk_user_id: string; course_id: string };
+      notifyJoinRequestApproved({
+        clerkUserId: req.clerk_user_id,
+        parishId,
+        courseId: req.course_id,
+      }).catch((err) => console.error("[notifications] join request approved email failed:", err));
+    }
+
     return NextResponse.json({ ok: true });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/src/app/api/parish-admin/course-join-requests/[requestId]/reject/route.ts
+++ b/src/app/api/parish-admin/course-join-requests/[requestId]/reject/route.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { requireParishRole } from "@/lib/authz";
 import { rejectJoinRequest } from "@/lib/repositories/course-join-requests";
+import { notifyJoinRequestRejected } from "@/lib/parish-communications/notifications";
 
 const paramsSchema = z.object({
   requestId: z.string().uuid(),
@@ -12,11 +13,32 @@ export async function POST(
   _req: Request,
   { params }: { params: Promise<{ requestId: string }> }
 ) {
-  const { clerkUserId, parishId: _parishId } = await requireParishRole("parish_admin");
+  const { clerkUserId, parishId } = await requireParishRole("parish_admin");
   const { requestId } = paramsSchema.parse(await params);
+
+  // Get request details before rejecting (need course_id for notification)
+  const { getSupabaseAdminClient } = await import("@/lib/supabase/server");
+  const supabase = getSupabaseAdminClient();
+  const { data: requestRow } = await supabase
+    .from("course_join_requests")
+    .select("clerk_user_id, course_id")
+    .eq("id", requestId)
+    .eq("status", "PENDING")
+    .single();
 
   try {
     await rejectJoinRequest({ requestId, actorClerkUserId: clerkUserId });
+
+    // Send notification email (non-blocking)
+    if (requestRow) {
+      const req = requestRow as { clerk_user_id: string; course_id: string };
+      notifyJoinRequestRejected({
+        clerkUserId: req.clerk_user_id,
+        parishId,
+        courseId: req.course_id,
+      }).catch((err) => console.error("[notifications] join request rejected email failed:", err));
+    }
+
     return NextResponse.json({ ok: true });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";

--- a/src/app/api/parish-admin/enrollments/route.ts
+++ b/src/app/api/parish-admin/enrollments/route.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { requireParishRole } from "@/lib/authz";
 import { recordAdminAuditLog } from "@/lib/audit-log";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import { notifyEnrollmentConfirmed } from "@/lib/parish-communications/notifications";
 
 const createEnrollmentSchema = z.object({
   clerkUserId: z.string().min(1),
@@ -134,6 +135,13 @@ export async function POST(req: Request) {
       clerk_user_id: payload.clerkUserId,
     },
   });
+
+  // Send enrollment confirmation email (non-blocking)
+  notifyEnrollmentConfirmed({
+    clerkUserId: payload.clerkUserId,
+    parishId,
+    courseId: payload.courseId,
+  }).catch((err) => console.error("[notifications] enrollment confirmed email failed:", err));
 
   return NextResponse.json({ enrollment: data }, { status: 201 });
 }

--- a/src/app/api/quiz-attempt/__tests__/route.test.ts
+++ b/src/app/api/quiz-attempt/__tests__/route.test.ts
@@ -20,9 +20,14 @@ vi.mock("@/lib/repositories/certificates", () => ({
   checkAndIssueCertificate: vi.fn(),
 }));
 
+vi.mock("@/lib/parish-communications/notifications", () => ({
+  notifyCourseCompletion: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { requireAuth, requireParishRole } from "@/lib/authz";
 import { isUserEnrolledForLesson, getCourseIdForLesson } from "@/lib/repositories/lessons";
 import { checkAndIssueCertificate } from "@/lib/repositories/certificates";
+import { notifyCourseCompletion } from "@/lib/parish-communications/notifications";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import { POST } from "@/app/api/quiz-attempt/route";
 
@@ -36,7 +41,7 @@ describe("POST /api/quiz-attempt", () => {
       role: "student",
     });
     vi.mocked(isUserEnrolledForLesson).mockResolvedValue(true);
-    vi.mocked(getCourseIdForLesson).mockResolvedValue("22222222-2222-4222-8222-222222222222");
+    vi.mocked(getCourseIdForLesson).mockResolvedValue(null);
     vi.mocked(checkAndIssueCertificate).mockResolvedValue(null);
   });
 
@@ -145,5 +150,88 @@ describe("POST /api/quiz-attempt", () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toEqual({ error: "Enrollment required for this lesson" });
+  });
+
+  it("issues certificate and triggers notification when course is completed", async () => {
+    vi.mocked(getCourseIdForLesson).mockResolvedValue("course-1");
+    vi.mocked(checkAndIssueCertificate).mockResolvedValue({
+      certificate: { id: "cert-new", clerk_user_id: "user-1", parish_id: "11111111-1111-4111-8111-111111111111", course_id: "course-1", issued_at: "2026-05-01", download_url: null },
+      newlyIssued: true,
+    });
+
+    const insert = vi.fn(async () => ({ error: null }));
+    const order = vi.fn(async () => ok([{ correct_option_index: 1 }]));
+    const eq = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ eq }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "questions") return { select };
+        if (table === "quiz_attempts") return { insert };
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/quiz-attempt", {
+        method: "POST",
+        body: JSON.stringify({
+          lessonId: "22222222-2222-4222-8222-222222222222",
+          parishId: "11111111-1111-4111-8111-111111111111",
+          answers: [1],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toMatchObject({ ok: true, score: 100, total: 1, certificateId: "cert-new" });
+    expect(checkAndIssueCertificate).toHaveBeenCalledWith({
+      clerkUserId: "user-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      courseId: "course-1",
+    });
+    expect(notifyCourseCompletion).toHaveBeenCalledWith({
+      clerkUserId: "user-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+      courseId: "course-1",
+    });
+  });
+
+  it("does not trigger notification when certificate already existed", async () => {
+    vi.mocked(getCourseIdForLesson).mockResolvedValue("course-1");
+    vi.mocked(checkAndIssueCertificate).mockResolvedValue({
+      certificate: { id: "cert-old", clerk_user_id: "user-1", parish_id: "11111111-1111-4111-8111-111111111111", course_id: "course-1", issued_at: "2026-04-01", download_url: null },
+      newlyIssued: false,
+    });
+
+    const insert = vi.fn(async () => ({ error: null }));
+    const order = vi.fn(async () => ok([{ correct_option_index: 1 }]));
+    const eq = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ eq }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "questions") return { select };
+        if (table === "quiz_attempts") return { insert };
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/quiz-attempt", {
+        method: "POST",
+        body: JSON.stringify({
+          lessonId: "22222222-2222-4222-8222-222222222222",
+          parishId: "11111111-1111-4111-8111-111111111111",
+          answers: [1],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toMatchObject({ ok: true, certificateId: "cert-old" });
+    expect(notifyCourseCompletion).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/quiz-attempt/route.ts
+++ b/src/app/api/quiz-attempt/route.ts
@@ -8,6 +8,7 @@ import { getCourseIdForLesson, isUserEnrolledForLesson } from "@/lib/repositorie
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 import { quizSubmissionSchema } from "@/lib/validation/quiz";
 import { checkAndIssueCertificate } from "@/lib/repositories/certificates";
+import { notifyCourseCompletion } from "@/lib/parish-communications/notifications";
 
 export async function POST(req: Request) {
   const clerkUserId = await requireAuth();
@@ -72,8 +73,13 @@ export async function POST(req: Request) {
   const courseId = await getCourseIdForLesson(payload.lessonId);
   let certificateId: string | null = null;
   if (courseId) {
-    const cert = await checkAndIssueCertificate({ clerkUserId, parishId, courseId });
-    certificateId = cert?.id ?? null;
+    const result = await checkAndIssueCertificate({ clerkUserId, parishId, courseId });
+    certificateId = result?.certificate.id ?? null;
+    if (result?.newlyIssued) {
+      notifyCourseCompletion({ clerkUserId, parishId, courseId }).catch(
+        (err) => console.error("[notifications] course completion email failed:", err),
+      );
+    }
   }
 
   return NextResponse.json({ ok: true, score: grade.score, total: grade.total, certificateId });

--- a/src/lib/parish-communications/__tests__/notifications.test.ts
+++ b/src/lib/parish-communications/__tests__/notifications.test.ts
@@ -25,7 +25,7 @@ describe("notifyCourseCompletion", () => {
   });
 
   it("does nothing when delivery is disabled", async () => {
-    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: false, provider: undefined });
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: false, provider: null });
     await notifyCourseCompletion({
       clerkUserId: "user-1",
       parishId: "parish-1",
@@ -35,7 +35,7 @@ describe("notifyCourseCompletion", () => {
   });
 
   it("does nothing when provider is not configured", async () => {
-    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: undefined });
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: null });
     await notifyCourseCompletion({
       clerkUserId: "user-1",
       parishId: "parish-1",

--- a/src/lib/parish-communications/__tests__/notifications.test.ts
+++ b/src/lib/parish-communications/__tests__/notifications.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fail, ok } from "@/test/supabase-route-mocks";
+
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseAdminClient: vi.fn(),
+}));
+
+vi.mock("@/lib/parish-communications/delivery-provider", () => ({
+  getParishDeliveryConfig: vi.fn(),
+  deliverParishMessage: vi.fn(),
+}));
+
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import { getParishDeliveryConfig, deliverParishMessage } from "@/lib/parish-communications/delivery-provider";
+import {
+  notifyCourseCompletion,
+  notifyJoinRequestApproved,
+  notifyJoinRequestRejected,
+  notifyEnrollmentConfirmed,
+} from "@/lib/parish-communications/notifications";
+
+describe("notifyCourseCompletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does nothing when delivery is disabled", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: false, provider: undefined });
+    await notifyCourseCompletion({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+    expect(deliverParishMessage).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when provider is not configured", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: undefined });
+    await notifyCourseCompletion({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+    expect(deliverParishMessage).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when user has no email", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: "mock" });
+    const from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ({ data: null, error: null })) })),
+      })),
+    }));
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from } as never);
+    await notifyCourseCompletion({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+    expect(deliverParishMessage).not.toHaveBeenCalled();
+  });
+
+  it("sends course completion email with correct data", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: "mock" });
+
+    let callIdx = 0;
+    const fromMock = vi.fn(() => {
+      callIdx++;
+      if (callIdx === 1) {
+        // user_profiles
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ok({ email: "user@test.com" })) })) })) };
+      } else if (callIdx === 2) {
+        // courses
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ok({ title: "Armenian Basics" })) })) })) };
+      } else {
+        // parishes
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ok({ name: "St. John" })) })) })) };
+      }
+    });
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: fromMock } as never);
+
+    await notifyCourseCompletion({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+
+    expect(deliverParishMessage).toHaveBeenCalledOnce();
+    expect(deliverParishMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "mock",
+        subject: "You've completed Armenian Basics!",
+        body: expect.stringContaining("Armenian Basics"),
+        recipients: [{ clerkUserId: "user-1", email: "user@test.com" }],
+      }),
+    );
+  });
+});
+
+describe("notifyJoinRequestApproved", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends approval email with correct subject and body", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: "mock" });
+
+    let callIdx = 0;
+    const fromMock = vi.fn(() => {
+      callIdx++;
+      if (callIdx === 1) {
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ok({ email: "user@test.com" })) })) })) };
+      } else if (callIdx === 2) {
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ok({ title: "Advanced Armenian" })) })) })) };
+      } else {
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ok({ name: "St. John" })) })) })) };
+      }
+    });
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: fromMock } as never);
+
+    await notifyJoinRequestApproved({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+
+    expect(deliverParishMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: "Your enrollment in Advanced Armenian is confirmed",
+        body: expect.stringContaining("Advanced Armenian"),
+        recipients: [{ clerkUserId: "user-1", email: "user@test.com" }],
+      }),
+    );
+  });
+});
+
+describe("notifyJoinRequestRejected", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends rejection email with correct subject and body", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: "mock" });
+
+    let callIdx = 0;
+    const fromMock = vi.fn(() => {
+      callIdx++;
+      if (callIdx === 1) {
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ok({ email: "user@test.com" })) })) })) };
+      } else if (callIdx === 2) {
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ok({ title: "Advanced Armenian" })) })) })) };
+      } else {
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ok({ name: "St. John" })) })) })) };
+      }
+    });
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: fromMock } as never);
+
+    await notifyJoinRequestRejected({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+
+    expect(deliverParishMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: "Update on your Advanced Armenian enrollment request",
+        body: expect.stringContaining("not approved"),
+        recipients: [{ clerkUserId: "user-1", email: "user@test.com" }],
+      }),
+    );
+  });
+});
+
+describe("notifyEnrollmentConfirmed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends enrollment confirmation email with correct data", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: "mock" });
+
+    let callIdx = 0;
+    const fromMock = vi.fn(() => {
+      callIdx++;
+      if (callIdx === 1) {
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ok({ email: "user@test.com" })) })) })) };
+      } else if (callIdx === 2) {
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ok({ title: "Liturgy 101" })) })) })) };
+      } else {
+        return { select: vi.fn(() => ({ eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ok({ name: "St. John" })) })) })) };
+      }
+    });
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: fromMock } as never);
+
+    await notifyEnrollmentConfirmed({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+
+    expect(deliverParishMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: "You've been enrolled in Liturgy 101",
+        body: expect.stringContaining("Liturgy 101"),
+        recipients: [{ clerkUserId: "user-1", email: "user@test.com" }],
+      }),
+    );
+  });
+});

--- a/src/lib/parish-communications/delivery-provider.ts
+++ b/src/lib/parish-communications/delivery-provider.ts
@@ -1,8 +1,12 @@
-export type ParishDeliveryProvider = "mock";
+import { sendEmailViaResend } from "./providers/resend";
+
+export type ParishDeliveryProvider = "mock" | "resend";
 
 export interface ParishDeliveryConfig {
   enabled: boolean;
   provider: ParishDeliveryProvider | null;
+  resendApiKey?: string;
+  resendFromEmail?: string;
 }
 
 export interface ParishDeliveryRecipient {
@@ -24,30 +28,50 @@ export interface ParishDeliveryResult {
 
 export function getParishDeliveryConfig(): ParishDeliveryConfig {
   const mode = (process.env.PARISH_COMMUNICATIONS_DELIVERY_MODE ?? "disabled").toLowerCase();
+
+  if (mode === "resend") {
+    const apiKey = process.env.RESEND_API_KEY;
+    const fromEmail = process.env.RESEND_FROM_EMAIL;
+    if (!apiKey || !fromEmail) {
+      console.warn("[parish-communications] RESEND_API_KEY or RESEND_FROM_EMAIL not set — falling back to disabled");
+      return { enabled: false, provider: null };
+    }
+    return { enabled: true, provider: "resend", resendApiKey: apiKey, resendFromEmail: fromEmail };
+  }
+
   if (mode === "mock") {
     return { enabled: true, provider: "mock" };
   }
+
   return { enabled: false, provider: null };
 }
 
 export async function deliverParishMessage(request: ParishDeliveryRequest): Promise<ParishDeliveryResult> {
-  if (request.provider !== "mock") {
-    throw new Error(`Unsupported parish delivery provider: ${request.provider}`);
-  }
+  if (request.provider === "mock") {
+    const sent: string[] = [];
+    const failed: Array<{ clerkUserId: string; error: string }> = [];
 
-  const sent: string[] = [];
-  const failed: Array<{ clerkUserId: string; error: string }> = [];
-
-  for (const recipient of request.recipients) {
-    if (!recipient.email) {
-      failed.push({
-        clerkUserId: recipient.clerkUserId,
-        error: "Recipient has no email on file.",
-      });
-      continue;
+    for (const recipient of request.recipients) {
+      if (!recipient.email) {
+        failed.push({ clerkUserId: recipient.clerkUserId, error: "Recipient has no email on file." });
+        continue;
+      }
+      sent.push(recipient.clerkUserId);
     }
-    sent.push(recipient.clerkUserId);
+
+    return { sent, failed };
   }
 
-  return { sent, failed };
+  if (request.provider === "resend") {
+    const config = getParishDeliveryConfig();
+    if (!config.enabled || !config.resendApiKey || !config.resendFromEmail) {
+      throw new Error("Resend provider is not configured");
+    }
+    return sendEmailViaResend(
+      { apiKey: config.resendApiKey, fromEmail: config.resendFromEmail },
+      request,
+    );
+  }
+
+  throw new Error(`Unsupported parish delivery provider: ${request.provider}`);
 }

--- a/src/lib/parish-communications/notifications.ts
+++ b/src/lib/parish-communications/notifications.ts
@@ -1,0 +1,136 @@
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import {
+  deliverParishMessage,
+  getParishDeliveryConfig,
+} from "@/lib/parish-communications/delivery-provider";
+
+/**
+ * Look up a student's email from user_profiles, along with course title and parish name.
+ */
+async function resolveNotificationData({
+  clerkUserId,
+  parishId,
+  courseId,
+}: {
+  clerkUserId: string;
+  parishId: string;
+  courseId: string;
+}): Promise<{ email: string | null; courseTitle: string; parishName: string } | null> {
+  const supabase = getSupabaseAdminClient();
+
+  const [{ data: profile }, { data: course }, { data: parish }] = await Promise.all([
+    supabase.from("user_profiles").select("email").eq("clerk_user_id", clerkUserId).maybeSingle(),
+    supabase.from("courses").select("title").eq("id", courseId).maybeSingle(),
+    supabase.from("parishes").select("name").eq("id", parishId).maybeSingle(),
+  ]);
+
+  const email = (profile as { email: string | null } | null)?.email ?? null;
+  const courseTitle = (course as { title: string } | null)?.title ?? "this course";
+  const parishName = (parish as { name: string } | null)?.name ?? "your parish";
+
+  return email ? { email, courseTitle, parishName } : null;
+}
+
+// ---------------------------------------------------------------------------
+// Join request notifications
+// ---------------------------------------------------------------------------
+
+export async function notifyJoinRequestApproved({
+  clerkUserId,
+  parishId,
+  courseId,
+}: {
+  clerkUserId: string;
+  parishId: string;
+  courseId: string;
+}): Promise<void> {
+  const config = getParishDeliveryConfig();
+  if (!config.enabled || !config.provider) return;
+
+  const data = await resolveNotificationData({ clerkUserId, parishId, courseId });
+  if (!data) return;
+
+  await deliverParishMessage({
+    provider: config.provider,
+    subject: `Your enrollment in ${data.courseTitle} is confirmed`,
+    body: `Your request to join ${data.courseTitle} at ${data.parishName} has been approved. You can now access the course in your dashboard.`,
+    recipients: [{ clerkUserId, email: data.email }],
+  });
+}
+
+export async function notifyJoinRequestRejected({
+  clerkUserId,
+  parishId,
+  courseId,
+}: {
+  clerkUserId: string;
+  parishId: string;
+  courseId: string;
+}): Promise<void> {
+  const config = getParishDeliveryConfig();
+  if (!config.enabled || !config.provider) return;
+
+  const data = await resolveNotificationData({ clerkUserId, parishId, courseId });
+  if (!data) return;
+
+  await deliverParishMessage({
+    provider: config.provider,
+    subject: `Update on your ${data.courseTitle} enrollment request`,
+    body: `Your request to join ${data.courseTitle} was not approved. Please contact your parish admin if you have questions.`,
+    recipients: [{ clerkUserId, email: data.email }],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Manual enrollment notification
+// ---------------------------------------------------------------------------
+
+export async function notifyEnrollmentConfirmed({
+  clerkUserId,
+  parishId,
+  courseId,
+}: {
+  clerkUserId: string;
+  parishId: string;
+  courseId: string;
+}): Promise<void> {
+  const config = getParishDeliveryConfig();
+  if (!config.enabled || !config.provider) return;
+
+  const data = await resolveNotificationData({ clerkUserId, parishId, courseId });
+  if (!data) return;
+
+  await deliverParishMessage({
+    provider: config.provider,
+    subject: `You've been enrolled in ${data.courseTitle}`,
+    body: `A parish administrator has enrolled you in ${data.courseTitle} at ${data.parishName}. Head to your dashboard to start learning.`,
+    recipients: [{ clerkUserId, email: data.email }],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Course completion notification
+// ---------------------------------------------------------------------------
+
+export async function notifyCourseCompletion({
+  clerkUserId,
+  parishId,
+  courseId,
+}: {
+  clerkUserId: string;
+  parishId: string;
+  courseId: string;
+}): Promise<void> {
+  const config = getParishDeliveryConfig();
+  if (!config.enabled || !config.provider) return;
+
+  const data = await resolveNotificationData({ clerkUserId, parishId, courseId });
+  if (!data) return;
+
+  await deliverParishMessage({
+    provider: config.provider,
+    subject: `You've completed ${data.courseTitle}!`,
+    body: `Congratulations! You've finished all lessons in ${data.courseTitle}. Great work on your learning journey.`,
+    recipients: [{ clerkUserId, email: data.email }],
+  });
+}

--- a/src/lib/parish-communications/providers/__tests__/resend.test.ts
+++ b/src/lib/parish-communications/providers/__tests__/resend.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendEmailViaResend } from "@/lib/parish-communications/providers/resend";
+
+global.fetch = vi.fn();
+
+function mockFetch(response: unknown, ok = true) {
+  vi.mocked(global.fetch).mockResolvedValueOnce({
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => response,
+    text: async () => "server error",
+  } as never);
+}
+
+describe("sendEmailViaResend", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const baseRequest = {
+    subject: "Test Subject",
+    body: "Test body",
+    recipients: [
+      { clerkUserId: "u-1", email: "user1@example.com" },
+      { clerkUserId: "u-2", email: "user2@example.com" },
+    ],
+  };
+
+  it("sends to all recipients when Resend returns all IDs", async () => {
+    mockFetch({ data: [{ id: "resend-id-1" }, { id: "resend-id-2" }] });
+    const result = await sendEmailViaResend(
+      { apiKey: "test-key", fromEmail: "from@example.com" },
+      baseRequest,
+    );
+    expect(result.sent).toEqual(["u-1", "u-2"]);
+    expect(result.failed).toHaveLength(0);
+  });
+
+  it("marks recipients as failed when response has no data array", async () => {
+    mockFetch({});
+    const result = await sendEmailViaResend(
+      { apiKey: "test-key", fromEmail: "from@example.com" },
+      baseRequest,
+    );
+    expect(result.sent).toHaveLength(0);
+    expect(result.failed).toEqual([
+      { clerkUserId: "u-1", error: "Resend batch response missing email ids" },
+      { clerkUserId: "u-2", error: "Resend batch response missing email ids" },
+    ]);
+  });
+
+  it("marks recipients as failed when response IDs count does not match batch size", async () => {
+    mockFetch({ data: [{ id: "only-one" }] });
+    const result = await sendEmailViaResend(
+      { apiKey: "test-key", fromEmail: "from@example.com" },
+      baseRequest,
+    );
+    expect(result.failed).toHaveLength(2);
+    expect(result.failed[0].error).toBe("Resend batch response missing email ids");
+  });
+
+  it("marks recipients as failed when some IDs are missing", async () => {
+    mockFetch({ data: [{ id: "id-1" }, null] });
+    const result = await sendEmailViaResend(
+      { apiKey: "test-key", fromEmail: "from@example.com" },
+      baseRequest,
+    );
+    expect(result.failed).toHaveLength(2);
+    expect(result.failed[0].error).toBe("Resend batch response missing email ids");
+  });
+
+  it("marks recipients as failed when Resend API returns non-ok status", async () => {
+    mockFetch({ message: "Invalid API key" }, false);
+    const result = await sendEmailViaResend(
+      { apiKey: "bad-key", fromEmail: "from@example.com" },
+      baseRequest,
+    );
+    expect(result.sent).toHaveLength(0);
+    expect(result.failed).toEqual([
+      { clerkUserId: "u-1", error: "Resend API error 500: server error" },
+      { clerkUserId: "u-2", error: "Resend API error 500: server error" },
+    ]);
+  });
+
+  it("marks recipients with null emails as failed on network error", async () => {
+    vi.mocked(global.fetch).mockRejectedValueOnce(new Error("Connection refused"));
+    const mixedRequest = {
+      ...baseRequest,
+      recipients: [
+        { clerkUserId: "u-1", email: "user1@example.com" },
+        { clerkUserId: "u-2", email: null },
+      ],
+    };
+    const result = await sendEmailViaResend(
+      { apiKey: "test-key", fromEmail: "from@example.com" },
+      mixedRequest,
+    );
+    expect(result.sent).toHaveLength(0);
+    expect(result.failed).toEqual([
+      { clerkUserId: "u-1", error: "Connection refused" },
+      // null email recipient is not added because it was filtered out before the try/catch
+    ]);
+  });
+
+  it("skips recipients with null emails", async () => {
+    mockFetch({ data: [{ id: "resend-id-1" }] });
+    const mixedRequest = {
+      ...baseRequest,
+      recipients: [
+        { clerkUserId: "u-1", email: "user1@example.com" },
+        { clerkUserId: "u-2", email: null },
+      ],
+    };
+    const result = await sendEmailViaResend(
+      { apiKey: "test-key", fromEmail: "from@example.com" },
+      mixedRequest,
+    );
+    expect(result.sent).toEqual(["u-1"]);
+    expect(result.failed).toHaveLength(0);
+  });
+
+  it("handles batch split when recipients exceed 100", async () => {
+    // First batch of 100, then second batch of 2
+    vi.mocked(global.fetch)
+      .mockResolvedValueOnce({
+        ok: true, status: 200,
+        json: async () => ({ data: Array.from({ length: 100 }, (_, i) => ({ id: `id-${i}` })) }),
+      } as never)
+      .mockResolvedValueOnce({
+        ok: true, status: 200,
+        json: async () => ({ data: Array.from({ length: 2 }, (_, i) => ({ id: `id-${100 + i}` })) }),
+      } as never);
+
+    const largeRequest = {
+      ...baseRequest,
+      recipients: Array.from({ length: 102 }, (_, i) => ({
+        clerkUserId: `u-${i}`,
+        email: `user${i}@example.com`,
+      })),
+    };
+
+    const result = await sendEmailViaResend(
+      { apiKey: "test-key", fromEmail: "from@example.com" },
+      largeRequest,
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(result.sent).toHaveLength(102);
+    expect(result.failed).toHaveLength(0);
+  });
+
+  it("treats non-Error thrown values as 'Network error'", async () => {
+    vi.mocked(global.fetch).mockRejectedValueOnce("string error" as never);
+    const result = await sendEmailViaResend(
+      { apiKey: "test-key", fromEmail: "from@example.com" },
+      baseRequest,
+    );
+    expect(result.failed[0].error).toBe("Network error");
+  });
+});

--- a/src/lib/parish-communications/providers/__tests__/resend.test.ts
+++ b/src/lib/parish-communications/providers/__tests__/resend.test.ts
@@ -18,6 +18,7 @@ describe("sendEmailViaResend", () => {
   });
 
   const baseRequest = {
+    provider: "resend" as const,
     subject: "Test Subject",
     body: "Test body",
     recipients: [

--- a/src/lib/parish-communications/providers/resend.ts
+++ b/src/lib/parish-communications/providers/resend.ts
@@ -7,7 +7,7 @@ export interface ResendConfig {
   fromEmail: string;
 }
 
-const RESEND_API_URL = "https://api.resend.com/emails";
+const RESEND_BATCH_API_URL = "https://api.resend.com/emails/batch";
 
 export async function sendEmailViaResend(
   config: ResendConfig,
@@ -20,30 +20,43 @@ export async function sendEmailViaResend(
   const BATCH_SIZE = 100;
   for (let i = 0; i < request.recipients.length; i += BATCH_SIZE) {
     const batch = request.recipients.slice(i, i + BATCH_SIZE);
-    const toEmails = batch.map((r) => r.email).filter((e): e is string => e !== null);
+    const recipientsWithEmail = batch.filter((r): r is typeof r & { email: string } => r.email !== null);
 
-    if (toEmails.length === 0) continue;
+    if (recipientsWithEmail.length === 0) continue;
+
+    const batchPayload = recipientsWithEmail.map((r) => ({
+      from: config.fromEmail,
+      to: [r.email],
+      subject: request.subject,
+      text: request.body,
+    }));
 
     try {
-      const response = await fetch(RESEND_API_URL, {
+      const response = await fetch(RESEND_BATCH_API_URL, {
         method: "POST",
         headers: {
           "Authorization": `Bearer ${config.apiKey}`,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({
-          from: config.fromEmail,
-          to: toEmails,
-          subject: request.subject,
-          text: request.body,
-        }),
+        body: JSON.stringify(batchPayload),
       });
 
       if (response.ok) {
-        // Add all recipients with valid emails to sent
-        for (const recipient of batch) {
-          if (recipient.email) {
+        const data = await response.json() as { data?: Array<{ id?: string }> };
+        const ids = data.data;
+        const allHaveIds =
+          Array.isArray(ids) &&
+          ids.length === recipientsWithEmail.length &&
+          ids.every((item) => Boolean(item?.id));
+
+        if (allHaveIds) {
+          for (const recipient of recipientsWithEmail) {
             sent.push(recipient.clerkUserId);
+          }
+        } else {
+          const errMsg = "Resend batch response missing email ids";
+          for (const recipient of recipientsWithEmail) {
+            failed.push({ clerkUserId: recipient.clerkUserId, error: errMsg });
           }
         }
       } else {

--- a/src/lib/parish-communications/providers/resend.ts
+++ b/src/lib/parish-communications/providers/resend.ts
@@ -40,12 +40,10 @@ export async function sendEmailViaResend(
       });
 
       if (response.ok) {
-        const data = await response.json() as { id?: string };
-        if (data.id) {
-          for (const recipient of batch) {
-            if (recipient.email) {
-              sent.push(recipient.clerkUserId);
-            }
+        // Add all recipients with valid emails to sent
+        for (const recipient of batch) {
+          if (recipient.email) {
+            sent.push(recipient.clerkUserId);
           }
         }
       } else {

--- a/src/lib/parish-communications/providers/resend.ts
+++ b/src/lib/parish-communications/providers/resend.ts
@@ -1,0 +1,73 @@
+import type { ParishDeliveryRequest, ParishDeliveryResult } from "../delivery-provider";
+
+export type ResendDeliveryProvider = "resend";
+
+export interface ResendConfig {
+  apiKey: string;
+  fromEmail: string;
+}
+
+const RESEND_API_URL = "https://api.resend.com/emails";
+
+export async function sendEmailViaResend(
+  config: ResendConfig,
+  request: ParishDeliveryRequest,
+): Promise<ParishDeliveryResult> {
+  const sent: string[] = [];
+  const failed: Array<{ clerkUserId: string; error: string }> = [];
+
+  // Send to up to 100 recipients per batch (Resend batch limit)
+  const BATCH_SIZE = 100;
+  for (let i = 0; i < request.recipients.length; i += BATCH_SIZE) {
+    const batch = request.recipients.slice(i, i + BATCH_SIZE);
+    const toEmails = batch.map((r) => r.email).filter((e): e is string => e !== null);
+
+    if (toEmails.length === 0) continue;
+
+    try {
+      const response = await fetch(RESEND_API_URL, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${config.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: config.fromEmail,
+          to: toEmails,
+          subject: request.subject,
+          text: request.body,
+        }),
+      });
+
+      if (response.ok) {
+        const data = await response.json() as { id?: string };
+        if (data.id) {
+          for (const recipient of batch) {
+            if (recipient.email) {
+              sent.push(recipient.clerkUserId);
+            }
+          }
+        }
+      } else {
+        const errorBody = await response.text();
+        for (const recipient of batch) {
+          if (recipient.email) {
+            failed.push({
+              clerkUserId: recipient.clerkUserId,
+              error: `Resend API error ${response.status}: ${errorBody}`,
+            });
+          }
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Network error";
+      for (const recipient of batch) {
+        if (recipient.email) {
+          failed.push({ clerkUserId: recipient.clerkUserId, error: message });
+        }
+      }
+    }
+  }
+
+  return { sent, failed };
+}

--- a/src/lib/repositories/__tests__/certificates.test.ts
+++ b/src/lib/repositories/__tests__/certificates.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ok } from "@/test/supabase-route-mocks";
+
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseAdminClient: vi.fn(),
+}));
+
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+import { checkAndIssueCertificate } from "@/lib/repositories/certificates";
+
+/** Helper: build a certificates table mock that supports .select().eq().eq().maybeSingle() */
+function certificatesMock(returnData: unknown) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            maybeSingle: vi.fn(async () => ({ data: returnData, error: null })),
+          })),
+        })),
+      })),
+    })),
+  };
+}
+
+function modulesMock(returnData: unknown) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({ data: returnData, error: null })),
+    })),
+  };
+}
+
+function lessonsMock(returnData: unknown) {
+  return {
+    select: vi.fn(() => ({
+      in: vi.fn(() => ({ data: returnData, error: null })),
+    })),
+  };
+}
+
+function videoProgressMock(returnData: unknown) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          in: vi.fn(() => ({
+            eq: vi.fn(() => ({ data: returnData, error: null })),
+          })),
+        })),
+      })),
+    })),
+  };
+}
+
+function insertMock(returnData: unknown) {
+  return {
+    insert: vi.fn(() => ({
+      select: vi.fn(() => ({
+        single: vi.fn(async () => ({ data: returnData, error: null })),
+      })),
+    })),
+  };
+}
+
+describe("checkAndIssueCertificate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns existing certificate with newlyIssued=false when certificate already exists", async () => {
+    const existingCert = { id: "cert-1", clerk_user_id: "user-1", parish_id: "parish-1", course_id: "course-1", issued_at: "2026-01-01", download_url: null };
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "certificates") return certificatesMock(existingCert);
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    const result = await checkAndIssueCertificate({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+
+    expect(result).toEqual({ certificate: existingCert, newlyIssued: false });
+  });
+
+  it("returns null when course has no modules", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "certificates") return certificatesMock(null);
+        if (table === "modules") return modulesMock([]);
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    const result = await checkAndIssueCertificate({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when not all lessons are completed", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "certificates") return certificatesMock(null);
+        if (table === "modules") return modulesMock([{ id: "mod-1" }]);
+        if (table === "lessons") return lessonsMock([{ id: "lesson-1" }, { id: "lesson-2" }]);
+        if (table === "video_progress") return videoProgressMock([{ lesson_id: "lesson-1", completed: true }]);
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    const result = await checkAndIssueCertificate({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("issues new certificate with newlyIssued=true when all lessons completed", async () => {
+    const newCert = { id: "new-cert", clerk_user_id: "user-1", parish_id: "parish-1", course_id: "course-1", issued_at: "2026-05-01", download_url: null };
+    let callCount = 0;
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "certificates") {
+          callCount++;
+          if (callCount === 1) return certificatesMock(null); // check exists
+          return insertMock(newCert); // insert new
+        }
+        if (table === "modules") return modulesMock([{ id: "mod-1" }]);
+        if (table === "lessons") return lessonsMock([{ id: "lesson-1" }]);
+        if (table === "video_progress") return videoProgressMock([{ lesson_id: "lesson-1", completed: true }]);
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    const result = await checkAndIssueCertificate({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+
+    expect(result).toEqual({ certificate: newCert, newlyIssued: true });
+  });
+
+  it("returns null when certificate insert fails", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "certificates") {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  eq: vi.fn(() => ({
+                    maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+                  })),
+                })),
+              })),
+            })),
+          };
+        }
+        if (table === "modules") return modulesMock([{ id: "mod-1" }]);
+        if (table === "lessons") return lessonsMock([{ id: "lesson-1" }]);
+        if (table === "video_progress") return videoProgressMock([{ lesson_id: "lesson-1", completed: true }]);
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    // Override insert to fail
+    let certCallCount = 0;
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "certificates") {
+          certCallCount++;
+          if (certCallCount === 1) {
+            return {
+              select: vi.fn(() => ({
+                eq: vi.fn(() => ({
+                  eq: vi.fn(() => ({
+                    eq: vi.fn(() => ({
+                      maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+                    })),
+                  })),
+                })),
+              })),
+            };
+          }
+          return {
+            insert: vi.fn(() => ({
+              select: vi.fn(() => ({
+                single: vi.fn(async () => ({ data: null, error: { message: "db error" } })),
+              })),
+            })),
+          };
+        }
+        if (table === "modules") return modulesMock([{ id: "mod-1" }]);
+        if (table === "lessons") return lessonsMock([{ id: "lesson-1" }]);
+        if (table === "video_progress") return videoProgressMock([{ lesson_id: "lesson-1", completed: true }]);
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    const result = await checkAndIssueCertificate({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/repositories/certificates.ts
+++ b/src/lib/repositories/certificates.ts
@@ -48,7 +48,7 @@ export async function checkAndIssueCertificate({
   clerkUserId: string;
   parishId: string;
   courseId: string;
-}): Promise<CertificateRecord | null> {
+}): Promise<{ certificate: CertificateRecord; newlyIssued: boolean } | null> {
   if (isE2ESmokeMode()) return null;
 
   const supabase = getSupabaseAdminClient();
@@ -62,7 +62,7 @@ export async function checkAndIssueCertificate({
     .eq("course_id", courseId)
     .maybeSingle();
 
-  if (existing) return existing as CertificateRecord;
+  if (existing) return { certificate: existing as CertificateRecord, newlyIssued: false };
 
   // Verify all lessons in course are completed
   const { data: modules } = await supabase
@@ -107,7 +107,7 @@ export async function checkAndIssueCertificate({
     .single();
 
   if (error) return null;
-  return cert as CertificateRecord;
+  return { certificate: cert as CertificateRecord, newlyIssued: true };
 }
 
 export async function listStudentCertificates(


### PR DESCRIPTION
## Summary

Issue #26: Integrate Resend.com for transactional email delivery

### Phase 1 — Resend Provider

- `providers/resend.ts` — `sendEmailViaResend()` using Resend REST API via native `fetch` (no SDK added)
- `delivery-provider.ts` — Added `resend` mode to `ParishDeliveryProvider`; `getParishDeliveryConfig()` reads `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `PARISH_COMMUNICATIONS_DELIVERY_MODE`
- `.env.example` — Documents all new env vars

### Phase 2 — Join Request Notifications

- `notifications.ts`: `notifyJoinRequestApproved()`, `notifyJoinRequestRejected()`
- Wired into `course-join-requests/[requestId]/approve/route.ts` and `reject/route.ts`
- Non-blocking via `.catch()` — email failure never breaks the admin action

### Phase 3 — Enrollment Notifications

- `notifications.ts`: `notifyEnrollmentConfirmed()`
- Wired into `parish-admin/enrollments/route.ts` (parish admin) and `admin/enrollments/route.ts` (diocese admin)
- Non-blocking

### Phase 4 — Course Completion

- `notifications.ts`: `notifyCourseCompletion()`
- Wired into `quiz-attempt/route.ts` — fires only when `checkAndIssueCertificate()` returns a newly issued certificate (not a duplicate)
- Non-blocking

### Environment Variables (add to `.env.local`)

```bash
RESEND_API_KEY=re_your_key_here
RESEND_FROM_EMAIL=WD Learning <noreply@yourdomain.com>
PARISH_COMMUNICATIONS_DELIVERY_MODE=resend  # disabled | mock | resend
```

To apply the certificate migration:
```bash
supabase db push
```

### Testing
- npm run typecheck — clean
- npm run lint — 0 errors, 22 warnings (pre-existing)
- npm test — 173 passed

Closes #26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces outbound email delivery via Resend and wires new notification side-effects into enrollment/join-request/quiz flows; failures are non-blocking but misconfiguration or provider/API errors could impact user communications and add external dependency behavior.
> 
> **Overview**
> Adds a new parish communications notification layer (`notifyJoinRequestApproved/Rejected`, `notifyEnrollmentConfirmed`, `notifyCourseCompletion`) that resolves recipient/course/parish data from Supabase and sends messages via `deliverParishMessage`.
> 
> Extends the delivery system with a `resend` provider (env-driven via `PARISH_COMMUNICATIONS_DELIVERY_MODE`, `RESEND_API_KEY`, `RESEND_FROM_EMAIL`) and implements Resend batch sending with basic error handling and batching.
> 
> Wires **non-blocking** email triggers into diocese/parish enrollment creation, join-request approve/reject endpoints, and quiz submission when a certificate is newly issued; updates `checkAndIssueCertificate` to return `{ certificate, newlyIssued }` and adds/updates tests around these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fa44ce3705c4896da3da5b1b076c34527b598ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->