### PR TITLE
fix(api): add 400 validation across 19 route handlers

### DIFF
--- a/src/app/api/admin/lessons/[lessonId]/questions/route.ts
+++ b/src/app/api/admin/lessons/[lessonId]/questions/route.ts
@@ -15,8 +15,25 @@ const createQuestionSchema = z.object({
 
 export async function POST(req: Request, ctx: { params: Promise<{ lessonId: string }> }) {
   await requireDioceseAdmin();
-  const { lessonId } = paramsSchema.parse(await ctx.params);
-  const payload = createQuestionSchema.parse(await req.json());
+  const parsedParams = paramsSchema.safeParse(await ctx.params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Invalid question request payload" }, { status: 400 });
+  }
+  const { lessonId } = parsedParams.data;
+
+  let rawPayload: unknown;
+  try {
+    rawPayload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid question request payload" }, { status: 400 });
+  }
+
+  const parsedPayload = createQuestionSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid question request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
 
   if (payload.correctOptionIndex >= payload.options.length) {
     return NextResponse.json({ error: "correctOptionIndex out of bounds" }, { status: 400 });

--- a/src/app/api/admin/modules/[moduleId]/lessons/__tests__/route.test.ts
+++ b/src/app/api/admin/modules/[moduleId]/lessons/__tests__/route.test.ts
@@ -85,47 +85,49 @@ describe("POST /api/admin/modules/[moduleId]/lessons", () => {
   it("rejects video lessons without a video id", async () => {
     vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: vi.fn() } as never);
 
-    await expect(() =>
-      POST(
-        new Request(
-          "http://x",
-          {
-            method: "POST",
-            body: JSON.stringify({
-              title: "Broken video",
-              contentType: "VIDEO",
-              sortOrder: 0,
-              passingScore: 80,
-            }),
-          },
-        ),
-        { params: Promise.resolve({ moduleId: "11111111-1111-4111-8111-111111111111" }) },
+    const res = await POST(
+      new Request(
+        "http://x",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            title: "Broken video",
+            contentType: "VIDEO",
+            sortOrder: 0,
+            passingScore: 80,
+          }),
+        },
       ),
-    ).rejects.toThrow("YouTube video ID is required for video lessons.");
+      { params: Promise.resolve({ moduleId: "11111111-1111-4111-8111-111111111111" }) },
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "YouTube video ID is required for video lessons." });
   });
 
   it("rejects document lessons with an invalid page range", async () => {
     vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: vi.fn() } as never);
 
-    await expect(() =>
-      POST(
-        new Request(
-          "http://x",
-          {
-            method: "POST",
-            body: JSON.stringify({
-              title: "Broken reading",
-              contentType: "DOCUMENT",
-              documentUrl: "/docs/reading.pdf",
-              documentPageStart: 5,
-              documentPageEnd: 3,
-              sortOrder: 0,
-              passingScore: 80,
-            }),
-          },
-        ),
-        { params: Promise.resolve({ moduleId: "11111111-1111-4111-8111-111111111111" }) },
+    const res = await POST(
+      new Request(
+        "http://x",
+        {
+          method: "POST",
+          body: JSON.stringify({
+            title: "Broken reading",
+            contentType: "DOCUMENT",
+            documentUrl: "/docs/reading.pdf",
+            documentPageStart: 5,
+            documentPageEnd: 3,
+            sortOrder: 0,
+            passingScore: 80,
+          }),
+        },
       ),
-    ).rejects.toThrow("Document end page must be greater than or equal to the start page.");
+      { params: Promise.resolve({ moduleId: "11111111-1111-4111-8111-111111111111" }) },
+    );
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toEqual({ error: "Document end page must be greater than or equal to the start page." });
   });
 });

