### PR TITLE
fix(admin): membership form & module route hardening (8 findings)

### DIFF
--- a/src/app/api/admin-membership/__tests__/route.test.ts
+++ b/src/app/api/admin-membership/__tests__/route.test.ts
@@ -18,20 +18,9 @@ describe("POST /api/admin-membership", () => {
     vi.mocked(requireDioceseAdmin).mockResolvedValue("admin-1");
   });
 
-  it("creates diocese admin and parish membership when requested", async () => {
-    const maybeSingle = vi.fn(async () => ({ data: null, error: null }));
-    const eq = vi.fn(() => ({ maybeSingle }));
-    const select = vi.fn(() => ({ eq }));
-    const dioceseUpsert = vi.fn(async () => ({ error: null }));
-    const membershipUpsert = vi.fn(async () => ({ error: null }));
-
-    vi.mocked(getSupabaseAdminClient).mockReturnValue({
-      from: vi.fn((table: string) => {
-        if (table === "diocese_admins") return { select, upsert: dioceseUpsert };
-        if (table === "parish_memberships") return { upsert: membershipUpsert };
-        throw new Error(`Unexpected table ${table}`);
-      }),
-    } as never);
+  it("rejects combined diocese admin and parish membership changes", async () => {
+    const from = vi.fn();
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from } as never);
 
     const response = await POST(
       new Request("http://localhost/api/admin-membership", {
@@ -45,19 +34,9 @@ describe("POST /api/admin-membership", () => {
       }),
     );
 
-    expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ ok: true });
-    expect(select).toHaveBeenCalledWith("clerk_user_id");
-    expect(eq).toHaveBeenCalledWith("clerk_user_id", "user-2");
-    expect(dioceseUpsert).toHaveBeenCalledWith({ clerk_user_id: "user-2" });
-    expect(membershipUpsert).toHaveBeenCalledWith(
-      {
-        parish_id: "11111111-1111-4111-8111-111111111111",
-        clerk_user_id: "user-2",
-        role: "instructor",
-      },
-      { onConflict: "parish_id,clerk_user_id" },
-    );
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Only one membership change may be requested at a time" });
+    expect(from).not.toHaveBeenCalled();
   });
 
   it("returns 400 when diocese upsert fails", async () => {
@@ -173,73 +152,4 @@ describe("POST /api/admin-membership", () => {
     await expect(response.json()).resolves.toEqual({ error: "invalid role" });
   });
 
-  it("rolls back a new diocese admin when combined parish membership upsert fails", async () => {
-    const maybeSingle = vi.fn(async () => ({ data: null, error: null }));
-    const selectEq = vi.fn(() => ({ maybeSingle }));
-    const select = vi.fn(() => ({ eq: selectEq }));
-    const dioceseUpsert = vi.fn(async () => ({ error: null }));
-    const membershipUpsert = vi.fn(async () => ({ error: { message: "invalid role" } }));
-    const deleteEq = vi.fn(async () => ({ error: null }));
-    const deleteDiocese = vi.fn(() => ({ eq: deleteEq }));
-
-    vi.mocked(getSupabaseAdminClient).mockReturnValue({
-      from: vi.fn((table: string) => {
-        if (table === "diocese_admins") return { select, upsert: dioceseUpsert, delete: deleteDiocese };
-        if (table === "parish_memberships") return { upsert: membershipUpsert };
-        throw new Error(`Unexpected table ${table}`);
-      }),
-    } as never);
-
-    const response = await POST(
-      new Request("http://localhost/api/admin-membership", {
-        method: "POST",
-        body: JSON.stringify({
-          clerkUserId: "user-2",
-          parishId: "11111111-1111-4111-8111-111111111111",
-          role: "student",
-          makeDioceseAdmin: true,
-        }),
-      }),
-    );
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({ error: "invalid role" });
-    expect(dioceseUpsert).toHaveBeenCalledWith({ clerk_user_id: "user-2" });
-    expect(deleteDiocese).toHaveBeenCalled();
-    expect(deleteEq).toHaveBeenCalledWith("clerk_user_id", "user-2");
-  });
-
-  it("keeps an existing diocese admin when combined parish membership upsert fails", async () => {
-    const maybeSingle = vi.fn(async () => ({ data: { clerk_user_id: "user-2" }, error: null }));
-    const selectEq = vi.fn(() => ({ maybeSingle }));
-    const select = vi.fn(() => ({ eq: selectEq }));
-    const membershipUpsert = vi.fn(async () => ({ error: { message: "invalid role" } }));
-    const deleteDiocese = vi.fn();
-
-    vi.mocked(getSupabaseAdminClient).mockReturnValue({
-      from: vi.fn((table: string) => {
-        if (table === "diocese_admins") {
-          return { select, upsert: vi.fn(async () => ({ error: null })), delete: deleteDiocese };
-        }
-        if (table === "parish_memberships") return { upsert: membershipUpsert };
-        throw new Error(`Unexpected table ${table}`);
-      }),
-    } as never);
-
-    const response = await POST(
-      new Request("http://localhost/api/admin-membership", {
-        method: "POST",
-        body: JSON.stringify({
-          clerkUserId: "user-2",
-          parishId: "11111111-1111-4111-8111-111111111111",
-          role: "student",
-          makeDioceseAdmin: true,
-        }),
-      }),
-    );
-
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toEqual({ error: "invalid role" });
-    expect(deleteDiocese).not.toHaveBeenCalled();
-  });
 });

