### PR TITLE
Fix clawpatch priority findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,6 @@ next-env.d.ts
 .temp/
 parish-leaders-course-videos/
 
+.agents
+.crabbox*
 .clawpatch/

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ next-env.d.ts
 
 .temp/
 parish-leaders-course-videos/
+
+.clawpatch/

--- a/scripts/content-builder.ts
+++ b/scripts/content-builder.ts
@@ -256,7 +256,13 @@ async function insertSingle<T>(
 
 async function importContent(
   content: ContentImport,
-  options?: { strict?: boolean; aiPalette?: AiPalette; aiStyle?: AiStyle; aiTextPlacement?: AiTextPlacement },
+  options?: {
+    strict?: boolean;
+    aiPalette?: AiPalette;
+    aiStyle?: AiStyle;
+    aiTextPlacement?: AiTextPlacement;
+    onCourseCreated?: (course: CourseRow) => void;
+  },
 ): Promise<ImportSummary> {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -336,6 +342,7 @@ async function importContent(
       .single(),
     "Course",
   );
+  options?.onCourseCreated?.(course);
 
   const summary: ImportSummary = {
     course,
@@ -556,18 +563,25 @@ async function main() {
 
   const options = { strict, aiPalette, aiStyle, aiTextPlacement };
   let summary: ImportSummary | undefined;
+  let createdCourse: CourseRow | undefined;
   try {
-    summary = await importContent(content, options);
+    summary = await importContent(content, {
+      ...options,
+      onCourseCreated: (course) => {
+        createdCourse = course;
+      },
+    });
     printSummary(summary);
   } catch (err) {
     // Best-effort cleanup: delete the partially-created course so retry is clean
-    if (summary?.course?.id) {
-      console.error(red(`\nImport failed — cleaning up course ${summary.course.id}...`));
+    const course = summary?.course ?? createdCourse;
+    if (course?.id) {
+      console.error(red(`\nImport failed — cleaning up course ${course.id}...`));
       try {
         const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
         const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
         const supabase = createClient(supabaseUrl, serviceRoleKey);
-        await supabase.from("courses").delete().eq("id", summary.course.id);
+        await supabase.from("courses").delete().eq("id", course.id);
         console.error(red("Cleanup done. Delete manually if cascade missed any rows."));
       } catch {
         // best-effort — don't mask the original error

--- a/scripts/crabbox-ensure-node-deps.sh
+++ b/scripts/crabbox-ensure-node-deps.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+need_node=0
+if ! command -v node >/dev/null 2>&1; then
+  need_node=1
+else
+  major="$(node -p 'Number(process.versions.node.split(".")[0])')"
+  if [ "$major" -lt 20 ]; then
+    need_node=1
+  fi
+fi
+
+if [ "$need_node" -eq 1 ]; then
+  if ! command -v curl >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y curl ca-certificates
+  fi
+  curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+  sudo apt-get install -y nodejs
+fi
+
+mkdir -p .crabbox
+lock_hash="$(sha256sum package-lock.json | awk '{print $1}')"
+
+if [ ! -d node_modules ] ||
+  [ ! -f .crabbox/package-lock.sha256 ] ||
+  [ "$(cat .crabbox/package-lock.sha256)" != "$lock_hash" ]; then
+  npm ci
+  printf '%s\n' "$lock_hash" > .crabbox/package-lock.sha256
+else
+  echo "node_modules already matches package-lock.json"
+fi

--- a/src/app/api/parish-admin/cohorts/[cohortId]/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/cohorts/[cohortId]/__tests__/route.test.ts
@@ -65,6 +65,62 @@ describe("/api/parish-admin/cohorts/[cohortId]", () => {
     expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves omitted optional fields when updating a cohort", async () => {
+    const existingMaybeSingle = vi.fn(async () => ({
+      data: {
+        id: "cohort-1",
+        facilitator_clerk_user_id: "facilitator-1",
+        next_session_at: "2025-01-01T00:00:00.000Z",
+      },
+      error: null,
+    }));
+    const existingEqParish = vi.fn(() => ({ maybeSingle: existingMaybeSingle }));
+    const existingEqId = vi.fn(() => ({ eq: existingEqParish }));
+    const cohortSelect = vi.fn(() => ({ eq: existingEqId }));
+
+    const updateSingle = vi.fn(async () => ({
+      data: {
+        id: "cohort-1",
+        name: "Updated",
+        facilitator_clerk_user_id: "facilitator-1",
+        next_session_at: "2025-01-01T00:00:00.000Z",
+      },
+      error: null,
+    }));
+    const updateSelect = vi.fn(() => ({ single: updateSingle }));
+    const updateEqParish = vi.fn(() => ({ select: updateSelect }));
+    const updateEqId = vi.fn(() => ({ eq: updateEqParish }));
+    const cohortUpdate = vi.fn(() => ({ eq: updateEqId }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "cohorts") return { select: cohortSelect, update: cohortUpdate };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await PATCH(
+      new Request("http://localhost/api/parish-admin/cohorts/11111111-1111-4111-8111-111111111111", {
+        method: "PATCH",
+        body: JSON.stringify({
+          name: "Updated",
+          cadence: "biweekly",
+        }),
+      }),
+      { params: Promise.resolve({ cohortId: "11111111-1111-4111-8111-111111111111" }) },
+    );
+
+    expect(response.status).toBe(200);
+    const updatePayload = (cohortUpdate.mock.calls as unknown as Array<[Record<string, unknown>]>)[0][0];
+    expect(updatePayload).not.toHaveProperty("facilitator_clerk_user_id");
+    expect(updatePayload).not.toHaveProperty("next_session_at");
+    const auditDetails = (
+      vi.mocked(recordAdminAuditLog).mock.calls as unknown as Array<[{ details: Record<string, unknown> }]>
+    )[0][0].details;
+    expect(auditDetails).not.toHaveProperty("facilitator_clerk_user_id");
+    expect(auditDetails).not.toHaveProperty("next_session_at");
+  });
+
   it("returns 403 when instructor tries to update unassigned cohort", async () => {
     vi.mocked(requireParishRole).mockResolvedValue({
       clerkUserId: "instructor-1",

--- a/src/app/api/parish-admin/cohorts/[cohortId]/route.ts
+++ b/src/app/api/parish-admin/cohorts/[cohortId]/route.ts
@@ -78,18 +78,51 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ cohortId: str
     return NextResponse.json({ error: "Only parish admins can reassign facilitators." }, { status: 403 });
   }
 
+  const hasFacilitatorClerkUserId = Object.prototype.hasOwnProperty.call(payload, "facilitatorClerkUserId");
+  const hasNextSessionAt = Object.prototype.hasOwnProperty.call(payload, "nextSessionAt");
+  const cohortUpdates: {
+    name: string;
+    cadence: z.infer<typeof cadenceSchema>;
+    updated_at: string;
+    facilitator_clerk_user_id?: string | null;
+    next_session_at?: string | null;
+  } = {
+    name: payload.name,
+    cadence: payload.cadence,
+    updated_at: new Date().toISOString(),
+  };
+
+  if (role === "parish_admin" && hasFacilitatorClerkUserId) {
+    cohortUpdates.facilitator_clerk_user_id = payload.facilitatorClerkUserId ?? null;
+  }
+
+  if (hasNextSessionAt) {
+    cohortUpdates.next_session_at = payload.nextSessionAt ?? null;
+  }
+
+  const auditDetails: {
+    parish_id: string;
+    name: string;
+    cadence: z.infer<typeof cadenceSchema>;
+    facilitator_clerk_user_id?: string | null;
+    next_session_at?: string | null;
+  } = {
+    parish_id: parishId,
+    name: payload.name,
+    cadence: payload.cadence,
+  };
+
+  if (role === "parish_admin" && hasFacilitatorClerkUserId) {
+    auditDetails.facilitator_clerk_user_id = payload.facilitatorClerkUserId ?? null;
+  }
+
+  if (hasNextSessionAt) {
+    auditDetails.next_session_at = payload.nextSessionAt ?? null;
+  }
+
   const { data, error } = await supabase
     .from("cohorts")
-    .update({
-      name: payload.name,
-      facilitator_clerk_user_id:
-        role === "parish_admin"
-          ? (payload.facilitatorClerkUserId ?? null)
-          : existingCohort.facilitator_clerk_user_id,
-      cadence: payload.cadence,
-      next_session_at: payload.nextSessionAt ?? null,
-      updated_at: new Date().toISOString(),
-    })
+    .update(cohortUpdates)
     .eq("id", cohortId)
     .eq("parish_id", parishId)
     .select("id,name,facilitator_clerk_user_id,cadence,next_session_at,created_at,updated_at")
@@ -104,13 +137,7 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ cohortId: str
     action: "parish.cohort_updated",
     resourceType: "cohort",
     resourceId: cohortId,
-    details: {
-      parish_id: parishId,
-      name: payload.name,
-      facilitator_clerk_user_id: payload.facilitatorClerkUserId ?? null,
-      cadence: payload.cadence,
-      next_session_at: payload.nextSessionAt ?? null,
-    },
+    details: auditDetails,
   });
 
   return NextResponse.json({ cohort: data });

--- a/src/app/api/parish-admin/participation/export/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/participation/export/__tests__/route.test.ts
@@ -64,6 +64,78 @@ describe("GET /api/parish-admin/participation/export", () => {
     expect(body).toContain("\"RCIA\"");
   });
 
+  it("neutralizes spreadsheet formulas in exported cells", async () => {
+    vi.mocked(getParishAdminDashboardDataForUser).mockResolvedValue({
+      role: "parish_admin",
+      overview: {
+        memberCount: 1,
+        enrollmentCount: 1,
+        activeLearnerCount: 1,
+        stalledLearnerCount: 0,
+        completionRate: 50,
+        pendingJoinRequestCount: 0,
+      },
+      visibleCourses: [
+        {
+          id: "22222222-2222-4222-8222-222222222222",
+          title: "@Course \"Alpha\"",
+          description: null,
+          published: true,
+          scope: "PARISH",
+        },
+      ],
+      dioceseCourses: [],
+      adoptedParishCourses: [],
+      availableParishCourses: [],
+      enrollments: [],
+      members: [
+        {
+          clerk_user_id: "-user-1",
+          role: "student",
+          email: "+person@example.com",
+          display_name: "=HYPERLINK(\"https://attacker.example\",\"click\")",
+        },
+      ],
+      cohorts: [
+        {
+          id: "33333333-3333-4333-8333-333333333333",
+          name: "\tCohort A",
+          facilitator_clerk_user_id: null,
+          cadence: "weekly",
+          next_session_at: null,
+          created_at: "2026-01-01T00:00:00.000Z",
+          updated_at: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      communicationSends: [],
+      participationRows: [
+        {
+          enrollment_id: "enroll-1",
+          clerk_user_id: "-user-1",
+          course_id: "22222222-2222-4222-8222-222222222222",
+          cohort_id: "33333333-3333-4333-8333-333333333333",
+          enrolled_at: "\r2026-01-02T00:00:00.000Z",
+          completed_lessons: 2,
+          started_lessons: 2,
+          total_lessons: 4,
+          progress_percent: 50,
+          last_activity_at: "2026-01-10T00:00:00.000Z",
+          status: "active",
+        },
+      ],
+    });
+
+    const response = await GET(new Request("http://localhost/api/parish-admin/participation/export"));
+    const body = await response.text();
+
+    expect(body).toContain("\"'=HYPERLINK(\"\"https://attacker.example\"\",\"\"click\"\")\"");
+    expect(body).toContain("\"'+person@example.com\"");
+    expect(body).toContain("\"'-user-1\"");
+    expect(body).toContain("\"'@Course \"\"Alpha\"\"\"");
+    expect(body).toContain("\"'\tCohort A\"");
+    expect(body).toContain("\"'\r2026-01-02T00:00:00.000Z\"");
+  });
+
   it("applies cohort and status filters", async () => {
     vi.mocked(getParishAdminDashboardDataForUser).mockResolvedValue({
       role: "parish_admin",

--- a/src/app/api/parish-admin/participation/export/route.ts
+++ b/src/app/api/parish-admin/participation/export/route.ts
@@ -68,7 +68,9 @@ function filterRows({
 }
 
 function csvValue(value: string | number | null) {
-  return `"${String(value ?? "").replaceAll('"', '""')}"`;
+  const text = String(value ?? "");
+  const safeText = /^[=+\-@\t\r]/.test(text) ? `'${text}` : text;
+  return `"${safeText.replaceAll('"', '""')}"`;
 }
 
 export async function GET(req: Request) {

--- a/src/app/app/admin/__tests__/page.test.tsx
+++ b/src/app/app/admin/__tests__/page.test.tsx
@@ -32,7 +32,7 @@ describe("DioceseAdminPage", () => {
   it("requires a diocese admin before rendering overview data", async () => {
     render(await DioceseAdminPage());
 
-    expect(requireDioceseAdmin).toHaveBeenCalledBefore(getDioceseOverview);
+    expect(vi.mocked(requireDioceseAdmin)).toHaveBeenCalledBefore(vi.mocked(getDioceseOverview));
     expect(screen.getByText("Parishes")).toBeInTheDocument();
     expect(screen.getByText("2")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Open access tool →" })).toHaveAttribute(

--- a/src/app/app/admin/__tests__/page.test.tsx
+++ b/src/app/app/admin/__tests__/page.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({
+  requireDioceseAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/diocese-admin", () => ({
+  getDioceseOverview: vi.fn(),
+}));
+
+import DioceseAdminPage from "@/app/app/admin/page";
+import { requireDioceseAdmin } from "@/lib/authz";
+import { getDioceseOverview } from "@/lib/repositories/diocese-admin";
+
+describe("DioceseAdminPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireDioceseAdmin).mockResolvedValue("admin-1");
+    vi.mocked(getDioceseOverview).mockResolvedValue({
+      parishCount: 2,
+      userCount: 12,
+      dioceseAdminCount: 1,
+      courseCount: 4,
+      publishedCourseCount: 3,
+      enrollmentCount: 20,
+      progressRecordCount: 10,
+      completedProgressRecordCount: 5,
+    });
+  });
+
+  it("requires a diocese admin before rendering overview data", async () => {
+    render(await DioceseAdminPage());
+
+    expect(requireDioceseAdmin).toHaveBeenCalledBefore(getDioceseOverview);
+    expect(screen.getByText("Parishes")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Open access tool →" })).toHaveAttribute(
+      "href",
+      "/app/admin/memberships",
+    );
+  });
+
+  it("does not load overview data when the guard rejects access", async () => {
+    const accessError = new Error("redirect");
+    vi.mocked(requireDioceseAdmin).mockRejectedValue(accessError);
+
+    await expect(DioceseAdminPage()).rejects.toThrow(accessError);
+    expect(getDioceseOverview).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/app/admin/audit/__tests__/page.test.tsx
+++ b/src/app/app/admin/audit/__tests__/page.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/admin-audit-log-viewer", () => ({
+  AdminAuditLogViewer: ({ initialLogs }: { initialLogs: unknown[] }) => (
+    <div>Audit logs: {initialLogs.length}</div>
+  ),
+}));
+
+vi.mock("@/lib/authz", () => ({
+  requireDioceseAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/audit-log", () => ({
+  listAdminAuditLogs: vi.fn(),
+}));
+
+import DioceseAdminAuditPage from "@/app/app/admin/audit/page";
+import { listAdminAuditLogs } from "@/lib/audit-log";
+import { requireDioceseAdmin } from "@/lib/authz";
+
+describe("DioceseAdminAuditPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireDioceseAdmin).mockResolvedValue("admin-1");
+    vi.mocked(listAdminAuditLogs).mockResolvedValue([
+      {
+        id: "log-1",
+        actor_clerk_user_id: "admin-1",
+        action: "parish.updated",
+        resource_type: "parish",
+        resource_id: "parish-1",
+        details: {},
+        created_at: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("requires a diocese admin before rendering audit logs", async () => {
+    render(await DioceseAdminAuditPage());
+
+    expect(requireDioceseAdmin).toHaveBeenCalledBefore(listAdminAuditLogs);
+    expect(listAdminAuditLogs).toHaveBeenCalledWith({ limit: 100 });
+    expect(screen.getByRole("heading", { name: "Audit Logs" })).toBeInTheDocument();
+    expect(screen.getByText("Audit logs: 1")).toBeInTheDocument();
+  });
+
+  it("does not load audit logs when the guard rejects access", async () => {
+    const accessError = new Error("redirect");
+    vi.mocked(requireDioceseAdmin).mockRejectedValue(accessError);
+
+    await expect(DioceseAdminAuditPage()).rejects.toThrow(accessError);
+    expect(listAdminAuditLogs).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/app/admin/audit/__tests__/page.test.tsx
+++ b/src/app/app/admin/audit/__tests__/page.test.tsx
@@ -39,7 +39,7 @@ describe("DioceseAdminAuditPage", () => {
   it("requires a diocese admin before rendering audit logs", async () => {
     render(await DioceseAdminAuditPage());
 
-    expect(requireDioceseAdmin).toHaveBeenCalledBefore(listAdminAuditLogs);
+    expect(vi.mocked(requireDioceseAdmin)).toHaveBeenCalledBefore(vi.mocked(listAdminAuditLogs));
     expect(listAdminAuditLogs).toHaveBeenCalledWith({ limit: 100 });
     expect(screen.getByRole("heading", { name: "Audit Logs" })).toBeInTheDocument();
     expect(screen.getByText("Audit logs: 1")).toBeInTheDocument();

--- a/src/app/app/admin/audit/page.tsx
+++ b/src/app/app/admin/audit/page.tsx
@@ -1,8 +1,11 @@
 import { AdminAuditLogViewer } from "@/components/admin-audit-log-viewer";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { listAdminAuditLogs } from "@/lib/audit-log";
+import { requireDioceseAdmin } from "@/lib/authz";
 
 export default async function DioceseAdminAuditPage() {
+  await requireDioceseAdmin();
+
   const logs = await listAdminAuditLogs({ limit: 100 });
 
   return (

--- a/src/app/app/admin/courses/[courseId]/__tests__/page.test.tsx
+++ b/src/app/app/admin/courses/[courseId]/__tests__/page.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigationMocks = vi.hoisted(() => ({
+  notFound: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: navigationMocks.notFound,
+}));
+
+vi.mock("@/components/admin-course-content-manager", () => ({
+  AdminCourseContentManager: ({ modules }: { modules: unknown[] }) => (
+    <div>Course content manager: {modules.length}</div>
+  ),
+}));
+
+vi.mock("@/lib/authz", () => ({
+  requireDioceseAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/diocese-admin", () => ({
+  getCourseContentForAdmin: vi.fn(),
+}));
+
+import DioceseAdminCourseContentPage from "@/app/app/admin/courses/[courseId]/page";
+import { requireDioceseAdmin } from "@/lib/authz";
+import { getCourseContentForAdmin } from "@/lib/repositories/diocese-admin";
+
+describe("DioceseAdminCourseContentPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireDioceseAdmin).mockResolvedValue("admin-1");
+    vi.mocked(getCourseContentForAdmin).mockResolvedValue({
+      course: {
+        id: "course-1",
+        title: "Test Course",
+        description: "Course description",
+        thumbnail_url: null,
+        scope: "DIOCESE",
+        published: true,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-02",
+      },
+      modules: [
+        {
+          id: "module-1",
+          course_id: "course-1",
+          title: "Test Module",
+          descriptor: null,
+          thumbnail_url: null,
+          sort_order: 1,
+          lessons: [],
+        },
+      ],
+    });
+  });
+
+  it("requires a diocese admin before rendering course content", async () => {
+    render(await DioceseAdminCourseContentPage({ params: Promise.resolve({ courseId: "course-1" }) }));
+
+    expect(vi.mocked(requireDioceseAdmin).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(getCourseContentForAdmin).mock.invocationCallOrder[0],
+    );
+    expect(getCourseContentForAdmin).toHaveBeenCalledWith("course-1");
+    expect(screen.getByText("Course content builder: Test Course")).toBeInTheDocument();
+    expect(screen.getByText("Course content manager: 1")).toBeInTheDocument();
+  });
+
+  it("does not load course content when the guard rejects access", async () => {
+    const accessError = new Error("redirect");
+    vi.mocked(requireDioceseAdmin).mockRejectedValue(accessError);
+
+    await expect(
+      DioceseAdminCourseContentPage({ params: Promise.resolve({ courseId: "course-1" }) }),
+    ).rejects.toThrow(accessError);
+    expect(getCourseContentForAdmin).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/app/admin/courses/[courseId]/lessons/[lessonId]/__tests__/page.test.tsx
+++ b/src/app/app/admin/courses/[courseId]/lessons/[lessonId]/__tests__/page.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigationMocks = vi.hoisted(() => ({
+  notFound: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: navigationMocks.notFound,
+}));
+
+vi.mock("@/components/admin-lesson-question-manager", () => ({
+  AdminLessonQuestionManager: ({ lesson }: { lesson: { questions: unknown[] } }) => (
+    <div>Question manager: {lesson.questions.length}</div>
+  ),
+}));
+
+vi.mock("@/lib/authz", () => ({
+  requireDioceseAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/diocese-admin", () => ({
+  getCourseLessonContentForAdmin: vi.fn(),
+}));
+
+import DioceseAdminLessonQuestionsPage from "@/app/app/admin/courses/[courseId]/lessons/[lessonId]/page";
+import { requireDioceseAdmin } from "@/lib/authz";
+import { getCourseLessonContentForAdmin } from "@/lib/repositories/diocese-admin";
+
+describe("DioceseAdminLessonQuestionsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireDioceseAdmin).mockResolvedValue("admin-1");
+    vi.mocked(getCourseLessonContentForAdmin).mockResolvedValue({
+      course: {
+        id: "course-1",
+        title: "Test Course",
+        description: null,
+        thumbnail_url: null,
+        scope: "DIOCESE",
+        published: true,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-02",
+      },
+      module: {
+        id: "module-1",
+        course_id: "course-1",
+        title: "Test Module",
+        descriptor: null,
+        thumbnail_url: null,
+        sort_order: 1,
+        lessons: [],
+      },
+      lesson: {
+        id: "lesson-1",
+        title: "Test Lesson",
+        module_id: "module-1",
+        descriptor: null,
+        thumbnail_url: null,
+        content_type: "VIDEO",
+        youtube_video_id: "abc123",
+        document_url: null,
+        document_page_start: null,
+        document_page_end: null,
+        passing_score: 80,
+        sort_order: 1,
+        questions: [],
+      },
+    });
+  });
+
+  it("requires a diocese admin before rendering lesson questions", async () => {
+    render(
+      await DioceseAdminLessonQuestionsPage({
+        params: Promise.resolve({ courseId: "course-1", lessonId: "lesson-1" }),
+      }),
+    );
+
+    expect(vi.mocked(requireDioceseAdmin).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(getCourseLessonContentForAdmin).mock.invocationCallOrder[0],
+    );
+    expect(getCourseLessonContentForAdmin).toHaveBeenCalledWith("course-1", "lesson-1");
+    expect(screen.getByText("Lesson question builder: Test Lesson")).toBeInTheDocument();
+    expect(screen.getByText("Question manager: 0")).toBeInTheDocument();
+  });
+
+  it("does not load lesson content when the guard rejects access", async () => {
+    const accessError = new Error("redirect");
+    vi.mocked(requireDioceseAdmin).mockRejectedValue(accessError);
+
+    await expect(
+      DioceseAdminLessonQuestionsPage({
+        params: Promise.resolve({ courseId: "course-1", lessonId: "lesson-1" }),
+      }),
+    ).rejects.toThrow(accessError);
+    expect(getCourseLessonContentForAdmin).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/app/admin/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/src/app/app/admin/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { AdminLessonQuestionManager } from "@/components/admin-lesson-question-manager";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { requireDioceseAdmin } from "@/lib/authz";
 import { getCourseLessonContentForAdmin } from "@/lib/repositories/diocese-admin";
 
 export default async function DioceseAdminLessonQuestionsPage({
@@ -12,6 +13,8 @@ export default async function DioceseAdminLessonQuestionsPage({
   params: Promise<{ courseId: string; lessonId: string }>;
 }) {
   const { courseId, lessonId } = await params;
+  await requireDioceseAdmin();
+
   const data = await getCourseLessonContentForAdmin(courseId, lessonId);
 
   if (!data) {

--- a/src/app/app/admin/courses/[courseId]/page.tsx
+++ b/src/app/app/admin/courses/[courseId]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 
 import { AdminCourseContentManager } from "@/components/admin-course-content-manager";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { requireDioceseAdmin } from "@/lib/authz";
 import { getCourseContentForAdmin } from "@/lib/repositories/diocese-admin";
 
 export default async function DioceseAdminCourseContentPage({
@@ -10,6 +11,8 @@ export default async function DioceseAdminCourseContentPage({
   params: Promise<{ courseId: string }>;
 }) {
   const { courseId } = await params;
+  await requireDioceseAdmin();
+
   const data = await getCourseContentForAdmin(courseId);
 
   if (!data) {

--- a/src/app/app/admin/courses/__tests__/page.test.tsx
+++ b/src/app/app/admin/courses/__tests__/page.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/admin-course-manager", () => ({
+  AdminCourseManager: ({ courses }: { courses: unknown[] }) => (
+    <div>Course manager: {courses.length}</div>
+  ),
+}));
+
+vi.mock("@/lib/authz", () => ({
+  requireDioceseAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/diocese-admin", () => ({
+  listCourses: vi.fn(),
+}));
+
+import DioceseAdminCoursesPage from "@/app/app/admin/courses/page";
+import { requireDioceseAdmin } from "@/lib/authz";
+import { listCourses } from "@/lib/repositories/diocese-admin";
+
+describe("DioceseAdminCoursesPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireDioceseAdmin).mockResolvedValue("admin-1");
+    vi.mocked(listCourses).mockResolvedValue([
+      {
+        id: "course-1",
+        title: "Test Course",
+        description: "Course description",
+        thumbnail_url: null,
+        scope: "DIOCESE",
+        published: true,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-02",
+      },
+    ]);
+  });
+
+  it("requires a diocese admin before rendering course data", async () => {
+    render(await DioceseAdminCoursesPage());
+
+    expect(vi.mocked(requireDioceseAdmin).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(listCourses).mock.invocationCallOrder[0],
+    );
+    expect(listCourses).toHaveBeenCalledWith(100);
+    expect(screen.getByRole("heading", { name: "Courses" })).toBeInTheDocument();
+    expect(screen.getByText("Course manager: 1")).toBeInTheDocument();
+  });
+
+  it("does not load course data when the guard rejects access", async () => {
+    const accessError = new Error("redirect");
+    vi.mocked(requireDioceseAdmin).mockRejectedValue(accessError);
+
+    await expect(DioceseAdminCoursesPage()).rejects.toThrow(accessError);
+    expect(listCourses).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/app/admin/courses/page.tsx
+++ b/src/app/app/admin/courses/page.tsx
@@ -1,10 +1,13 @@
 import { AdminCourseManager } from "@/components/admin-course-manager";
 import { Button } from "@/components/ui/button";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { requireDioceseAdmin } from "@/lib/authz";
 import { listCourses } from "@/lib/repositories/diocese-admin";
 import Link from "next/link";
 
 export default async function DioceseAdminCoursesPage() {
+  await requireDioceseAdmin();
+
   const courses = await listCourses(100);
 
   return (

--- a/src/app/app/admin/engagement/__tests__/page.test.tsx
+++ b/src/app/app/admin/engagement/__tests__/page.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/admin-engagement-report", () => ({
+  AdminEngagementReport: ({ courses, parishes }: { courses: unknown[]; parishes: unknown[] }) => (
+    <div>
+      Engagement report: {courses.length} courses; {parishes.length} parishes
+    </div>
+  ),
+}));
+
+vi.mock("@/components/admin-enrollment-manager", () => ({
+  AdminEnrollmentManager: ({
+    courses,
+    enrollments,
+    parishes,
+  }: {
+    courses: unknown[];
+    enrollments: unknown[];
+    parishes: unknown[];
+  }) => (
+    <div>
+      Enrollment manager: {courses.length} courses; {enrollments.length} enrollments; {parishes.length} parishes
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/authz", () => ({
+  requireDioceseAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/diocese-admin", () => ({
+  listCourses: vi.fn(),
+  listEngagement: vi.fn(),
+  listEnrollments: vi.fn(),
+  listParishes: vi.fn(),
+}));
+
+import DioceseAdminEngagementPage from "@/app/app/admin/engagement/page";
+import { requireDioceseAdmin } from "@/lib/authz";
+import { listCourses, listEngagement, listEnrollments, listParishes } from "@/lib/repositories/diocese-admin";
+
+describe("DioceseAdminEngagementPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireDioceseAdmin).mockResolvedValue("admin-1");
+    vi.mocked(listEngagement).mockResolvedValue([
+      {
+        parish_id: "parish-1",
+        course_id: "course-1",
+        learners_started: 2,
+        learners_completed: 1,
+      },
+    ]);
+    vi.mocked(listEnrollments).mockResolvedValue([
+      {
+        id: "enrollment-1",
+        parish_id: "parish-1",
+        clerk_user_id: "user-1",
+        course_id: "course-1",
+        created_at: "2026-01-01",
+      },
+    ]);
+    vi.mocked(listParishes).mockResolvedValue([
+      {
+        id: "parish-1",
+        name: "St Anne",
+        slug: "st-anne",
+        allow_self_signup: true,
+        archived_at: null,
+        created_at: "2026-01-01",
+      },
+    ]);
+    vi.mocked(listCourses).mockResolvedValue([
+      {
+        id: "course-1",
+        title: "Intro Course",
+        description: null,
+        thumbnail_url: null,
+        scope: "DIOCESE",
+        published: true,
+        created_at: "2026-01-01",
+        updated_at: "2026-01-01",
+      },
+    ]);
+  });
+
+  it("requires a diocese admin before rendering engagement data", async () => {
+    render(await DioceseAdminEngagementPage());
+
+    const guardCallOrder = vi.mocked(requireDioceseAdmin).mock.invocationCallOrder[0];
+    expect(guardCallOrder).toBeLessThan(vi.mocked(listEngagement).mock.invocationCallOrder[0]);
+    expect(guardCallOrder).toBeLessThan(vi.mocked(listEnrollments).mock.invocationCallOrder[0]);
+    expect(guardCallOrder).toBeLessThan(vi.mocked(listParishes).mock.invocationCallOrder[0]);
+    expect(guardCallOrder).toBeLessThan(vi.mocked(listCourses).mock.invocationCallOrder[0]);
+    expect(listEngagement).toHaveBeenCalledWith(200);
+    expect(listEnrollments).toHaveBeenCalledWith(200);
+    expect(listParishes).toHaveBeenCalledWith(200);
+    expect(listCourses).toHaveBeenCalledWith(200);
+    expect(screen.getByText("50%")).toBeInTheDocument();
+    expect(screen.getByText("of 1 enrolled learners")).toBeInTheDocument();
+    expect(screen.getByText("Enrollment manager: 1 courses; 1 enrollments; 1 parishes")).toBeInTheDocument();
+    expect(screen.getByText("Engagement report: 1 courses; 1 parishes")).toBeInTheDocument();
+  });
+
+  it("does not load engagement data when the guard rejects access", async () => {
+    const accessError = new Error("redirect");
+    vi.mocked(requireDioceseAdmin).mockRejectedValue(accessError);
+
+    await expect(DioceseAdminEngagementPage()).rejects.toThrow(accessError);
+    expect(listEngagement).not.toHaveBeenCalled();
+    expect(listEnrollments).not.toHaveBeenCalled();
+    expect(listParishes).not.toHaveBeenCalled();
+    expect(listCourses).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/app/admin/engagement/page.tsx
+++ b/src/app/app/admin/engagement/page.tsx
@@ -2,9 +2,12 @@ import { AdminEngagementReport } from "@/components/admin-engagement-report";
 import { AdminEnrollmentManager } from "@/components/admin-enrollment-manager";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ProgressBar } from "@/components/ui/progress-bar";
+import { requireDioceseAdmin } from "@/lib/authz";
 import { listCourses, listEngagement, listEnrollments, listParishes } from "@/lib/repositories/diocese-admin";
 
 export default async function DioceseAdminEngagementPage() {
+  await requireDioceseAdmin();
+
   const [engagementRows, enrollments, parishes, courses] = await Promise.all([
     listEngagement(200),
     listEnrollments(200),

--- a/src/app/app/admin/page.tsx
+++ b/src/app/app/admin/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { requireDioceseAdmin } from "@/lib/authz";
 import { getDioceseOverview } from "@/lib/repositories/diocese-admin";
 
 const statRow1 = [
@@ -35,6 +36,8 @@ function StatCard({ label, value, sub }: { label: string; value: number; sub?: s
 }
 
 export default async function DioceseAdminPage() {
+  await requireDioceseAdmin();
+
   const overview = await getDioceseOverview();
 
   const completionRate =

--- a/src/app/app/admin/parishes/__tests__/page.test.tsx
+++ b/src/app/app/admin/parishes/__tests__/page.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/admin-parish-manager", () => ({
+  AdminParishManager: ({ parishes }: { parishes: unknown[] }) => (
+    <div>Parish manager: {parishes.length}</div>
+  ),
+}));
+
+vi.mock("@/lib/authz", () => ({
+  requireDioceseAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/diocese-admin", () => ({
+  listParishes: vi.fn(),
+}));
+
+import DioceseAdminParishesPage from "@/app/app/admin/parishes/page";
+import { requireDioceseAdmin } from "@/lib/authz";
+import { listParishes } from "@/lib/repositories/diocese-admin";
+
+describe("DioceseAdminParishesPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireDioceseAdmin).mockResolvedValue("admin-1");
+    vi.mocked(listParishes).mockResolvedValue([
+      {
+        id: "parish-1",
+        name: "St Anne",
+        slug: "st-anne",
+        allow_self_signup: true,
+        archived_at: null,
+        created_at: "2026-01-01",
+      },
+    ]);
+  });
+
+  it("requires a diocese admin before rendering parish data", async () => {
+    render(await DioceseAdminParishesPage());
+
+    expect(requireDioceseAdmin).toHaveBeenCalledBefore(listParishes);
+    expect(listParishes).toHaveBeenCalledWith(100);
+    expect(screen.getByRole("heading", { name: "Parishes" })).toBeInTheDocument();
+    expect(screen.getByText("Parish manager: 1")).toBeInTheDocument();
+  });
+
+  it("does not load parish data when the guard rejects access", async () => {
+    const accessError = new Error("redirect");
+    vi.mocked(requireDioceseAdmin).mockRejectedValue(accessError);
+
+    await expect(DioceseAdminParishesPage()).rejects.toThrow(accessError);
+    expect(listParishes).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/app/admin/parishes/__tests__/page.test.tsx
+++ b/src/app/app/admin/parishes/__tests__/page.test.tsx
@@ -38,7 +38,7 @@ describe("DioceseAdminParishesPage", () => {
   it("requires a diocese admin before rendering parish data", async () => {
     render(await DioceseAdminParishesPage());
 
-    expect(requireDioceseAdmin).toHaveBeenCalledBefore(listParishes);
+    expect(vi.mocked(requireDioceseAdmin)).toHaveBeenCalledBefore(vi.mocked(listParishes));
     expect(listParishes).toHaveBeenCalledWith(100);
     expect(screen.getByRole("heading", { name: "Parishes" })).toBeInTheDocument();
     expect(screen.getByText("Parish manager: 1")).toBeInTheDocument();

--- a/src/app/app/admin/parishes/page.tsx
+++ b/src/app/app/admin/parishes/page.tsx
@@ -1,8 +1,11 @@
 import { AdminParishManager } from "@/components/admin-parish-manager";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { requireDioceseAdmin } from "@/lib/authz";
 import { listParishes } from "@/lib/repositories/diocese-admin";
 
 export default async function DioceseAdminParishesPage() {
+  await requireDioceseAdmin();
+
   const parishes = await listParishes(100);
 
   return (

--- a/src/app/app/admin/users/__tests__/page.test.tsx
+++ b/src/app/app/admin/users/__tests__/page.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/admin-user-directory-manager", () => ({
+  AdminUserDirectoryManager: ({
+    initialParishes,
+    initialUsers,
+  }: {
+    initialParishes: unknown[];
+    initialUsers: unknown[];
+  }) => (
+    <div>
+      Directory users: {initialUsers.length}; parishes: {initialParishes.length}
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/authz", () => ({
+  requireDioceseAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/diocese-admin", () => ({
+  listDioceseUserDirectory: vi.fn(),
+}));
+
+import DioceseAdminUsersPage from "@/app/app/admin/users/page";
+import { requireDioceseAdmin } from "@/lib/authz";
+import { listDioceseUserDirectory } from "@/lib/repositories/diocese-admin";
+
+describe("DioceseAdminUsersPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireDioceseAdmin).mockResolvedValue("admin-1");
+    vi.mocked(listDioceseUserDirectory).mockResolvedValue({
+      users: [
+        {
+          clerk_user_id: "user-1",
+          email: "user@example.com",
+          display_name: "User One",
+          onboarding_completed_at: null,
+          created_at: "2026-01-01",
+          is_diocese_admin: false,
+          memberships: [],
+        },
+      ],
+      parishes: [{ id: "parish-1", name: "St Anne" }],
+    });
+  });
+
+  it("requires a diocese admin before rendering directory data", async () => {
+    render(await DioceseAdminUsersPage());
+
+    expect(requireDioceseAdmin).toHaveBeenCalledBefore(listDioceseUserDirectory);
+    expect(listDioceseUserDirectory).toHaveBeenCalledWith(200);
+    expect(screen.getByRole("heading", { name: "Users" })).toBeInTheDocument();
+    expect(screen.getByText("Directory users: 1; parishes: 1")).toBeInTheDocument();
+  });
+
+  it("does not load directory data when the guard rejects access", async () => {
+    const accessError = new Error("redirect");
+    vi.mocked(requireDioceseAdmin).mockRejectedValue(accessError);
+
+    await expect(DioceseAdminUsersPage()).rejects.toThrow(accessError);
+    expect(listDioceseUserDirectory).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/app/admin/users/__tests__/page.test.tsx
+++ b/src/app/app/admin/users/__tests__/page.test.tsx
@@ -50,7 +50,7 @@ describe("DioceseAdminUsersPage", () => {
   it("requires a diocese admin before rendering directory data", async () => {
     render(await DioceseAdminUsersPage());
 
-    expect(requireDioceseAdmin).toHaveBeenCalledBefore(listDioceseUserDirectory);
+    expect(vi.mocked(requireDioceseAdmin)).toHaveBeenCalledBefore(vi.mocked(listDioceseUserDirectory));
     expect(listDioceseUserDirectory).toHaveBeenCalledWith(200);
     expect(screen.getByRole("heading", { name: "Users" })).toBeInTheDocument();
     expect(screen.getByText("Directory users: 1; parishes: 1")).toBeInTheDocument();

--- a/src/app/app/admin/users/page.tsx
+++ b/src/app/app/admin/users/page.tsx
@@ -1,8 +1,11 @@
 import { AdminUserDirectoryManager } from "@/components/admin-user-directory-manager";
 import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { requireDioceseAdmin } from "@/lib/authz";
 import { listDioceseUserDirectory } from "@/lib/repositories/diocese-admin";
 
 export default async function DioceseAdminUsersPage() {
+  await requireDioceseAdmin();
+
   const directoryData = await listDioceseUserDirectory(200);
 
   return (

--- a/src/app/app/onboarding/page.tsx
+++ b/src/app/app/onboarding/page.tsx
@@ -78,6 +78,18 @@ async function completeOnboarding(formData: FormData) {
     primaryEmail = null;
   }
 
+  const { error: membershipError } = await supabase.from("parish_memberships").upsert(
+    {
+      parish_id: parsed.data.parishId,
+      clerk_user_id: userId,
+      role: "student",
+    },
+    { onConflict: "parish_id,clerk_user_id", ignoreDuplicates: true },
+  );
+  if (membershipError) {
+    redirect("/app/onboarding?error=membership_save_failed");
+  }
+
   const { error: profileError } = await supabase.from("user_profiles").upsert(
     {
       clerk_user_id: userId,
@@ -89,18 +101,6 @@ async function completeOnboarding(formData: FormData) {
   );
   if (profileError) {
     redirect("/app/onboarding?error=profile_save_failed");
-  }
-
-  const { error: membershipError } = await supabase.from("parish_memberships").upsert(
-    {
-      parish_id: parsed.data.parishId,
-      clerk_user_id: userId,
-      role: "student",
-    },
-    { onConflict: "parish_id,clerk_user_id", ignoreDuplicates: true },
-  );
-  if (membershipError) {
-    redirect("/app/onboarding?error=membership_save_failed");
   }
 
   store.set("active_parish_id", parsed.data.parishId, {

--- a/src/app/app/onboarding/page.tsx
+++ b/src/app/app/onboarding/page.tsx
@@ -97,7 +97,7 @@ async function completeOnboarding(formData: FormData) {
       clerk_user_id: userId,
       role: "student",
     },
-    { onConflict: "parish_id,clerk_user_id" },
+    { onConflict: "parish_id,clerk_user_id", ignoreDuplicates: true },
   );
   if (membershipError) {
     redirect("/app/onboarding?error=membership_save_failed");

--- a/src/app/app/parish-admin/communications/__tests__/page.test.tsx
+++ b/src/app/app/parish-admin/communications/__tests__/page.test.tsx
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/parish-communications-manager", () => ({
+  ParishCommunicationsManager: () => <div>Communications manager</div>,
+}));
+
+vi.mock("@/lib/authz", () => ({
+  requireParishRole: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/parish-admin", () => ({
+  getParishAdminDashboardDataForUser: vi.fn(),
+}));
+
+import CommunicationsPage from "@/app/app/parish-admin/communications/page";
+import { requireParishRole } from "@/lib/authz";
+import { getParishAdminDashboardDataForUser } from "@/lib/repositories/parish-admin";
+
+describe("CommunicationsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not fetch parish-admin dashboard data for instructors", async () => {
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      role: "instructor",
+    });
+
+    await expect(CommunicationsPage()).resolves.toBeNull();
+
+    expect(requireParishRole).toHaveBeenCalledWith("parish_admin");
+    expect(getParishAdminDashboardDataForUser).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/app/parish-admin/communications/page.tsx
+++ b/src/app/app/parish-admin/communications/page.tsx
@@ -4,17 +4,13 @@ import { requireParishRole } from "@/lib/authz";
 import { getParishAdminDashboardDataForUser } from "@/lib/repositories/parish-admin";
 
 export default async function CommunicationsPage() {
-  const { parishId, role, clerkUserId } = await requireParishRole("instructor");
-  const data = await getParishAdminDashboardDataForUser({ parishId, role, clerkUserId });
+  const { parishId, role, clerkUserId } = await requireParishRole("parish_admin");
 
   if (role !== "parish_admin") {
     return null;
   }
 
-  function firstValue(value: string | string[] | undefined) {
-    if (Array.isArray(value)) return value[0];
-    return value;
-  }
+  const data = await getParishAdminDashboardDataForUser({ parishId, role, clerkUserId });
 
   // Communications page doesn't use prefill from search params in this tabbed version
   const prefill = { audienceType: null, audienceValue: null, subject: null, body: null };

--- a/src/app/app/select-parish/page.tsx
+++ b/src/app/app/select-parish/page.tsx
@@ -82,7 +82,7 @@ async function joinParish(formData: FormData) {
       clerk_user_id: userId,
       role: "student",
     },
-    { onConflict: "parish_id,clerk_user_id" },
+    { onConflict: "parish_id,clerk_user_id", ignoreDuplicates: true },
   );
 
   if (error) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,12 +30,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <AuthProvider>
-      <html lang="en" className={`${merriweather.variable} ${sourceSans.variable}`} suppressHydrationWarning>
-        <body>
+    <html lang="en" className={`${merriweather.variable} ${sourceSans.variable}`} suppressHydrationWarning>
+      <body>
+        <AuthProvider>
           <QueryProvider>{children}</QueryProvider>
-        </body>
-      </html>
-    </AuthProvider>
+        </AuthProvider>
+      </body>
+    </html>
   );
 }

--- a/src/components/__tests__/admin-parish-manager.test.tsx
+++ b/src/components/__tests__/admin-parish-manager.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AdminParishManager } from "@/components/admin-parish-manager";
+import type { DioceseParishRow } from "@/lib/repositories/diocese-admin";
+
+const refresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+function parish(overrides: Partial<DioceseParishRow>): DioceseParishRow {
+  return {
+    id: "parish-1",
+    name: "Existing Parish",
+    slug: "existing-parish",
+    allow_self_signup: true,
+    archived_at: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("AdminParishManager", () => {
+  beforeEach(() => {
+    refresh.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("saves a parish added by refreshed props before any field changes", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const initialParish = parish({ id: "parish-1" });
+    const refreshedParish = parish({
+      id: "parish-2",
+      name: "Refreshed Parish",
+      slug: "refreshed-parish",
+      allow_self_signup: false,
+    });
+
+    const { rerender } = render(<AdminParishManager parishes={[initialParish]} />);
+    rerender(<AdminParishManager parishes={[initialParish, refreshedParish]} />);
+
+    const refreshedRow = screen.getByDisplayValue("Refreshed Parish").closest("tr");
+    expect(refreshedRow).not.toBeNull();
+
+    fireEvent.click(within(refreshedRow as HTMLTableRowElement).getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/admin/parishes/parish-2",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({
+            name: "Refreshed Parish",
+            slug: "refreshed-parish",
+            allowSelfSignup: false,
+          }),
+        }),
+      ),
+    );
+    expect(refresh).toHaveBeenCalled();
+  });
+});

--- a/src/components/__tests__/admin-user-directory-manager.test.tsx
+++ b/src/components/__tests__/admin-user-directory-manager.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AdminUserDirectoryManager } from "@/components/admin-user-directory-manager";
+
+const refresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh }),
+}));
+
+const initialUsers = [
+  {
+    clerk_user_id: "user-1",
+    email: "old@example.com",
+    display_name: "Old Name",
+    onboarding_completed_at: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+    is_diocese_admin: false,
+    memberships: [],
+  },
+];
+
+const initialParishes = [
+  { id: "parish-1", name: "St. Anne" },
+  { id: "parish-2", name: "St. Mark" },
+];
+
+describe("AdminUserDirectoryManager", () => {
+  beforeEach(() => {
+    refresh.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reloads user data when access saving fails after a profile update", async () => {
+    const reloadedUsers = [
+      {
+        ...initialUsers[0],
+        email: "new@example.com",
+        display_name: "New Name",
+      },
+    ];
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url === "/api/admin/users/user-1" && init?.method === "PATCH") {
+        return {
+          ok: true,
+          json: async () => ({ ok: true }),
+        } as Response;
+      }
+
+      if (url === "/api/admin/users/access" && init?.method === "POST") {
+        return {
+          ok: false,
+          json: async () => ({ error: "Access update failed." }),
+        } as Response;
+      }
+
+      if (url === "/api/admin/users?") {
+        return {
+          ok: true,
+          json: async () => ({ users: reloadedUsers, parishes: initialParishes }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <AdminUserDirectoryManager
+        initialParishes={initialParishes}
+        initialUsers={initialUsers}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.change(within(dialog).getByDisplayValue("Old Name"), {
+      target: { value: "New Name" },
+    });
+    fireEvent.change(within(dialog).getByDisplayValue("old@example.com"), {
+      target: { value: "new@example.com" },
+    });
+    fireEvent.change(within(dialog).getByDisplayValue("Select parish to add"), {
+      target: { value: "parish-2" },
+    });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Add parish" }));
+    fireEvent.click(within(dialog).getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/admin/users?"));
+    expect(refresh).toHaveBeenCalled();
+    expect(await screen.findByText("New Name")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Access update failed. Some changes may have already been saved; the user list has been reloaded.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/document-review-card.test.tsx
+++ b/src/components/__tests__/document-review-card.test.tsx
@@ -71,4 +71,23 @@ describe("DocumentReviewCard", () => {
     expect(await screen.findByText("db error")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Mark section reviewed" })).toBeEnabled();
   });
+
+  it("reenables review action when the progress request rejects", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("network error"));
+
+    render(
+      <DocumentReviewCard
+        documentLabel="Assigned document"
+        documentUrl="/docs/reading.pdf"
+        initiallyCompleted={false}
+        lessonId="11111111-1111-4111-8111-111111111111"
+        parishId="22222222-2222-4222-8222-222222222222"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Mark section reviewed" }));
+
+    expect(await screen.findByText("Unable to update review status.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Mark section reviewed" })).toBeEnabled();
+  });
 });

--- a/src/components/__tests__/theme-toggle.test.tsx
+++ b/src/components/__tests__/theme-toggle.test.tsx
@@ -1,9 +1,28 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ThemeToggle } from "@/components/theme-toggle";
 
 describe("ThemeToggle", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    localStorage.removeItem("wd-lms-theme");
+  });
   it("applies saved theme from localStorage", async () => {
     localStorage.setItem("wd-lms-theme", "dark");
 
@@ -27,5 +46,36 @@ describe("ThemeToggle", () => {
       expect(document.documentElement.dataset.theme).toBe("dark");
     });
     expect(localStorage.getItem("wd-lms-theme")).toBe("dark");
+  });
+
+  it("falls back to system theme when no saved theme", async () => {
+    localStorage.removeItem("wd-lms-theme");
+
+    render(<ThemeToggle />);
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.theme).toBe("light");
+    });
+  });
+
+  it("toggles from dark to light", async () => {
+    localStorage.setItem("wd-lms-theme", "dark");
+
+    render(<ThemeToggle />);
+
+    const button = await screen.findByRole("button", { name: "Toggle theme" });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.theme).toBe("light");
+    });
+    expect(localStorage.getItem("wd-lms-theme")).toBe("light");
+  });
+
+  it("includes sr-only text for accessibility", async () => {
+    render(<ThemeToggle />);
+
+    await screen.findByRole("button", { name: "Toggle theme" });
+    expect(screen.getByText("Toggle theme")).toBeInTheDocument();
   });
 });

--- a/src/components/admin-parish-manager.tsx
+++ b/src/components/admin-parish-manager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import type { DioceseParishRow } from "@/lib/repositories/diocese-admin";
@@ -18,6 +18,29 @@ interface ParishDraft {
   archivedAt: string | null;
 }
 
+function buildParishDraft(parish: DioceseParishRow): ParishDraft {
+  return {
+    id: parish.id,
+    name: parish.name,
+    slug: parish.slug,
+    allowSelfSignup: parish.allow_self_signup,
+    archivedAt: parish.archived_at,
+  };
+}
+
+function buildParishDrafts(parishes: DioceseParishRow[]) {
+  return Object.fromEntries(parishes.map((parish) => [parish.id, buildParishDraft(parish)])) as Record<string, ParishDraft>;
+}
+
+function isSameDraft(left: ParishDraft, right: ParishDraft) {
+  return (
+    left.name === right.name &&
+    left.slug === right.slug &&
+    left.allowSelfSignup === right.allowSelfSignup &&
+    left.archivedAt === right.archivedAt
+  );
+}
+
 export function AdminParishManager({ parishes }: { parishes: DioceseParishRow[] }) {
   const router = useRouter();
   const [showCreateForm, setShowCreateForm] = useState(false);
@@ -25,21 +48,24 @@ export function AdminParishManager({ parishes }: { parishes: DioceseParishRow[] 
   const [newSlug, setNewSlug] = useState("");
   const [newAllowSelfSignup, setNewAllowSelfSignup] = useState(true);
   const [statusFilter, setStatusFilter] = useState<"all" | "active" | "archived">("all");
-  const [drafts, setDrafts] = useState<Record<string, ParishDraft>>(
-    Object.fromEntries(
-      parishes.map((parish) => [
-        parish.id,
-        {
-          id: parish.id,
-          name: parish.name,
-          slug: parish.slug,
-          allowSelfSignup: parish.allow_self_signup,
-          archivedAt: parish.archived_at,
-        },
-      ]),
-    ),
-  );
+  const [drafts, setDrafts] = useState<Record<string, ParishDraft>>(() => buildParishDrafts(parishes));
+  const previousPropDrafts = useRef<Record<string, ParishDraft>>(buildParishDrafts(parishes));
   const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    setDrafts((prev) => {
+      const next = { ...prev };
+      for (const parish of parishes) {
+        const propDraft = buildParishDraft(parish);
+        const previousPropDraft = previousPropDrafts.current[parish.id];
+        if (!next[parish.id] || (previousPropDraft && isSameDraft(next[parish.id], previousPropDraft))) {
+          next[parish.id] = propDraft;
+        }
+      }
+      return next;
+    });
+    previousPropDrafts.current = buildParishDrafts(parishes);
+  }, [parishes]);
 
   async function createParish() {
     const response = await fetch("/api/admin/parishes", {
@@ -63,7 +89,13 @@ export function AdminParishManager({ parishes }: { parishes: DioceseParishRow[] 
   }
 
   async function saveParish(id: string) {
-    const draft = drafts[id];
+    const parish = parishes.find((candidate) => candidate.id === id);
+    const draft = drafts[id] ?? (parish ? buildParishDraft(parish) : null);
+    if (!draft) {
+      setMessage("Unable to find parish draft.");
+      return;
+    }
+
     const response = await fetch(`/api/admin/parishes/${id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },

--- a/src/components/admin-user-directory-manager.tsx
+++ b/src/components/admin-user-directory-manager.tsx
@@ -285,7 +285,11 @@ export function AdminUserDirectoryManager({
       closeEditor();
       setMessage("User profile and access updated.");
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : "Failed to update user.");
+      const errorMessage = error instanceof Error ? error.message : "Failed to update user.";
+      await loadUsers(filters);
+      router.refresh();
+      closeEditor();
+      setMessage(`${errorMessage} Some changes may have already been saved; the user list has been reloaded.`);
     } finally {
       setSaving(false);
     }

--- a/src/components/document-review-card.tsx
+++ b/src/components/document-review-card.tsx
@@ -26,28 +26,32 @@ export function DocumentReviewCard({
     setSubmitting(true);
     setMessage("");
 
-    const response = await fetch("/api/progress", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        lessonId,
-        parishId,
-        percentWatched: 100,
-        lastPositionSeconds: 0,
-        completed: true,
-      }),
-    });
+    try {
+      const response = await fetch("/api/progress", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          lessonId,
+          parishId,
+          percentWatched: 100,
+          lastPositionSeconds: 0,
+          completed: true,
+        }),
+      });
 
-    const data = await response.json();
+      const data = (await response.json()) as { error?: string };
 
-    if (response.ok) {
-      setCompleted(true);
-      setMessage("Section marked as reviewed.");
-    } else {
-      setMessage(data.error ?? "Unable to update review status.");
+      if (response.ok) {
+        setCompleted(true);
+        setMessage("Section marked as reviewed.");
+      } else {
+        setMessage(data.error ?? "Unable to update review status.");
+      }
+    } catch {
+      setMessage("Unable to update review status.");
+    } finally {
+      setSubmitting(false);
     }
-
-    setSubmitting(false);
   }
 
   return (

--- a/src/components/player/__tests__/youtube-player.test.tsx
+++ b/src/components/player/__tests__/youtube-player.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { YoutubePlayer } from "@/components/player/youtube-player";
+
+vi.mock("next/script", () => ({
+  default: () => null,
+}));
+
+function readBlob(blob: Blob) {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error);
+    reader.onload = () => resolve(String(reader.result));
+    reader.readAsText(blob);
+  });
+}
+
+describe("YoutubePlayer", () => {
+  const player = {
+    destroy: vi.fn(),
+    getCurrentTime: vi.fn(() => 45),
+    getDuration: vi.fn(() => 120),
+    seekTo: vi.fn(),
+  };
+  const playerConstructor = vi.fn(function Player() {
+    return player;
+  });
+  const sendBeacon = vi.fn<(url: string | URL, data?: BodyInit | null) => boolean>(
+    () => true,
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(new Response())));
+
+    Object.defineProperty(navigator, "sendBeacon", {
+      configurable: true,
+      value: sendBeacon,
+    });
+    Object.defineProperty(window, "YT", {
+      configurable: true,
+      value: {
+        Player: playerConstructor,
+        PlayerState: {
+          PLAYING: 1,
+          PAUSED: 2,
+          ENDED: 0,
+        },
+      },
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    delete window.YT;
+    delete window.onYouTubeIframeAPIReady;
+  });
+
+  it("uses sendBeacon for beforeunload progress saves", async () => {
+    render(
+      <YoutubePlayer
+        lessonId="lesson-1"
+        parishId="parish-1"
+        videoId="video-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(playerConstructor).toHaveBeenCalledTimes(1);
+    });
+
+    window.dispatchEvent(new Event("beforeunload"));
+
+    expect(sendBeacon).toHaveBeenCalledTimes(1);
+    const [url, body] = sendBeacon.mock.calls[0]!;
+    expect(url).toBe("/api/progress");
+    expect(body).toBeInstanceOf(Blob);
+    await expect(readBlob(body as Blob)).resolves.toBe(
+      JSON.stringify({
+        lessonId: "lesson-1",
+        parishId: "parish-1",
+        lastPositionSeconds: 45,
+        percentWatched: 38,
+        completed: false,
+      }),
+    );
+  });
+});

--- a/src/components/player/youtube-player.tsx
+++ b/src/components/player/youtube-player.tsx
@@ -48,6 +48,31 @@ async function saveProgress(payload: {
   });
 }
 
+function saveProgressOnUnload(payload: {
+  lessonId: string;
+  parishId: string;
+  lastPositionSeconds: number;
+  percentWatched: number;
+  completed: boolean;
+}) {
+  const body = JSON.stringify(payload);
+
+  if (navigator.sendBeacon) {
+    navigator.sendBeacon(
+      "/api/progress",
+      new Blob([body], { type: "application/json" }),
+    );
+    return;
+  }
+
+  void fetch("/api/progress", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body,
+    keepalive: true,
+  });
+}
+
 export function YoutubePlayer({
   lessonId,
   parishId,
@@ -65,22 +90,36 @@ export function YoutubePlayer({
     [lessonId],
   );
 
-  const flushProgress = useCallback(
-    async (forcedCompleted = false) => {
-      if (!playerRef.current) return;
+  const buildProgressPayload = useCallback(
+    (forcedCompleted = false) => {
+      if (!playerRef.current) return null;
       const duration = Math.max(1, playerRef.current.getDuration?.() || 1);
       const lastPosition = Math.floor(playerRef.current.getCurrentTime?.() || 0);
       const percent = Math.min(100, Math.round((lastPosition / duration) * 100));
-      await saveProgress({
+
+      return {
         lessonId,
         parishId,
         lastPositionSeconds: lastPosition,
         percentWatched: percent,
         completed: forcedCompleted || percent >= 90,
-      });
+      };
     },
     [lessonId, parishId],
   );
+
+  const flushProgress = useCallback(
+    async (forcedCompleted = false) => {
+      const payload = buildProgressPayload(forcedCompleted);
+      if (payload) await saveProgress(payload);
+    },
+    [buildProgressPayload],
+  );
+
+  const flushProgressOnUnload = useCallback(() => {
+    const payload = buildProgressPayload(false);
+    if (payload) saveProgressOnUnload(payload);
+  }, [buildProgressPayload]);
 
   useEffect(() => {
     window.onYouTubeIframeAPIReady = () => setApiReady(true);
@@ -129,7 +168,7 @@ export function YoutubePlayer({
     playerRef.current = player;
 
     const onBeforeUnload = () => {
-      void flushProgress(false);
+      flushProgressOnUnload();
     };
 
     window.addEventListener("beforeunload", onBeforeUnload);
@@ -141,7 +180,14 @@ export function YoutubePlayer({
       player.destroy();
       playerRef.current = null;
     };
-  }, [apiReady, flushProgress, playerContainerId, resumeSeconds, videoId]);
+  }, [
+    apiReady,
+    flushProgress,
+    flushProgressOnUnload,
+    playerContainerId,
+    resumeSeconds,
+    videoId,
+  ]);
 
   return (
     <>

--- a/src/components/ui/__tests__/radix-primitives.test.tsx
+++ b/src/components/ui/__tests__/radix-primitives.test.tsx
@@ -14,6 +14,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 
 describe("Radix primitives", () => {
   it("renders Dialog content when open", () => {
@@ -60,5 +61,19 @@ describe("Radix primitives", () => {
     );
 
     expect(screen.getByRole("tooltip")).toHaveTextContent("Helpful context");
+  });
+
+  it("renders Sheet content on the right side", () => {
+    render(
+      <Sheet open onOpenChange={() => {}}>
+        <SheetContent side="right">
+          <SheetHeader>
+            <SheetTitle>Sheet Title</SheetTitle>
+          </SheetHeader>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expect(screen.getByText("Sheet Title")).toBeInTheDocument();
   });
 });

--- a/src/lib/parish-communications/__tests__/delivery-provider.test.ts
+++ b/src/lib/parish-communications/__tests__/delivery-provider.test.ts
@@ -22,6 +22,64 @@ describe("getParishDeliveryConfig", () => {
       provider: "mock",
     });
   });
+
+  it("enables resend when configured with all env vars", () => {
+    process.env.PARISH_COMMUNICATIONS_DELIVERY_MODE = "resend";
+    process.env.RESEND_API_KEY = "re_test_key";
+    process.env.RESEND_FROM_EMAIL = "parish@test.com";
+
+    expect(getParishDeliveryConfig()).toEqual({
+      enabled: true,
+      provider: "resend",
+      resendApiKey: "re_test_key",
+      resendFromEmail: "parish@test.com",
+    });
+
+    delete process.env.RESEND_API_KEY;
+    delete process.env.RESEND_FROM_EMAIL;
+  });
+
+  it("falls back to disabled when resend is configured but missing api key", () => {
+    process.env.PARISH_COMMUNICATIONS_DELIVERY_MODE = "resend";
+    process.env.RESEND_FROM_EMAIL = "parish@test.com";
+
+    expect(getParishDeliveryConfig()).toEqual({
+      enabled: false,
+      provider: null,
+    });
+
+    delete process.env.RESEND_FROM_EMAIL;
+  });
+
+  it("falls back to disabled when resend is configured but missing from email", () => {
+    process.env.PARISH_COMMUNICATIONS_DELIVERY_MODE = "resend";
+    process.env.RESEND_API_KEY = "re_test_key";
+
+    expect(getParishDeliveryConfig()).toEqual({
+      enabled: false,
+      provider: null,
+    });
+
+    delete process.env.RESEND_API_KEY;
+  });
+
+  it("returns disabled for unknown delivery mode", () => {
+    process.env.PARISH_COMMUNICATIONS_DELIVERY_MODE = "smtp";
+
+    expect(getParishDeliveryConfig()).toEqual({
+      enabled: false,
+      provider: null,
+    });
+  });
+
+  it("returns disabled when mode is explicitly set to disabled", () => {
+    process.env.PARISH_COMMUNICATIONS_DELIVERY_MODE = "disabled";
+
+    expect(getParishDeliveryConfig()).toEqual({
+      enabled: false,
+      provider: null,
+    });
+  });
 });
 
 describe("deliverParishMessage", () => {
@@ -50,6 +108,37 @@ describe("deliverParishMessage", () => {
     expect(result).toEqual({
       sent: ["u-1"],
       failed: [{ clerkUserId: "u-2", error: "Recipient has no email on file." }],
+    });
+  });
+
+  it("sends to all recipients when all have valid emails", async () => {
+    const result = await deliverParishMessage({
+      provider: "mock",
+      subject: "Subject",
+      body: "Body",
+      recipients: [
+        { clerkUserId: "u-1", email: "u1@example.com" },
+        { clerkUserId: "u-2", email: "u2@example.com" },
+      ],
+    });
+
+    expect(result).toEqual({
+      sent: ["u-1", "u-2"],
+      failed: [],
+    });
+  });
+
+  it("returns empty sent and failed when recipients array is empty", async () => {
+    const result = await deliverParishMessage({
+      provider: "mock",
+      subject: "Subject",
+      body: "Body",
+      recipients: [],
+    });
+
+    expect(result).toEqual({
+      sent: [],
+      failed: [],
     });
   });
 });

--- a/src/lib/parish-communications/__tests__/notifications.test.ts
+++ b/src/lib/parish-communications/__tests__/notifications.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fail, ok } from "@/test/supabase-route-mocks";
+import { ok } from "@/test/supabase-route-mocks";
 
 vi.mock("@/lib/supabase/server", () => ({
   getSupabaseAdminClient: vi.fn(),
@@ -102,6 +102,43 @@ describe("notifyJoinRequestApproved", () => {
     vi.clearAllMocks();
   });
 
+  it("does nothing when delivery is disabled", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: false, provider: null });
+    await notifyJoinRequestApproved({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+    expect(deliverParishMessage).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when provider is not configured", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: null });
+    await notifyJoinRequestApproved({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+    expect(deliverParishMessage).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when user has no email", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: "mock" });
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ({ data: null, error: null })) })),
+        })),
+      })),
+    } as never);
+    await notifyJoinRequestApproved({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+    expect(deliverParishMessage).not.toHaveBeenCalled();
+  });
+
   it("sends approval email with correct subject and body", async () => {
     vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: "mock" });
 
@@ -139,6 +176,43 @@ describe("notifyJoinRequestRejected", () => {
     vi.clearAllMocks();
   });
 
+  it("does nothing when delivery is disabled", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: false, provider: null });
+    await notifyJoinRequestRejected({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+    expect(deliverParishMessage).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when provider is not configured", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: null });
+    await notifyJoinRequestRejected({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+    expect(deliverParishMessage).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when user has no email", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: "mock" });
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ({ data: null, error: null })) })),
+        })),
+      })),
+    } as never);
+    await notifyJoinRequestRejected({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+    expect(deliverParishMessage).not.toHaveBeenCalled();
+  });
+
   it("sends rejection email with correct subject and body", async () => {
     vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: "mock" });
 
@@ -174,6 +248,43 @@ describe("notifyJoinRequestRejected", () => {
 describe("notifyEnrollmentConfirmed", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("does nothing when delivery is disabled", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: false, provider: null });
+    await notifyEnrollmentConfirmed({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+    expect(deliverParishMessage).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when provider is not configured", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: null });
+    await notifyEnrollmentConfirmed({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+    expect(deliverParishMessage).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when user has no email", async () => {
+    vi.mocked(getParishDeliveryConfig).mockReturnValue({ enabled: true, provider: "mock" });
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => ({ maybeSingle: vi.fn(async () => ({ data: null, error: null })) })),
+        })),
+      })),
+    } as never);
+    await notifyEnrollmentConfirmed({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+    expect(deliverParishMessage).not.toHaveBeenCalled();
   });
 
   it("sends enrollment confirmation email with correct data", async () => {

--- a/src/lib/reports/__tests__/engagement-report.test.ts
+++ b/src/lib/reports/__tests__/engagement-report.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseEngagementFilters,
+  hasDateFilters,
+  getDateRangeBounds,
+} from "@/lib/reports/engagement-report";
+
+describe("parseEngagementFilters", () => {
+  it("returns empty filters when no params provided", () => {
+    const result = parseEngagementFilters(new URLSearchParams());
+    expect(result.ok).toBe(true);
+    expect(result).toEqual({ ok: true, filters: {} });
+  });
+
+  it("parses all valid filter params", () => {
+    const result = parseEngagementFilters(
+      new URLSearchParams("parishId=p1&courseId=c1&startDate=2024-01-01&endDate=2024-12-31"),
+    );
+    expect(result).toEqual({
+      ok: true,
+      filters: { parishId: "p1", courseId: "c1", startDate: "2024-01-01", endDate: "2024-12-31" },
+    });
+  });
+
+  it("returns error for invalid startDate format", () => {
+    const result = parseEngagementFilters(new URLSearchParams("startDate=not-a-date"));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("startDate");
+    }
+  });
+
+  it("returns error for invalid endDate format", () => {
+    const result = parseEngagementFilters(new URLSearchParams("endDate=not-a-date"));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("endDate");
+    }
+  });
+
+  it("returns error when startDate is after endDate", () => {
+    const result = parseEngagementFilters(
+      new URLSearchParams("startDate=2024-12-31&endDate=2024-01-01"),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("startDate");
+    }
+  });
+
+  it("allows startDate equal to endDate", () => {
+    const result = parseEngagementFilters(
+      new URLSearchParams("startDate=2024-06-15&endDate=2024-06-15"),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects invalid calendar date", () => {
+    const result = parseEngagementFilters(new URLSearchParams("startDate=2024-02-30"));
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts leap year feb 29", () => {
+    const result = parseEngagementFilters(new URLSearchParams("startDate=2024-02-29"));
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects feb 29 in non-leap year", () => {
+    const result = parseEngagementFilters(new URLSearchParams("startDate=2025-02-29"));
+    expect(result.ok).toBe(false);
+  });
+
+  it("allows startDate without endDate", () => {
+    const result = parseEngagementFilters(new URLSearchParams("startDate=2024-01-01"));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filters.startDate).toBe("2024-01-01");
+    }
+  });
+
+  it("allows endDate without startDate", () => {
+    const result = parseEngagementFilters(new URLSearchParams("endDate=2024-12-31"));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filters.endDate).toBe("2024-12-31");
+    }
+  });
+});
+
+describe("hasDateFilters", () => {
+  it("returns false when both dates are undefined", () => {
+    expect(hasDateFilters({})).toBe(false);
+  });
+
+  it("returns true when only startDate is set", () => {
+    expect(hasDateFilters({ startDate: "2024-01-01" })).toBe(true);
+  });
+
+  it("returns true when only endDate is set", () => {
+    expect(hasDateFilters({ endDate: "2024-12-31" })).toBe(true);
+  });
+
+  it("returns true when both dates are set", () => {
+    expect(hasDateFilters({ startDate: "2024-01-01", endDate: "2024-12-31" })).toBe(true);
+  });
+});
+
+describe("getDateRangeBounds", () => {
+  it("returns null when no date filters", () => {
+    expect(getDateRangeBounds({})).toBeNull();
+  });
+
+  it("returns correct bounds when only startDate is set", () => {
+    const result = getDateRangeBounds({ startDate: "2024-06-15" });
+    expect(result).toEqual({
+      startAt: "2024-06-15T00:00:00.000Z",
+      endAt: "9999-12-31T23:59:59.999Z",
+    });
+  });
+
+  it("returns correct bounds when only endDate is set", () => {
+    const result = getDateRangeBounds({ endDate: "2024-12-31" });
+    expect(result).toEqual({
+      startAt: "1970-01-01T00:00:00.000Z",
+      endAt: "2024-12-31T23:59:59.999Z",
+    });
+  });
+
+  it("returns correct bounds when both dates are set", () => {
+    const result = getDateRangeBounds({ startDate: "2024-01-01", endDate: "2024-12-31" });
+    expect(result).toEqual({
+      startAt: "2024-01-01T00:00:00.000Z",
+      endAt: "2024-12-31T23:59:59.999Z",
+    });
+  });
+});

--- a/src/lib/repositories/__tests__/certificates.test.ts
+++ b/src/lib/repositories/__tests__/certificates.test.ts
@@ -1,12 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { ok } from "@/test/supabase-route-mocks";
 
 vi.mock("@/lib/supabase/server", () => ({
   getSupabaseAdminClient: vi.fn(),
 }));
 
+vi.mock("@/lib/e2e-mode", () => ({
+  isE2ESmokeMode: vi.fn(() => false),
+}));
+
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
-import { checkAndIssueCertificate } from "@/lib/repositories/certificates";
+import { isE2ESmokeMode } from "@/lib/e2e-mode";
+import {
+  checkAndIssueCertificate,
+  listStudentCertificates,
+  getCertificatePdfData,
+} from "@/lib/repositories/certificates";
 
 /** Helper: build a certificates table mock that supports .select().eq().eq().maybeSingle() */
 function certificatesMock(returnData: unknown) {
@@ -151,46 +159,13 @@ describe("checkAndIssueCertificate", () => {
   });
 
   it("returns null when certificate insert fails", async () => {
-    vi.mocked(getSupabaseAdminClient).mockReturnValue({
-      from: vi.fn((table: string) => {
-        if (table === "certificates") {
-          return {
-            select: vi.fn(() => ({
-              eq: vi.fn(() => ({
-                eq: vi.fn(() => ({
-                  eq: vi.fn(() => ({
-                    maybeSingle: vi.fn(async () => ({ data: null, error: null })),
-                  })),
-                })),
-              })),
-            })),
-          };
-        }
-        if (table === "modules") return modulesMock([{ id: "mod-1" }]);
-        if (table === "lessons") return lessonsMock([{ id: "lesson-1" }]);
-        if (table === "video_progress") return videoProgressMock([{ lesson_id: "lesson-1", completed: true }]);
-        throw new Error(`Unexpected table ${table}`);
-      }),
-    } as never);
-
-    // Override insert to fail
     let certCallCount = 0;
     vi.mocked(getSupabaseAdminClient).mockReturnValue({
       from: vi.fn((table: string) => {
         if (table === "certificates") {
           certCallCount++;
           if (certCallCount === 1) {
-            return {
-              select: vi.fn(() => ({
-                eq: vi.fn(() => ({
-                  eq: vi.fn(() => ({
-                    eq: vi.fn(() => ({
-                      maybeSingle: vi.fn(async () => ({ data: null, error: null })),
-                    })),
-                  })),
-                })),
-              })),
-            };
+            return certificatesMock(null);
           }
           return {
             insert: vi.fn(() => ({
@@ -214,5 +189,366 @@ describe("checkAndIssueCertificate", () => {
     });
 
     expect(result).toBeNull();
+  });
+
+  it("returns null in e2e smoke mode", async () => {
+    vi.mocked(isE2ESmokeMode).mockReturnValue(true);
+
+    const result = await checkAndIssueCertificate({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when course has modules but no lessons", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "certificates") return certificatesMock(null);
+        if (table === "modules") return modulesMock([{ id: "mod-1" }]);
+        if (table === "lessons") return lessonsMock([]);
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    const result = await checkAndIssueCertificate({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      courseId: "course-1",
+    });
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("listStudentCertificates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isE2ESmokeMode).mockReturnValue(false);
+  });
+
+  function fromMock(tables: Record<string, unknown>) {
+    return vi.fn((table: string) => {
+      const mock = tables[table];
+      if (!mock) throw new Error(`Unexpected table "${table}" in test mock`);
+      return mock;
+    });
+  }
+
+  it("returns empty array in e2e smoke mode", async () => {
+    vi.mocked(isE2ESmokeMode).mockReturnValue(true);
+    const result = await listStudentCertificates("user-1", "parish-1");
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when certificates query errors", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: fromMock({
+        certificates: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                order: vi.fn(async () => ({ data: null, error: { message: "db error" } })),
+              })),
+            })),
+          })),
+        },
+      }),
+    } as never);
+
+    const result = await listStudentCertificates("user-1", "parish-1");
+    expect(result).toEqual([]);
+  });
+
+  it("returns enriched certificates with parish name and student name and lesson counts", async () => {
+    const certs = [
+      { id: "cert-1", clerk_user_id: "user-1", parish_id: "parish-1", course_id: "course-1", issued_at: "2026-01-15T00:00:00Z", download_url: null },
+      { id: "cert-2", clerk_user_id: "user-1", parish_id: "parish-1", course_id: "course-2", issued_at: "2026-02-20T00:00:00Z", download_url: null },
+    ];
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: fromMock({
+        certificates: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                order: vi.fn(async () => ({ data: certs, error: null })),
+              })),
+            })),
+          })),
+        },
+        courses: {
+          select: vi.fn(() => ({
+            in: vi.fn(async () => ({
+              data: [
+                { id: "course-1", title: "Armenian 101" },
+                { id: "course-2", title: "Bible Study" },
+              ],
+              error: null,
+            })),
+          })),
+        },
+        parishes: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({ data: { name: "St. John" }, error: null })),
+            })),
+          })),
+        },
+        user_profiles: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({ data: { display_name: "John Doe" }, error: null })),
+            })),
+          })),
+        },
+        modules: {
+          select: vi.fn(() => ({
+            in: vi.fn(async () => ({
+              data: [
+                { id: "mod-1", course_id: "course-1" },
+                { id: "mod-2", course_id: "course-2" },
+              ],
+              error: null,
+            })),
+          })),
+        },
+        lessons: {
+          select: vi.fn(() => ({
+            in: vi.fn(async () => ({
+              data: [
+                { id: "lesson-1", module_id: "mod-1" },
+                { id: "lesson-2", module_id: "mod-1" },
+                { id: "lesson-3", module_id: "mod-2" },
+              ],
+              error: null,
+            })),
+          })),
+        },
+      }),
+    } as never);
+
+    const result = await listStudentCertificates("user-1", "parish-1");
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ course_title: "Armenian 101", parish_name: "St. John", student_name: "John Doe", lesson_count: 2 });
+    expect(result[1]).toMatchObject({ course_title: "Bible Study", parish_name: "St. John", student_name: "John Doe", lesson_count: 1 });
+  });
+
+  it("returns empty array when certificates query returns null data", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: fromMock({
+        certificates: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                order: vi.fn(async () => ({ data: null, error: null })),
+              })),
+            })),
+          })),
+        },
+      }),
+    } as never);
+
+    const result = await listStudentCertificates("user-1", "parish-1");
+    expect(result).toEqual([]);
+  });
+  it("uses fallback values when enrichment data is missing", async () => {
+    const certs = [
+      { id: "cert-1", clerk_user_id: "user-1", parish_id: "parish-1", course_id: "course-1", issued_at: "2026-01-15T00:00:00Z", download_url: null },
+    ];
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: fromMock({
+        certificates: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                order: vi.fn(async () => ({ data: certs, error: null })),
+              })),
+            })),
+          })),
+        },
+        courses: {
+          select: vi.fn(() => ({
+            in: vi.fn(async () => ({ data: null, error: null })),
+          })),
+        },
+        parishes: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({ data: null, error: null })),
+            })),
+          })),
+        },
+        user_profiles: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+            })),
+          })),
+        },
+        modules: {
+          select: vi.fn(() => ({
+            in: vi.fn(async () => ({ data: null, error: null })),
+          })),
+        },
+        lessons: {
+          select: vi.fn(() => ({
+            in: vi.fn(async () => ({ data: null, error: null })),
+          })),
+        },
+      }),
+    } as never);
+
+    const result = await listStudentCertificates("user-1", "parish-1");
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      course_title: "Unknown Course",
+      parish_name: "Unknown Parish",
+      student_name: "user-1",
+      lesson_count: 0,
+    });
+  });
+});
+
+describe("getCertificatePdfData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isE2ESmokeMode).mockReturnValue(false);
+  });
+
+  function fromMock(tables: Record<string, unknown>) {
+    return vi.fn((table: string) => {
+      const mock = tables[table];
+      if (!mock) throw new Error(`Unexpected table "${table}" in test mock`);
+      return mock;
+    });
+  }
+
+  it("returns null in e2e smoke mode", async () => {
+    vi.mocked(isE2ESmokeMode).mockReturnValue(true);
+    const result = await getCertificatePdfData("cert-1");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when certificate not found", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: fromMock({
+        certificates: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({ data: null, error: null })),
+            })),
+          })),
+        },
+      }),
+    } as never);
+
+    const result = await getCertificatePdfData("cert-1");
+    expect(result).toBeNull();
+  });
+
+  it("returns certificate pdf data with correct fields", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: fromMock({
+        certificates: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({
+                data: {
+                  clerk_user_id: "user-1",
+                  parish_id: "parish-1",
+                  course_id: "course-1",
+                  issued_at: "2026-03-15T12:00:00Z",
+                },
+                error: null,
+              })),
+            })),
+          })),
+        },
+        parishes: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({ data: { name: "St. John" }, error: null })),
+            })),
+          })),
+        },
+        user_profiles: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({ data: { display_name: "John Doe" }, error: null })),
+            })),
+          })),
+        },
+        courses: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({ data: { title: "Armenian 101" }, error: null })),
+            })),
+          })),
+        },
+      }),
+    } as never);
+
+    const result = await getCertificatePdfData("cert-1");
+    expect(result).toEqual({
+      studentName: "John Doe",
+      courseTitle: "Armenian 101",
+      parishName: "St. John",
+      completionDate: "March 15, 2026",
+      courseLessonCount: 0,
+    });
+  });
+
+  it("returns empty array when course not found during pdf data lookup", async () => {
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: fromMock({
+        certificates: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({
+                data: {
+                  clerk_user_id: "user-1",
+                  parish_id: "parish-1",
+                  course_id: "course-1",
+                  issued_at: "2026-03-15T12:00:00Z",
+                },
+                error: null,
+              })),
+            })),
+          })),
+        },
+        parishes: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({ data: { name: "St. John" }, error: null })),
+            })),
+          })),
+        },
+        user_profiles: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({ data: { display_name: "John Doe" }, error: null })),
+            })),
+          })),
+        },
+        courses: {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({ data: null, error: null })),
+            })),
+          })),
+        },
+      }),
+    } as never);
+
+    const result = await getCertificatePdfData("cert-1");
+    expect(result).toMatchObject({
+      courseTitle: "Unknown Course",
+      parishName: "St. John",
+      studentName: "John Doe",
+    });
   });
 });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -27,20 +27,27 @@ function createMemoryStorage(): Storage {
   };
 }
 
-if (typeof localStorage?.clear !== "function" || typeof localStorage?.setItem !== "function") {
+const existingStorage = globalThis.localStorage;
+
+if (
+  typeof existingStorage?.clear !== "function" ||
+  typeof existingStorage?.setItem !== "function"
+) {
   Object.defineProperty(globalThis, "localStorage", {
     configurable: true,
     value: createMemoryStorage(),
   });
 
-  Object.defineProperty(window, "localStorage", {
-    configurable: true,
-    value: globalThis.localStorage,
-  });
+  if (typeof globalThis.window !== "undefined") {
+    Object.defineProperty(globalThis.window, "localStorage", {
+      configurable: true,
+      value: globalThis.localStorage,
+    });
+  }
 }
 
 afterEach(() => {
   cleanup();
-  localStorage.clear();
+  globalThis.localStorage.clear();
   delete document.documentElement.dataset.theme;
 });


### PR DESCRIPTION
## Summary
- Fixes high-priority clawpatch findings, including admin route authorization guards and root layout provider placement
- Fixes data-loss/security findings from clawpatch: content import cleanup, CSV formula neutralization, onboarding/self-signup role preservation, progress save reliability, cohort PATCH optional fields, and related UI failure states
- Adds focused regression tests for the fixed paths

## Validation
- npm run typecheck
- npm run lint (passes with existing warnings)
- clawpatch revalidate for each committed finding

High-priority open findings are now at 0; 209 lower-priority findings remain open.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth guards, membership upserts, and admin data paths; changes are defensive and well-tested but span security-sensitive surfaces.
> 
> **Overview**
> This PR closes **high-priority clawpatch findings** with targeted auth, data-integrity, and export-safety fixes, plus regression tests.
> 
> **Authorization:** Diocese admin server pages now call `requireDioceseAdmin()` before loading data; parish **communications** is limited to `parish_admin` (no dashboard fetch for instructors). Root layout moves `AuthProvider` inside `<html>`/`<body>`.
> 
> **Data & security:** Cohort `PATCH` only updates `facilitatorClerkUserId` / `nextSessionAt` when those keys are present. Participation CSV prefixes cells that start with formula characters (`=`, `+`, `-`, `@`, tab, CR). Onboarding and select-parish membership upserts use `ignoreDuplicates: true` so existing roles are not overwritten. Onboarding creates membership before profile save.
> 
> **Reliability:** Content import tracks the created course via `onCourseCreated` for cleanup on failure. YouTube progress uses `sendBeacon` (or `keepalive` fetch) on `beforeunload`. Document review and admin user-directory flows handle partial failures and reload state.
> 
> **UI:** `AdminParishManager` syncs drafts when props refresh; related admin save/error paths are tightened.
> 
> Also adds `.gitignore` entries for agent/crabbox tooling and `scripts/crabbox-ensure-node-deps.sh` for Node 20 + `npm ci`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 552e91abb2e66de863f963be4d367bf49f2d8183. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->