### PR TITLE
Fix medium data integrity issues

### DIFF
--- a/src/app/api/admin-membership/__tests__/route.test.ts
+++ b/src/app/api/admin-membership/__tests__/route.test.ts
@@ -80,6 +80,67 @@ describe("POST /api/admin-membership", () => {
     await expect(response.json()).resolves.toEqual({ error: "cannot promote" });
   });
 
+  it("returns 400 for invalid request payloads", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/admin-membership", {
+        method: "POST",
+        body: JSON.stringify({
+          clerkUserId: "user-2",
+          parishId: "not-a-uuid",
+          role: "student",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid admin membership request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/admin-membership", {
+        method: "POST",
+        body: "{",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid admin membership request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for no-op membership payloads", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/admin-membership", {
+        method: "POST",
+        body: JSON.stringify({
+          clerkUserId: "user-2",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid admin membership request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for incomplete parish membership payloads", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/admin-membership", {
+        method: "POST",
+        body: JSON.stringify({
+          clerkUserId: "user-2",
+          parishId: "11111111-1111-4111-8111-111111111111",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid admin membership request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
   it("returns 400 when parish membership upsert fails", async () => {
     const membershipUpsert = vi.fn(async () => ({ error: { message: "invalid role" } }));
 

--- a/src/app/api/admin-membership/route.ts
+++ b/src/app/api/admin-membership/route.ts
@@ -13,7 +13,21 @@ const schema = z.object({
 
 export async function POST(req: Request) {
   await requireDioceseAdmin();
-  const payload = schema.parse(await req.json());
+  let payload: z.infer<typeof schema>;
+
+  try {
+    payload = schema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ error: "Invalid admin membership request payload" }, { status: 400 });
+  }
+
+  const hasParishMembershipChange = Boolean(payload.parishId && payload.role);
+  const hasPartialParishMembershipChange = Boolean(payload.parishId || payload.role) && !hasParishMembershipChange;
+
+  if (hasPartialParishMembershipChange || (!payload.makeDioceseAdmin && !hasParishMembershipChange)) {
+    return NextResponse.json({ error: "Invalid admin membership request payload" }, { status: 400 });
+  }
+
   const supabase = getSupabaseAdminClient();
 
   if (payload.makeDioceseAdmin) {
@@ -23,7 +37,7 @@ export async function POST(req: Request) {
     if (error) return NextResponse.json({ error: error.message }, { status: 400 });
   }
 
-  if (payload.parishId && payload.role) {
+  if (hasParishMembershipChange) {
     const { error } = await supabase.from("parish_memberships").upsert(
       {
         parish_id: payload.parishId,

--- a/src/app/api/admin/courses/[courseId]/modules/__tests__/route.test.ts
+++ b/src/app/api/admin/courses/[courseId]/modules/__tests__/route.test.ts
@@ -26,4 +26,15 @@ describe("POST /api/admin/courses/[courseId]/modules", () => {
 
     expect(res.status).toBe(201);
   });
+
+  it("returns 400 for invalid module payloads", async () => {
+    const res = await POST(
+      new Request("http://x", { method: "POST", body: JSON.stringify({ title: "", sortOrder: -1 }) }),
+      { params: Promise.resolve({ courseId: "11111111-1111-4111-8111-111111111111" }) },
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid module request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/admin/courses/[courseId]/modules/route.ts
+++ b/src/app/api/admin/courses/[courseId]/modules/route.ts
@@ -29,8 +29,15 @@ const createModuleSchema = z.object({
 
 export async function POST(req: Request, ctx: { params: Promise<{ courseId: string }> }) {
   await requireDioceseAdmin();
-  const { courseId } = paramsSchema.parse(await ctx.params);
-  const payload = createModuleSchema.parse(await req.json());
+  let courseId: string;
+  let payload: z.infer<typeof createModuleSchema>;
+
+  try {
+    courseId = paramsSchema.parse(await ctx.params).courseId;
+    payload = createModuleSchema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ error: "Invalid module request payload" }, { status: 400 });
+  }
 
   const supabase = getSupabaseAdminClient();
   const { data, error } = await supabase

--- a/src/app/api/admin/courses/[courseId]/route.ts
+++ b/src/app/api/admin/courses/[courseId]/route.ts
@@ -25,8 +25,15 @@ const updateCourseSchema = z.object({
 
 export async function PATCH(req: Request, ctx: { params: Promise<{ courseId: string }> }) {
   await requireDioceseAdmin();
-  const { courseId } = paramsSchema.parse(await ctx.params);
-  const payload = updateCourseSchema.parse(await req.json());
+  let courseId: string;
+  let payload: z.infer<typeof updateCourseSchema>;
+
+  try {
+    courseId = paramsSchema.parse(await ctx.params).courseId;
+    payload = updateCourseSchema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ error: "Invalid course request payload" }, { status: 400 });
+  }
 
   const supabase = getSupabaseAdminClient();
   const { data, error } = await supabase
@@ -52,7 +59,13 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ courseId: str
 
 export async function DELETE(_req: Request, ctx: { params: Promise<{ courseId: string }> }) {
   await requireDioceseAdmin();
-  const { courseId } = paramsSchema.parse(await ctx.params);
+  let courseId: string;
+
+  try {
+    courseId = paramsSchema.parse(await ctx.params).courseId;
+  } catch {
+    return NextResponse.json({ error: "Invalid course request payload" }, { status: 400 });
+  }
 
   const supabase = getSupabaseAdminClient();
   const { error } = await supabase.from("courses").delete().eq("id", courseId);

--- a/src/app/api/admin/courses/__tests__/route.test.ts
+++ b/src/app/api/admin/courses/__tests__/route.test.ts
@@ -85,6 +85,19 @@ describe("/api/admin/courses", () => {
     await expect(response.json()).resolves.toEqual({ error: "bad payload" });
   });
 
+  it("returns 400 for invalid create payloads", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/admin/courses", {
+        method: "POST",
+        body: JSON.stringify({ title: "Course A", scope: "BAD" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid course request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
   it("updates a course", async () => {
     const single = vi.fn(async () => ({ data: { id: "c1", title: "Updated" }, error: null }));
     const select = vi.fn(() => ({ single }));
@@ -127,6 +140,20 @@ describe("/api/admin/courses", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "not found" });
+  });
+
+  it("returns 400 for invalid update route params", async () => {
+    const response = await PATCH(
+      new Request("http://localhost/api/admin/courses/not-a-uuid", {
+        method: "PATCH",
+        body: JSON.stringify({ title: "Updated", description: null, scope: "PARISH", published: true }),
+      }),
+      { params: Promise.resolve({ courseId: "not-a-uuid" }) },
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid course request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
   });
 
   it("deletes a course", async () => {

--- a/src/app/api/admin/courses/route.ts
+++ b/src/app/api/admin/courses/route.ts
@@ -36,7 +36,13 @@ export async function GET() {
 
 export async function POST(req: Request) {
   await requireDioceseAdmin();
-  const payload = createCourseSchema.parse(await req.json());
+  let payload: z.infer<typeof createCourseSchema>;
+
+  try {
+    payload = createCourseSchema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ error: "Invalid course request payload" }, { status: 400 });
+  }
 
   const supabase = getSupabaseAdminClient();
   const { data, error } = await supabase

--- a/src/app/api/admin/enrollments/__tests__/route.test.ts
+++ b/src/app/api/admin/enrollments/__tests__/route.test.ts
@@ -49,6 +49,23 @@ describe("/api/admin/enrollments", () => {
     await expect(response.json()).resolves.toEqual({ enrollment: { id: "e1" } });
   });
 
+  it("returns 400 for invalid create payloads", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/admin/enrollments", {
+        method: "POST",
+        body: JSON.stringify({
+          parishId: "not-a-uuid",
+          courseId: "22222222-2222-4222-8222-222222222222",
+          clerkUserId: "user-1",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid enrollment request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
   it("deletes enrollment", async () => {
     const eqCourse = vi.fn(async () => ({ error: null }));
     const eqUser = vi.fn(() => ({ eq: eqCourse }));
@@ -70,5 +87,21 @@ describe("/api/admin/enrollments", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
+  });
+
+  it("returns 400 for invalid delete payloads", async () => {
+    const response = await DELETE(
+      new Request("http://localhost/api/admin/enrollments", {
+        method: "DELETE",
+        body: JSON.stringify({
+          parishId: "11111111-1111-4111-8111-111111111111",
+          clerkUserId: "user-1",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid enrollment request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/admin/enrollments/route.ts
+++ b/src/app/api/admin/enrollments/route.ts
@@ -17,6 +17,14 @@ const deleteEnrollmentSchema = z.object({
   courseId: z.string().uuid(),
 });
 
+async function parseJsonBody<T>(req: Request, schema: z.ZodSchema<T>) {
+  try {
+    return schema.safeParse(await req.json());
+  } catch {
+    return { success: false } as const;
+  }
+}
+
 export async function GET(req: Request) {
   await requireDioceseAdmin();
   const url = new URL(req.url);
@@ -45,7 +53,13 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   await requireDioceseAdmin();
-  const payload = createEnrollmentSchema.parse(await req.json());
+  const parsedPayload = await parseJsonBody(req, createEnrollmentSchema);
+
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid enrollment request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
   const supabase = getSupabaseAdminClient();
 
   const { data, error } = await supabase
@@ -77,7 +91,13 @@ export async function POST(req: Request) {
 
 export async function DELETE(req: Request) {
   await requireDioceseAdmin();
-  const payload = deleteEnrollmentSchema.parse(await req.json());
+  const parsedPayload = await parseJsonBody(req, deleteEnrollmentSchema);
+
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid enrollment request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
   const supabase = getSupabaseAdminClient();
 
   const { error } = await supabase

--- a/src/app/api/admin/questions/[questionId]/__tests__/route.test.ts
+++ b/src/app/api/admin/questions/[questionId]/__tests__/route.test.ts
@@ -27,6 +27,39 @@ describe("/api/admin/questions/[questionId]", () => {
     expect(res.status).toBe(200);
   });
 
+  it("returns 400 for invalid question ids", async () => {
+    const res = await PATCH(
+      new Request("http://x", { method: "PATCH", body: JSON.stringify({ prompt: "P", options: ["A", "B"], correctOptionIndex: 1, sortOrder: 0 }) }),
+      { params: Promise.resolve({ questionId: "not-a-uuid" }) },
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid question request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid update payloads", async () => {
+    const res = await PATCH(
+      new Request("http://x", { method: "PATCH", body: JSON.stringify({ prompt: "P", options: ["A", "B"] }) }),
+      { params: Promise.resolve({ questionId: "11111111-1111-4111-8111-111111111111" }) },
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid question request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for malformed JSON update payloads", async () => {
+    const res = await PATCH(
+      new Request("http://x", { method: "PATCH", body: "{" }),
+      { params: Promise.resolve({ questionId: "11111111-1111-4111-8111-111111111111" }) },
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid question request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
   it("deletes question", async () => {
     const eq = vi.fn(async () => ({ error: null }));
     const del = vi.fn(() => ({ eq }));

--- a/src/app/api/admin/questions/[questionId]/route.ts
+++ b/src/app/api/admin/questions/[questionId]/route.ts
@@ -13,10 +13,28 @@ const updateQuestionSchema = z.object({
   sortOrder: z.number().int().min(0),
 });
 
+async function parseJsonBody<T>(req: Request, schema: z.ZodSchema<T>) {
+  try {
+    return schema.safeParse(await req.json());
+  } catch {
+    return { success: false } as const;
+  }
+}
+
 export async function PATCH(req: Request, ctx: { params: Promise<{ questionId: string }> }) {
   await requireDioceseAdmin();
-  const { questionId } = paramsSchema.parse(await ctx.params);
-  const payload = updateQuestionSchema.parse(await req.json());
+  const parsedParams = paramsSchema.safeParse(await ctx.params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Invalid question request payload" }, { status: 400 });
+  }
+
+  const parsedPayload = await parseJsonBody(req, updateQuestionSchema);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid question request payload" }, { status: 400 });
+  }
+
+  const { questionId } = parsedParams.data;
+  const payload = parsedPayload.data;
 
   if (payload.correctOptionIndex >= payload.options.length) {
     return NextResponse.json({ error: "correctOptionIndex out of bounds" }, { status: 400 });

--- a/src/app/api/parish-admin/communications/[sendId]/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/communications/[sendId]/__tests__/route.test.ts
@@ -53,7 +53,26 @@ describe("/api/parish-admin/communications/[sendId]", () => {
     const recipientOrder = vi.fn(() => ({ limit: recipientLimit }));
     const recipientEqParish = vi.fn(() => ({ order: recipientOrder }));
     const recipientEqSend = vi.fn(() => ({ eq: recipientEqParish }));
-    const recipientSelect = vi.fn(() => ({ eq: recipientEqSend }));
+    const countByStatus: Record<string, number> = {
+      not_configured: 0,
+      pending: 0,
+      sent: 1,
+      failed: 1,
+    };
+    const recipientCountSelect = vi.fn((_columns: string, options?: { head?: boolean }) => {
+      if (!options?.head) {
+        return { eq: recipientEqSend };
+      }
+      const eqSend = vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(async (_column: string, status: string) => ({
+            count: countByStatus[status] ?? 0,
+            error: null,
+          })),
+        })),
+      }));
+      return { eq: eqSend };
+    });
 
     const profilesIn = vi.fn(async () => ({
       data: [
@@ -67,7 +86,7 @@ describe("/api/parish-admin/communications/[sendId]", () => {
     vi.mocked(getSupabaseAdminClient).mockReturnValue({
       from: vi.fn((table: string) => {
         if (table === "parish_message_sends") return { select: sendSelect };
-        if (table === "parish_message_recipients") return { select: recipientSelect };
+        if (table === "parish_message_recipients") return { select: recipientCountSelect };
         if (table === "user_profiles") return { select: profileSelect };
         throw new Error(`Unexpected table: ${table}`);
       }),
@@ -87,6 +106,85 @@ describe("/api/parish-admin/communications/[sendId]", () => {
       failed: 1,
     });
     expect(json.recipients).toHaveLength(2);
+    expect(json.pagination).toEqual({ returned: 2, limit: 500, hasMore: false });
+  });
+
+  it("keeps summary total from the send count when the recipient list is capped", async () => {
+    const sendMaybeSingle = vi.fn(async () => ({
+      data: {
+        id: "22222222-2222-4222-8222-222222222222",
+        subject: "Reminder",
+        body: "Please continue.",
+        delivery_status: "queued",
+        recipient_count: 501,
+        created_at: "2026-02-11T00:00:00.000Z",
+      },
+      error: null,
+    }));
+    const sendEqParish = vi.fn(() => ({ maybeSingle: sendMaybeSingle }));
+    const sendEqId = vi.fn(() => ({ eq: sendEqParish }));
+    const sendSelect = vi.fn(() => ({ eq: sendEqId }));
+
+    const recipientLimit = vi.fn(async () => ({
+      data: Array.from({ length: 500 }, (_, index) => ({
+        clerk_user_id: `user-${index}`,
+        delivery_status: "pending",
+        delivery_attempted_at: null,
+        delivery_error: null,
+      })),
+      error: null,
+    }));
+    const recipientOrder = vi.fn(() => ({ limit: recipientLimit }));
+    const recipientEqParish = vi.fn(() => ({ order: recipientOrder }));
+    const recipientEqSend = vi.fn(() => ({ eq: recipientEqParish }));
+    const countByStatus: Record<string, number> = {
+      not_configured: 0,
+      pending: 501,
+      sent: 0,
+      failed: 0,
+    };
+    const recipientSelect = vi.fn((_columns: string, options?: { head?: boolean }) => {
+      if (!options?.head) {
+        return { eq: recipientEqSend };
+      }
+      const eqSend = vi.fn(() => ({
+        eq: vi.fn(() => ({
+          eq: vi.fn(async (_column: string, status: string) => ({
+            count: countByStatus[status] ?? 0,
+            error: null,
+          })),
+        })),
+      }));
+      return { eq: eqSend };
+    });
+
+    const profilesIn = vi.fn(async () => ({ data: [], error: null }));
+    const profileSelect = vi.fn(() => ({ in: profilesIn }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "parish_message_sends") return { select: sendSelect };
+        if (table === "parish_message_recipients") return { select: recipientSelect };
+        if (table === "user_profiles") return { select: profileSelect };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ sendId: "22222222-2222-4222-8222-222222222222" }),
+    });
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json.summary).toEqual({
+      total: 501,
+      not_configured: 0,
+      pending: 501,
+      sent: 0,
+      failed: 0,
+    });
+    expect(json.recipients).toHaveLength(500);
+    expect(json.pagination).toEqual({ returned: 500, limit: 500, hasMore: true });
   });
 
   it("returns 404 when send is not found", async () => {

--- a/src/app/api/parish-admin/communications/[sendId]/route.ts
+++ b/src/app/api/parish-admin/communications/[sendId]/route.ts
@@ -9,6 +9,7 @@ const paramsSchema = z.object({
 });
 
 type RecipientDeliveryStatus = "not_configured" | "pending" | "sent" | "failed";
+const recipientDeliveryStatuses: RecipientDeliveryStatus[] = ["not_configured", "pending", "sent", "failed"];
 
 export async function GET(_req: Request, ctx: { params: Promise<{ sendId: string }> }) {
   const { parishId } = await requireParishRole("parish_admin");
@@ -41,6 +42,23 @@ export async function GET(_req: Request, ctx: { params: Promise<{ sendId: string
     return NextResponse.json({ error: recipientError.message }, { status: 400 });
   }
 
+  const statusCounts = await Promise.all(
+    recipientDeliveryStatuses.map(async (status) => {
+      const { count, error } = await supabase
+        .from("parish_message_recipients")
+        .select("id", { count: "exact", head: true })
+        .eq("send_id", params.sendId)
+        .eq("parish_id", parishId)
+        .eq("delivery_status", status);
+
+      return { count: count ?? 0, error, status };
+    }),
+  );
+  const statusCountError = statusCounts.find(({ error }) => error);
+  if (statusCountError?.error) {
+    return NextResponse.json({ error: statusCountError.error.message }, { status: 400 });
+  }
+
   const recipients =
     (recipientRows as Array<{
       clerk_user_id: string;
@@ -68,16 +86,18 @@ export async function GET(_req: Request, ctx: { params: Promise<{ sendId: string
   }
 
   const profileById = new Map(profiles.map((profile) => [profile.clerk_user_id, profile]));
-  const summary = {
-    total: recipients.length,
-    not_configured: 0,
-    pending: 0,
-    sent: 0,
-    failed: 0,
-  };
+  const summary = statusCounts.reduce(
+    (acc, { count, status }) => ({ ...acc, [status]: count }),
+    {
+      total: send.recipient_count as number,
+      not_configured: 0,
+      pending: 0,
+      sent: 0,
+      failed: 0,
+    },
+  );
 
   const detailedRecipients = recipients.map((recipient) => {
-    summary[recipient.delivery_status] += 1;
     const profile = profileById.get(recipient.clerk_user_id);
     return {
       clerk_user_id: recipient.clerk_user_id,
@@ -92,6 +112,11 @@ export async function GET(_req: Request, ctx: { params: Promise<{ sendId: string
   return NextResponse.json({
     send,
     summary,
+    pagination: {
+      returned: detailedRecipients.length,
+      limit: 500,
+      hasMore: (send.recipient_count as number) > detailedRecipients.length,
+    },
     recipients: detailedRecipients,
   });
 }

--- a/src/app/api/parish-admin/communications/__tests__/route.branches.test.ts
+++ b/src/app/api/parish-admin/communications/__tests__/route.branches.test.ts
@@ -132,13 +132,15 @@ describe("/api/parish-admin/communications branch coverage", () => {
     const sendSingle = vi.fn(async () => ({ data: { id: "send-1", recipient_count: 1 }, error: null }));
     const sendSelect = vi.fn(() => ({ single: sendSingle }));
     const sendInsert = vi.fn(() => ({ select: sendSelect }));
+    const sendDeleteEq = vi.fn(async () => ({ error: null }));
+    const sendDelete = vi.fn(() => ({ eq: sendDeleteEq }));
 
     const recipientInsert = vi.fn(async () => ({ error: { message: "recipient insert failed" } }));
 
     vi.mocked(getSupabaseAdminClient).mockReturnValue({
       from: vi.fn((table: string) => {
         if (table === "parish_memberships") return { select: membershipSelect };
-        if (table === "parish_message_sends") return { insert: sendInsert };
+        if (table === "parish_message_sends") return { insert: sendInsert, delete: sendDelete };
         if (table === "parish_message_recipients") return { insert: recipientInsert };
         throw new Error(`Unexpected table: ${table}`);
       }),
@@ -157,6 +159,8 @@ describe("/api/parish-admin/communications branch coverage", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "recipient insert failed" });
+    expect(sendDelete).toHaveBeenCalledTimes(1);
+    expect(sendDeleteEq).toHaveBeenCalledWith("id", "send-1");
   });
 
   it("returns 500 and marks send as failed when queueing fails", async () => {

--- a/src/app/api/parish-admin/communications/route.ts
+++ b/src/app/api/parish-admin/communications/route.ts
@@ -188,6 +188,7 @@ export async function POST(req: Request) {
   );
 
   if (recipientInsertError) {
+    await supabase.from("parish_message_sends").delete().eq("id", send.id as string);
     return NextResponse.json({ error: recipientInsertError.message }, { status: 400 });
   }
 

--- a/src/app/api/student/course-join-requests/__tests__/route.test.ts
+++ b/src/app/api/student/course-join-requests/__tests__/route.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({
+  requireParishRole: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/course-join-requests", () => ({
+  createJoinRequest: vi.fn(),
+  getStudentPendingRequests: vi.fn(),
+}));
+
+import { POST } from "@/app/api/student/course-join-requests/route";
+import { requireParishRole } from "@/lib/authz";
+import { createJoinRequest } from "@/lib/repositories/course-join-requests";
+
+describe("POST /api/student/course-join-requests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "student-1",
+      parishId: "11111111-1111-4111-8111-111111111111",
+    });
+  });
+
+  it("returns 400 for invalid course ids", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/student/course-join-requests", {
+        method: "POST",
+        body: JSON.stringify({ courseId: "not-a-uuid" }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: expect.any(String) });
+    expect(createJoinRequest).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/student/course-join-requests/__tests__/route.test.ts
+++ b/src/app/api/student/course-join-requests/__tests__/route.test.ts
@@ -19,6 +19,7 @@ describe("POST /api/student/course-join-requests", () => {
     vi.mocked(requireParishRole).mockResolvedValue({
       clerkUserId: "student-1",
       parishId: "11111111-1111-4111-8111-111111111111",
+      role: "student",
     });
   });
 

--- a/src/app/api/student/course-join-requests/route.ts
+++ b/src/app/api/student/course-join-requests/route.ts
@@ -18,9 +18,9 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const { clerkUserId, parishId } = await requireParishRole("student");
-  const payload = createSchema.parse(await req.json());
 
   try {
+    const payload = createSchema.parse(await req.json());
     const request = await createJoinRequest({
       parishId,
       clerkUserId,


### PR DESCRIPTION
## Summary
- standardize validation error responses across admin membership, courses, enrollments, questions, and join request endpoints
- fix orphaned communication-send handling and recipient summary details
- add regression coverage for affected API routes

## Tests
- Not run in this PR creation step

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes membership, enrollment, and message-send write paths; low auth impact but incorrect rollback or summary logic could affect admin operations and reporting.
> 
> **Overview**
> This PR tightens **request validation** and **communication-send consistency** across several API routes, with matching regression tests.
> 
> **Admin and student APIs** now return **HTTP 400** with stable error messages when Zod validation fails or JSON is malformed, instead of throwing. Affected areas include **admin membership** (including rejecting no-op or half-filled parish membership payloads), **courses** (create/update/delete and modules), **enrollments**, **questions**, and **student course join requests** (invalid `courseId` never hits the repository).
> 
> **Parish communications**: if recipient rows fail to insert after a send is created, the send row is **deleted** to avoid orphans. The **send detail** endpoint builds delivery **summary counts from the database** (per status), uses the stored **recipient_count** for totals when the recipient list is capped at 500, and returns **pagination** (`returned`, `limit`, `hasMore`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68fdca483fe797b6a186df2fe523e8b29f53556d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->