--- a/src/app/api/admin-membership/__tests__/route.test.ts
+++ b/src/app/api/admin-membership/__tests__/route.test.ts
@@ -19,12 +19,15 @@ describe("POST /api/admin-membership", () => {
   });
 
   it("creates diocese admin and parish membership when requested", async () => {
+    const maybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const eq = vi.fn(() => ({ maybeSingle }));
+    const select = vi.fn(() => ({ eq }));
     const dioceseUpsert = vi.fn(async () => ({ error: null }));
     const membershipUpsert = vi.fn(async () => ({ error: null }));
 
     vi.mocked(getSupabaseAdminClient).mockReturnValue({
       from: vi.fn((table: string) => {
-        if (table === "diocese_admins") return { upsert: dioceseUpsert };
+        if (table === "diocese_admins") return { select, upsert: dioceseUpsert };
         if (table === "parish_memberships") return { upsert: membershipUpsert };
         throw new Error(`Unexpected table ${table}`);
       }),
@@ -44,6 +47,8 @@ describe("POST /api/admin-membership", () => {
 
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(select).toHaveBeenCalledWith("clerk_user_id");
+    expect(eq).toHaveBeenCalledWith("clerk_user_id", "user-2");
     expect(dioceseUpsert).toHaveBeenCalledWith({ clerk_user_id: "user-2" });
     expect(membershipUpsert).toHaveBeenCalledWith(
       {
@@ -166,5 +171,75 @@ describe("POST /api/admin-membership", () => {
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "invalid role" });
+  });
+
+  it("rolls back a new diocese admin when combined parish membership upsert fails", async () => {
+    const maybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const selectEq = vi.fn(() => ({ maybeSingle }));
+    const select = vi.fn(() => ({ eq: selectEq }));
+    const dioceseUpsert = vi.fn(async () => ({ error: null }));
+    const membershipUpsert = vi.fn(async () => ({ error: { message: "invalid role" } }));
+    const deleteEq = vi.fn(async () => ({ error: null }));
+    const deleteDiocese = vi.fn(() => ({ eq: deleteEq }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "diocese_admins") return { select, upsert: dioceseUpsert, delete: deleteDiocese };
+        if (table === "parish_memberships") return { upsert: membershipUpsert };
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/admin-membership", {
+        method: "POST",
+        body: JSON.stringify({
+          clerkUserId: "user-2",
+          parishId: "11111111-1111-4111-8111-111111111111",
+          role: "student",
+          makeDioceseAdmin: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "invalid role" });
+    expect(dioceseUpsert).toHaveBeenCalledWith({ clerk_user_id: "user-2" });
+    expect(deleteDiocese).toHaveBeenCalled();
+    expect(deleteEq).toHaveBeenCalledWith("clerk_user_id", "user-2");
+  });
+
+  it("keeps an existing diocese admin when combined parish membership upsert fails", async () => {
+    const maybeSingle = vi.fn(async () => ({ data: { clerk_user_id: "user-2" }, error: null }));
+    const selectEq = vi.fn(() => ({ maybeSingle }));
+    const select = vi.fn(() => ({ eq: selectEq }));
+    const membershipUpsert = vi.fn(async () => ({ error: { message: "invalid role" } }));
+    const deleteDiocese = vi.fn();
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "diocese_admins") {
+          return { select, upsert: vi.fn(async () => ({ error: null })), delete: deleteDiocese };
+        }
+        if (table === "parish_memberships") return { upsert: membershipUpsert };
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/admin-membership", {
+        method: "POST",
+        body: JSON.stringify({
+          clerkUserId: "user-2",
+          parishId: "11111111-1111-4111-8111-111111111111",
+          role: "student",
+          makeDioceseAdmin: true,
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "invalid role" });
+    expect(deleteDiocese).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/admin-membership/route.ts
+++ b/src/app/api/admin-membership/route.ts
@@ -28,19 +28,14 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Invalid admin membership request payload" }, { status: 400 });
   }
 
-  const supabase = getSupabaseAdminClient();
-  let removeDioceseAdminOnMembershipFailure = false;
-
   if (payload.makeDioceseAdmin && hasParishMembershipChange) {
-    const { data, error } = await supabase
-      .from("diocese_admins")
-      .select("clerk_user_id")
-      .eq("clerk_user_id", payload.clerkUserId)
-      .maybeSingle();
-
-    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-    removeDioceseAdminOnMembershipFailure = !data;
+    return NextResponse.json(
+      { error: "Only one membership change may be requested at a time" },
+      { status: 400 },
+    );
   }
+
+  const supabase = getSupabaseAdminClient();
 
   if (payload.makeDioceseAdmin) {
     const { error } = await supabase.from("diocese_admins").upsert({
@@ -59,13 +54,7 @@ export async function POST(req: Request) {
       { onConflict: "parish_id,clerk_user_id" },
     );
 
-    if (error) {
-      if (removeDioceseAdminOnMembershipFailure) {
-        await supabase.from("diocese_admins").delete().eq("clerk_user_id", payload.clerkUserId);
-      }
-
-      return NextResponse.json({ error: error.message }, { status: 400 });
-    }
+    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
   }
 
   return NextResponse.json({ ok: true });

--- a/src/app/api/admin-membership/route.ts
+++ b/src/app/api/admin-membership/route.ts
@@ -29,6 +29,18 @@ export async function POST(req: Request) {
   }
 
   const supabase = getSupabaseAdminClient();
+  let removeDioceseAdminOnMembershipFailure = false;
+
+  if (payload.makeDioceseAdmin && hasParishMembershipChange) {
+    const { data, error } = await supabase
+      .from("diocese_admins")
+      .select("clerk_user_id")
+      .eq("clerk_user_id", payload.clerkUserId)
+      .maybeSingle();
+
+    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+    removeDioceseAdminOnMembershipFailure = !data;
+  }
 
   if (payload.makeDioceseAdmin) {
     const { error } = await supabase.from("diocese_admins").upsert({
@@ -47,7 +59,13 @@ export async function POST(req: Request) {
       { onConflict: "parish_id,clerk_user_id" },
     );
 
-    if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+    if (error) {
+      if (removeDioceseAdminOnMembershipFailure) {
+        await supabase.from("diocese_admins").delete().eq("clerk_user_id", payload.clerkUserId);
+      }
+
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
   }
 
   return NextResponse.json({ ok: true });

--- a/src/app/api/admin/modules/[moduleId]/__tests__/route.test.ts
+++ b/src/app/api/admin/modules/[moduleId]/__tests__/route.test.ts
@@ -37,4 +37,14 @@ describe("/api/admin/modules/[moduleId]", () => {
     });
     expect(res.status).toBe(200);
   });
+
+  it("returns 400 for invalid delete route params", async () => {
+    const res = await DELETE(new Request("http://x", { method: "DELETE" }), {
+      params: Promise.resolve({ moduleId: "not-a-uuid" }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid module request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/admin/modules/[moduleId]/__tests__/route.test.ts
+++ b/src/app/api/admin/modules/[moduleId]/__tests__/route.test.ts
@@ -38,6 +38,27 @@ describe("/api/admin/modules/[moduleId]", () => {
     expect(res.status).toBe(200);
   });
 
+  it("returns 400 for invalid patch route params", async () => {
+    const res = await PATCH(
+      new Request("http://x", { method: "PATCH", body: JSON.stringify({ title: "M", sortOrder: 0 }) }),
+      { params: Promise.resolve({ moduleId: "not-a-uuid" }) },
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid module request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid patch request body", async () => {
+    const res = await PATCH(new Request("http://x", { method: "PATCH", body: "not-json" }), {
+      params: Promise.resolve({ moduleId: "11111111-1111-4111-8111-111111111111" }),
+    });
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Invalid module request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
   it("returns 400 for invalid delete route params", async () => {
     const res = await DELETE(new Request("http://x", { method: "DELETE" }), {
       params: Promise.resolve({ moduleId: "not-a-uuid" }),

--- a/src/app/api/admin/modules/[moduleId]/route.ts
+++ b/src/app/api/admin/modules/[moduleId]/route.ts
@@ -29,8 +29,20 @@ const updateModuleSchema = z.object({
 
 export async function PATCH(req: Request, ctx: { params: Promise<{ moduleId: string }> }) {
   await requireDioceseAdmin();
-  const { moduleId } = paramsSchema.parse(await ctx.params);
-  const payload = updateModuleSchema.parse(await req.json());
+
+  let moduleId: string;
+  try {
+    moduleId = paramsSchema.parse(await ctx.params).moduleId;
+  } catch {
+    return NextResponse.json({ error: "Invalid module request payload" }, { status: 400 });
+  }
+
+  let payload: z.infer<typeof updateModuleSchema>;
+  try {
+    payload = updateModuleSchema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ error: "Invalid module request payload" }, { status: 400 });
+  }
 
   const supabase = getSupabaseAdminClient();
   const { data, error } = await supabase

--- a/src/app/api/admin/modules/[moduleId]/route.ts
+++ b/src/app/api/admin/modules/[moduleId]/route.ts
@@ -51,7 +51,13 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ moduleId: str
 
 export async function DELETE(_req: Request, ctx: { params: Promise<{ moduleId: string }> }) {
   await requireDioceseAdmin();
-  const { moduleId } = paramsSchema.parse(await ctx.params);
+  let moduleId: string;
+
+  try {
+    moduleId = paramsSchema.parse(await ctx.params).moduleId;
+  } catch {
+    return NextResponse.json({ error: "Invalid module request payload" }, { status: 400 });
+  }
 
   const supabase = getSupabaseAdminClient();
   const { error } = await supabase.from("modules").delete().eq("id", moduleId);

--- a/src/components/__tests__/admin-membership-form.test.tsx
+++ b/src/components/__tests__/admin-membership-form.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AdminMembershipForm } from "@/components/admin-membership-form";
+
+describe("AdminMembershipForm", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("prevents duplicate membership submissions while saving", async () => {
+    let resolveFetch: (response: Response) => void;
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AdminMembershipForm />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add membership" }));
+    fireEvent.click(screen.getByRole("button", { name: "Saving..." }));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("button", { name: "Saving..." })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Saving..." })).toHaveAttribute("aria-busy", "true");
+
+    resolveFetch!({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Add membership" })).toBeEnabled());
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+  });
+});

--- a/src/components/admin-membership-form.tsx
+++ b/src/components/admin-membership-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -13,16 +13,30 @@ export function AdminMembershipForm() {
   const [role, setRole] = useState("student");
   const [makeDioceseAdmin, setMakeDioceseAdmin] = useState(false);
   const [message, setMessage] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const submittingRef = useRef(false);
 
   async function submit() {
-    const response = await fetch("/api/admin-membership", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ clerkUserId, parishId: parishId || undefined, role, makeDioceseAdmin }),
-    });
+    if (submittingRef.current) {
+      return;
+    }
 
-    const data = await response.json();
-    setMessage(response.ok ? "Saved" : data.error ?? "Failed");
+    submittingRef.current = true;
+    setSubmitting(true);
+
+    try {
+      const response = await fetch("/api/admin-membership", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ clerkUserId, parishId: parishId || undefined, role, makeDioceseAdmin }),
+      });
+
+      const data = await response.json();
+      setMessage(response.ok ? "Saved" : data.error ?? "Failed");
+    } finally {
+      submittingRef.current = false;
+      setSubmitting(false);
+    }
   }
 
   return (
@@ -62,8 +76,8 @@ export function AdminMembershipForm() {
         />
         Make Diocese Admin
       </label>
-      <Button onClick={submit} size="sm" type="button">
-        Add membership
+      <Button aria-busy={submitting} disabled={submitting} onClick={submit} size="sm" type="button">
+        {submitting ? "Saving..." : "Add membership"}
       </Button>
       {message && <p className="mt-3 text-[13px] text-muted-foreground">{message}</p>}
     </div>

--- a/src/components/admin-membership-form.tsx
+++ b/src/components/admin-membership-form.tsx
@@ -33,6 +33,8 @@ export function AdminMembershipForm() {
 
       const data = await response.json();
       setMessage(response.ok ? "Saved" : data.error ?? "Failed");
+    } catch {
+      setMessage("Request failed. Check your connection and try again.");
     } finally {
       submittingRef.current = false;
       setSubmitting(false);

--- a/src/components/admin-membership-form.tsx
+++ b/src/components/admin-membership-form.tsx
@@ -28,7 +28,7 @@ export function AdminMembershipForm() {
       const response = await fetch("/api/admin-membership", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ clerkUserId, parishId: parishId || undefined, role, makeDioceseAdmin }),
+        body: JSON.stringify({ clerkUserId, parishId: parishId || undefined, role: parishId ? role : undefined, makeDioceseAdmin }),
       });
 
       const data = await response.json();


### PR DESCRIPTION
## Summary

Fixes 8 clawpatch findings across admin membership form/route and admin modules route.

### Changes

**Admin Modules (3 findings)**
| Commit | Description |
|--------|-------------|
| `3b3a8bd` | Add module route validation — return 400 for invalid PATCH/DELETE params |
| `704acdd` | Add PATCH body validation — wrap JSON and schema parsing in try/catch |

**Admin Membership Route (2 findings)**
| Commit | Description |
|--------|-------------|
| `6ab1ee4` | Wrap JSON schema parsing in try/catch returning 400; batch writes |
| `0937f1f` | Reject compound mutations up-front for atomicity |

**Admin Membership Form (3 findings)**
| Commit | Description |
|--------|-------------|
| `b14c6a1` | Prevent double-submit, show errors, add render test |
| `3e4383c` | Catch fetch/JSON failures with user-visible error message |

### Validation
- 297/297 tests passing
- Typecheck ✓
- Lint ✓
- 8/8 findings revalidated as fixed via `clawpatch revalidate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes diocese-admin membership API semantics (no combined diocese + parish updates) and admin write paths; behavior is stricter but still behind requireDioceseAdmin.
> 
> **Overview**
> Hardens **admin** membership and module APIs and improves the membership form UX.
> 
> **Membership API** now returns **400** when a single request tries to promote a diocese admin *and* upsert parish membership, so only one mutation runs per call. Tests were updated to expect rejection instead of a combined success path.
> 
> **Module PATCH/DELETE** wrap route-param and body **Zod** parsing in try/catch and respond with a consistent **400** (`Invalid module request payload`) instead of surfacing parse failures; new route tests cover bad UUIDs and malformed PATCH bodies without hitting Supabase.
> 
> **Admin membership form** blocks double-submit (ref + disabled **Saving...** button with `aria-busy`), omits `role` from the JSON when no parish is set, shows a connection error on fetch failure, and adds a render test for in-flight submission behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7693d4333a3ccb35a084227dd1af37a2cc488683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->