--- a/src/app/api/admin/modules/[moduleId]/lessons/route.ts
+++ b/src/app/api/admin/modules/[moduleId]/lessons/route.ts
@@ -96,7 +96,8 @@ export async function POST(req: Request, ctx: { params: Promise<{ moduleId: stri
 
   const parsedPayload = createLessonSchema.safeParse(rawPayload);
   if (!parsedPayload.success) {
-    return NextResponse.json({ error: "Invalid lesson request payload" }, { status: 400 });
+    const firstIssue = parsedPayload.error.issues[0];
+    return NextResponse.json({ error: firstIssue?.message ?? "Invalid lesson request payload" }, { status: 400 });
   }
 
   const payload = parsedPayload.data;

--- a/src/app/api/admin/modules/[moduleId]/lessons/route.ts
+++ b/src/app/api/admin/modules/[moduleId]/lessons/route.ts
@@ -81,8 +81,25 @@ const createLessonSchema = z.object({
 
 export async function POST(req: Request, ctx: { params: Promise<{ moduleId: string }> }) {
   await requireDioceseAdmin();
-  const { moduleId } = paramsSchema.parse(await ctx.params);
-  const payload = createLessonSchema.parse(await req.json());
+  const parsedParams = paramsSchema.safeParse(await ctx.params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Invalid lesson request payload" }, { status: 400 });
+  }
+  const { moduleId } = parsedParams.data;
+
+  let rawPayload: unknown;
+  try {
+    rawPayload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid lesson request payload" }, { status: 400 });
+  }
+
+  const parsedPayload = createLessonSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid lesson request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
 
   const supabase = getSupabaseAdminClient();
   const { data, error } = await supabase

--- a/src/app/api/admin/parishes/[parishId]/archive/route.ts
+++ b/src/app/api/admin/parishes/[parishId]/archive/route.ts
@@ -15,8 +15,25 @@ const bodySchema = z.object({
 
 export async function POST(req: Request, ctx: { params: Promise<{ parishId: string }> }) {
   const actorUserId = await requireDioceseAdmin();
-  const { parishId } = paramsSchema.parse(await ctx.params);
-  const payload = bodySchema.parse(await req.json());
+  const parsedParams = paramsSchema.safeParse(await ctx.params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Invalid parish request payload" }, { status: 400 });
+  }
+  const { parishId } = parsedParams.data;
+
+  let rawPayload: unknown;
+  try {
+    rawPayload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid parish request payload" }, { status: 400 });
+  }
+
+  const parsedPayload = bodySchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid parish request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
 
   const archivedAt = payload.archive ? new Date().toISOString() : null;
 

--- a/src/app/api/admin/parishes/[parishId]/route.ts
+++ b/src/app/api/admin/parishes/[parishId]/route.ts
@@ -17,8 +17,25 @@ const updateParishSchema = z.object({
 
 export async function PATCH(req: Request, ctx: { params: Promise<{ parishId: string }> }) {
   const actorUserId = await requireDioceseAdmin();
-  const { parishId } = paramsSchema.parse(await ctx.params);
-  const payload = updateParishSchema.parse(await req.json());
+  const parsedParams = paramsSchema.safeParse(await ctx.params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Invalid parish request payload" }, { status: 400 });
+  }
+  const { parishId } = parsedParams.data;
+
+  let rawPayload: unknown;
+  try {
+    rawPayload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid parish request payload" }, { status: 400 });
+  }
+
+  const parsedPayload = updateParishSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid parish request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
 
   const supabase = getSupabaseAdminClient();
   const { data, error } = await supabase
@@ -53,7 +70,11 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ parishId: str
 
 export async function DELETE(_req: Request, ctx: { params: Promise<{ parishId: string }> }) {
   const actorUserId = await requireDioceseAdmin();
-  const { parishId } = paramsSchema.parse(await ctx.params);
+  const parsedParams = paramsSchema.safeParse(await ctx.params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Invalid parish request payload" }, { status: 400 });
+  }
+  const { parishId } = parsedParams.data;
 
   const supabase = getSupabaseAdminClient();
   const { error } = await supabase.from("parishes").delete().eq("id", parishId);

--- a/src/app/api/admin/parishes/route.ts
+++ b/src/app/api/admin/parishes/route.ts
@@ -28,7 +28,20 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const actorUserId = await requireDioceseAdmin();
-  const payload = createParishSchema.parse(await req.json());
+  let rawPayload: unknown;
+
+  try {
+    rawPayload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid parish request payload" }, { status: 400 });
+  }
+
+  const parsedPayload = createParishSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid parish request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
 
   const supabase = getSupabaseAdminClient();
   const { data, error } = await supabase

--- a/src/app/api/admin/questions/[questionId]/route.ts
+++ b/src/app/api/admin/questions/[questionId]/route.ts
@@ -59,7 +59,11 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ questionId: s
 
 export async function DELETE(_req: Request, ctx: { params: Promise<{ questionId: string }> }) {
   await requireDioceseAdmin();
-  const { questionId } = paramsSchema.parse(await ctx.params);
+  const parsedParams = paramsSchema.safeParse(await ctx.params);
+  if (!parsedParams.success) {
+    return NextResponse.json({ error: "Invalid question request payload" }, { status: 400 });
+  }
+  const { questionId } = parsedParams.data;
 
   const supabase = getSupabaseAdminClient();
   const { error } = await supabase.from("questions").delete().eq("id", questionId);

--- a/src/app/api/parish-admin/cohort-assignments/route.ts
+++ b/src/app/api/parish-admin/cohort-assignments/route.ts
@@ -12,7 +12,20 @@ const updateAssignmentSchema = z.object({
 
 export async function PATCH(req: Request) {
   const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
-  const payload = updateAssignmentSchema.parse(await req.json());
+  let rawPayload: unknown;
+
+  try {
+    rawPayload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid cohort assignment request payload" }, { status: 400 });
+  }
+
+  const parsedPayload = updateAssignmentSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid cohort assignment request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
   const supabase = getSupabaseAdminClient();
 
   if (payload.cohortId) {

--- a/src/app/api/parish-admin/cohorts/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/cohorts/__tests__/route.test.ts
@@ -92,6 +92,38 @@ describe("/api/parish-admin/cohorts", () => {
     expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    ["missing name", { cadence: "weekly" }],
+    ["invalid cadence", { name: "RCIA A", cadence: "daily" }],
+    ["invalid next session datetime", { name: "RCIA A", nextSessionAt: "2026-02-20 19:00" }],
+  ])("returns 400 for invalid create payloads: %s", async (_caseName, body) => {
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/cohorts", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid cohort request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+    expect(recordAdminAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for malformed JSON create payloads", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/cohorts", {
+        method: "POST",
+        body: "{",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid cohort request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+    expect(recordAdminAuditLog).not.toHaveBeenCalled();
+  });
+
   it("returns 400 when facilitator is not eligible", async () => {
     const membershipMaybeSingle = vi.fn(async () => ({ data: { role: "student" }, error: null }));
     const membershipEqUser = vi.fn(() => ({ maybeSingle: membershipMaybeSingle }));

--- a/src/app/api/parish-admin/cohorts/route.ts
+++ b/src/app/api/parish-admin/cohorts/route.ts
@@ -59,7 +59,14 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
-  const payload = createCohortSchema.parse(await req.json());
+  let payload: z.infer<typeof createCohortSchema>;
+
+  try {
+    payload = createCohortSchema.parse(await req.json());
+  } catch {
+    return NextResponse.json({ error: "Invalid cohort request payload" }, { status: 400 });
+  }
+
   const supabase = getSupabaseAdminClient();
 
   if (payload.facilitatorClerkUserId) {

--- a/src/app/api/parish-admin/communications/[sendId]/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/communications/[sendId]/__tests__/route.test.ts
@@ -207,4 +207,14 @@ describe("/api/parish-admin/communications/[sendId]", () => {
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ error: "Message send not found." });
   });
+
+  it("returns 400 for invalid send ids", async () => {
+    const response = await GET(new Request("http://localhost"), {
+      params: Promise.resolve({ sendId: "not-a-uuid" }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid message send id." });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
 });

--- a/src/app/api/parish-admin/communications/[sendId]/route.ts
+++ b/src/app/api/parish-admin/communications/[sendId]/route.ts
@@ -13,7 +13,11 @@ const recipientDeliveryStatuses: RecipientDeliveryStatus[] = ["not_configured", 
 
 export async function GET(_req: Request, ctx: { params: Promise<{ sendId: string }> }) {
   const { parishId } = await requireParishRole("parish_admin");
-  const params = paramsSchema.parse(await ctx.params);
+  const paramsResult = paramsSchema.safeParse(await ctx.params);
+  if (!paramsResult.success) {
+    return NextResponse.json({ error: "Invalid message send id." }, { status: 400 });
+  }
+  const params = paramsResult.data;
   const supabase = getSupabaseAdminClient();
 
   const { data: send, error: sendError } = await supabase

--- a/src/app/api/parish-admin/communications/__tests__/route.test.ts
+++ b/src/app/api/parish-admin/communications/__tests__/route.test.ts
@@ -75,6 +75,36 @@ describe("/api/parish-admin/communications", () => {
     expect(recordAdminAuditLog).toHaveBeenCalledTimes(1);
   });
 
+  it("returns 400 for malformed JSON", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/communications", {
+        method: "POST",
+        body: "{",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid communication request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for invalid request payloads", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/parish-admin/communications", {
+        method: "POST",
+        body: JSON.stringify({
+          subject: "",
+          body: "Please continue your course this week.",
+          audienceType: "all_members",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid communication request payload" });
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
   it("returns 400 when audience resolves to no recipients", async () => {
     const membershipEq = vi.fn(async () => ({ data: [], error: null }));
     const membershipSelect = vi.fn(() => ({ eq: membershipEq }));

--- a/src/app/api/parish-admin/communications/route.ts
+++ b/src/app/api/parish-admin/communications/route.ts
@@ -124,7 +124,20 @@ export async function GET() {
 
 export async function POST(req: Request) {
   const { clerkUserId, parishId } = await requireParishRole("parish_admin");
-  const payload = sendMessageSchema.parse(await req.json());
+  let rawPayload: unknown;
+
+  try {
+    rawPayload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid communication request payload" }, { status: 400 });
+  }
+
+  const parsedPayload = sendMessageSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid communication request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
   const supabase = getSupabaseAdminClient();
   const deliveryConfig = getParishDeliveryConfig();
 

--- a/src/app/api/parish-admin/course-adoptions/route.ts
+++ b/src/app/api/parish-admin/course-adoptions/route.ts
@@ -11,7 +11,20 @@ const courseAdoptionSchema = z.object({
 
 export async function POST(req: Request) {
   const { clerkUserId, parishId } = await requireParishRole("parish_admin");
-  const payload = courseAdoptionSchema.parse(await req.json());
+  let rawPayload: unknown;
+
+  try {
+    rawPayload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid course adoption request payload" }, { status: 400 });
+  }
+
+  const parsedPayload = courseAdoptionSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid course adoption request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
   const supabase = getSupabaseAdminClient();
 
   const { data: course, error: courseError } = await supabase
@@ -56,7 +69,20 @@ export async function POST(req: Request) {
 
 export async function DELETE(req: Request) {
   const { clerkUserId, parishId } = await requireParishRole("parish_admin");
-  const payload = courseAdoptionSchema.parse(await req.json());
+  let rawPayload: unknown;
+
+  try {
+    rawPayload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid course adoption request payload" }, { status: 400 });
+  }
+
+  const parsedPayload = courseAdoptionSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid course adoption request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
   const supabase = getSupabaseAdminClient();
 
   const { data: course, error: courseError } = await supabase

--- a/src/app/api/parish-admin/course-join-requests/[requestId]/approve/route.ts
+++ b/src/app/api/parish-admin/course-join-requests/[requestId]/approve/route.ts
@@ -14,19 +14,19 @@ export async function POST(
   { params }: { params: Promise<{ requestId: string }> }
 ) {
   const { clerkUserId, parishId } = await requireParishRole("parish_admin");
-  const { requestId } = paramsSchema.parse(await params);
-
-  // Get request details before approving (need course_id for notification)
-  const { getSupabaseAdminClient } = await import("@/lib/supabase/server");
-  const supabase = getSupabaseAdminClient();
-  const { data: requestRow } = await supabase
-    .from("course_join_requests")
-    .select("clerk_user_id, course_id")
-    .eq("id", requestId)
-    .eq("status", "PENDING")
-    .single();
 
   try {
+    const { requestId } = paramsSchema.parse(await params);
+
+    // Get request details before approving (need course_id for notification)
+    const { getSupabaseAdminClient } = await import("@/lib/supabase/server");
+    const supabase = getSupabaseAdminClient();
+    const { data: requestRow } = await supabase
+      .from("course_join_requests")
+      .select("clerk_user_id, course_id")
+      .eq("id", requestId)
+      .eq("status", "PENDING")
+      .single();
     await approveJoinRequest({ requestId, actorClerkUserId: clerkUserId });
 
     // Send notification email (non-blocking - don't fail the request if email fails)
@@ -41,6 +41,9 @@ export async function POST(
 
     return NextResponse.json({ ok: true });
   } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: "Invalid request parameters" }, { status: 400 });
+    }
     const message = err instanceof Error ? err.message : "Unknown error";
     return NextResponse.json({ error: message }, { status: 400 });
   }

--- a/src/app/api/parish-admin/course-join-requests/[requestId]/reject/route.ts
+++ b/src/app/api/parish-admin/course-join-requests/[requestId]/reject/route.ts
@@ -14,19 +14,19 @@ export async function POST(
   { params }: { params: Promise<{ requestId: string }> }
 ) {
   const { clerkUserId, parishId } = await requireParishRole("parish_admin");
-  const { requestId } = paramsSchema.parse(await params);
-
-  // Get request details before rejecting (need course_id for notification)
-  const { getSupabaseAdminClient } = await import("@/lib/supabase/server");
-  const supabase = getSupabaseAdminClient();
-  const { data: requestRow } = await supabase
-    .from("course_join_requests")
-    .select("clerk_user_id, course_id")
-    .eq("id", requestId)
-    .eq("status", "PENDING")
-    .single();
 
   try {
+    const { requestId } = paramsSchema.parse(await params);
+
+    // Get request details before rejecting (need course_id for notification)
+    const { getSupabaseAdminClient } = await import("@/lib/supabase/server");
+    const supabase = getSupabaseAdminClient();
+    const { data: requestRow } = await supabase
+      .from("course_join_requests")
+      .select("clerk_user_id, course_id")
+      .eq("id", requestId)
+      .eq("status", "PENDING")
+      .single();
     await rejectJoinRequest({ requestId, actorClerkUserId: clerkUserId });
 
     // Send notification email (non-blocking)
@@ -41,6 +41,9 @@ export async function POST(
 
     return NextResponse.json({ ok: true });
   } catch (err) {
+    if (err instanceof z.ZodError) {
+      return NextResponse.json({ error: "Invalid request parameters" }, { status: 400 });
+    }
     const message = err instanceof Error ? err.message : "Unknown error";
     return NextResponse.json({ error: message }, { status: 400 });
   }

--- a/src/app/api/parish-admin/enrollments/route.ts
+++ b/src/app/api/parish-admin/enrollments/route.ts
@@ -58,7 +58,20 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
-  const payload = createEnrollmentSchema.parse(await req.json());
+  let rawPayload: unknown;
+
+  try {
+    rawPayload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid enrollment request payload" }, { status: 400 });
+  }
+
+  const parsedPayload = createEnrollmentSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid enrollment request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
   const supabase = getSupabaseAdminClient();
 
   const { data: membership, error: membershipError } = await supabase
@@ -148,7 +161,20 @@ export async function POST(req: Request) {
 
 export async function DELETE(req: Request) {
   const { clerkUserId: actorUserId, parishId } = await requireParishRole("parish_admin");
-  const payload = deleteEnrollmentSchema.parse(await req.json());
+  let rawPayload: unknown;
+
+  try {
+    rawPayload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid enrollment request payload" }, { status: 400 });
+  }
+
+  const parsedPayload = deleteEnrollmentSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid enrollment request payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
   const supabase = getSupabaseAdminClient();
 
   const { error } = await supabase

--- a/src/app/api/quiz-attempt/route.ts
+++ b/src/app/api/quiz-attempt/route.ts
@@ -13,7 +13,20 @@ import { notifyCourseCompletion } from "@/lib/parish-communications/notification
 export async function POST(req: Request) {
   const clerkUserId = await requireAuth();
   const { parishId } = await requireParishRole("student");
-  const payload = quizSubmissionSchema.parse(await req.json());
+
+  let rawPayload: unknown;
+  try {
+    rawPayload = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid quiz submission payload" }, { status: 400 });
+  }
+
+  const parsedPayload = quizSubmissionSchema.safeParse(rawPayload);
+  if (!parsedPayload.success) {
+    return NextResponse.json({ error: "Invalid quiz submission payload" }, { status: 400 });
+  }
+
+  const payload = parsedPayload.data;
 
   if (payload.parishId !== parishId) {
     return NextResponse.json({ error: "Invalid parish context" }, { status: 403 });


### PR DESCRIPTION
## Summary

Fixes 19 API contract findings across parish-admin, admin, and student/quiz routes — all the same pattern: invalid/malformed request bodies and route params were escaping as unhandled 500 errors instead of returning proper 400 JSON responses.

### Pattern
Every route now wraps `req.json()` in try/catch for malformed JSON and uses `schema.safeParse()` for Zod validation, returning `NextResponse.json({ error: "..." }, { status: 400 })`.

### Routes Fixed

**Parish Admin (8)**
- `cohorts` — POST body validation
- `communications` — POST body validation
- `communications/:sendId` — invalid sendId validation
- `course-join-requests/:requestId/reject` — param validation
- `course-join-requests/:requestId/approve` — param validation
- `enrollments` — POST body validation
- `course-adoptions` — POST body validation
- `cohort-assignments` — POST body validation

**Admin (9)**
- `questions/:questionId` — params/body validation
- `lessons/:lessonId/questions` — params/body validation
- `modules/:moduleId/lessons` — params/body validation
- `courses` — POST body validation
- `courses/:courseId` — params/body validation
- `courses/:courseId/modules` — params/body validation
- `parishes` — POST body validation
- `parishes/:parishId` — params/body validation
- `parishes/:parishId/archive` — params/body validation

**Student/Quiz (2)**
- `student/course-join-requests` — POST body validation
- `quiz-attempt` — POST body validation

### Validation
- 300/300 tests passing
- Typecheck ✓
- 19/19 findings revalidated as fixed via `clawpatch revalidate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive input validation and error-response shaping only; core business logic and auth paths are unchanged.
> 
> **Overview**
> Replaces throwing Zod/`req.json()` failures with **HTTP 400** JSON errors across many **admin**, **parish-admin**, and **quiz** route handlers. Handlers now **`safeParse`** route params and bodies (with **try/catch** on malformed JSON) and return stable `{ error: "..." }` messages instead of unhandled **500**s.
> 
> **Lesson** creation still surfaces domain rules (e.g. missing YouTube ID, bad document page range) via the first Zod issue message where applicable. **Join-request** approve/reject routes map invalid **`requestId`** params to **400** inside existing error handling. Tests were updated or added to assert **400** responses and that Supabase/audit side effects are skipped on bad input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2872639ffed78b42f6c7b7d275de6b6ca78df6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->