### PR TITLE
fix(ui): client bug hardening

### DIFF
--- a/src/app/app/__tests__/layout.test.tsx
+++ b/src/app/app/__tests__/layout.test.tsx
@@ -1,0 +1,55 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const headerMock = vi.hoisted(() => ({
+  AppHeaderClient: vi.fn(() => <header>App header</header>),
+}));
+
+vi.mock("@/components/app-header-client", () => headerMock);
+
+vi.mock("@/components/help-panel", () => ({
+  HelpPanel: () => <div>Help panel</div>,
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock("@/lib/e2e-mode", () => ({
+  isE2ESmokeMode: vi.fn(() => true),
+}));
+
+vi.mock("@/lib/authz", () => ({
+  getActiveParishRole: vi.fn(),
+  isDioceseAdmin: vi.fn(),
+  requireAuth: vi.fn(),
+}));
+
+import AppLayout from "@/app/app/layout";
+import { AppHeaderClient } from "@/components/app-header-client";
+import { getActiveParishRole, isDioceseAdmin, requireAuth } from "@/lib/authz";
+import { cookies } from "next/headers";
+
+describe("AppLayout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAuth).mockResolvedValue("user-1");
+    vi.mocked(isDioceseAdmin).mockResolvedValue(false);
+    vi.mocked(cookies).mockResolvedValue({
+      get: vi.fn(() => undefined),
+    } as unknown as Awaited<ReturnType<typeof cookies>>);
+  });
+
+  it("shows the Parish Admin nav item for active parish admins", async () => {
+    vi.mocked(getActiveParishRole).mockResolvedValue("parish_admin");
+
+    render(await AppLayout({ children: <div>Content</div> }));
+
+    expect(AppHeaderClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        navItems: expect.arrayContaining([{ label: "Parish Admin", href: "/app/parish-admin" }]),
+      }),
+      undefined,
+    );
+  });
+});

--- a/src/app/app/certificates/__tests__/page.test.tsx
+++ b/src/app/app/certificates/__tests__/page.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({
+  requireParishRole: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/certificates", () => ({
+  listStudentCertificates: vi.fn(),
+}));
+
+import CertificatesPage from "@/app/app/certificates/page";
+import { requireParishRole } from "@/lib/authz";
+import {
+  type CertificateWithDetails,
+  listStudentCertificates,
+} from "@/lib/repositories/certificates";
+
+const certificate: CertificateWithDetails = {
+  id: "cert-1",
+  clerk_user_id: "user-1",
+  parish_id: "parish-1",
+  course_id: "course-1",
+  issued_at: "2026-01-01T00:00:00.000Z",
+  download_url: null,
+  course_title: "Safe Environment",
+  parish_name: "St. Test Parish",
+  student_name: "Test Student",
+  completion_date: "January 1, 2026",
+  lesson_count: 3,
+};
+
+describe("CertificatesPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      clerkUserId: "user-1",
+      parishId: "parish-1",
+      role: "student",
+    });
+    vi.mocked(listStudentCertificates).mockResolvedValue([certificate]);
+  });
+
+  it("renders certificate actions as links without nested buttons", async () => {
+    render(await CertificatesPage());
+
+    const viewLink = screen.getByRole("link", { name: "View Certificate" });
+    const pdfLink = screen.getByRole("link", { name: /PDF/ });
+
+    expect(viewLink).toHaveAttribute("href", "/app/certificates/cert-1");
+    expect(pdfLink).toHaveAttribute("href", "/api/certificates/cert-1/pdf");
+    expect(pdfLink).toHaveAttribute("target", "_blank");
+    expect(pdfLink).toHaveAttribute("rel", "noopener noreferrer");
+    expect(within(viewLink).queryByRole("button")).not.toBeInTheDocument();
+    expect(within(pdfLink).queryByRole("button")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/app/certificates/page.tsx
+++ b/src/app/app/certificates/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { requireParishRole } from "@/lib/authz";
 import { listStudentCertificates } from "@/lib/repositories/certificates";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export default async function CertificatesPage() {
@@ -40,30 +41,20 @@ export default async function CertificatesPage() {
                   Issued {cert.completion_date}
                 </p>
                 <div className="flex gap-2">
-                  <Link
-                    className="flex-1"
-                    href={`/app/certificates/${cert.id}`}
-                  >
-                    <button
-                      className="w-full rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:bg-primary/90"
-                      type="button"
-                    >
+                  <Button asChild className="flex-1" size="sm">
+                    <Link href={`/app/certificates/${cert.id}`}>
                       View Certificate
-                    </button>
-                  </Link>
-                  <a
-                    className="flex-shrink-0"
-                    href={`/api/certificates/${cert.id}/pdf`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <button
-                      className="rounded-md border border-border px-3 py-2 text-xs font-medium text-foreground hover:bg-secondary"
-                      type="button"
+                    </Link>
+                  </Button>
+                  <Button asChild className="flex-shrink-0" variant="outline" size="sm">
+                    <a
+                      href={`/api/certificates/${cert.id}/pdf`}
+                      target="_blank"
+                      rel="noopener noreferrer"
                     >
                       ↓ PDF
-                    </button>
-                  </a>
+                    </a>
+                  </Button>
                 </div>
               </CardContent>
             </Card>

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -9,7 +9,7 @@ import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
 import { E2E_PARISHES } from "@/lib/e2e-fixtures";
 import { isE2ESmokeMode } from "@/lib/e2e-mode";
-import { hasActiveParishRole, isDioceseAdmin, requireAuth } from "@/lib/authz";
+import { getActiveParishRole, isDioceseAdmin, requireAuth } from "@/lib/authz";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 
 export default async function AppLayout({
@@ -19,7 +19,8 @@ export default async function AppLayout({
 }) {
   const clerkUserId = await requireAuth();
   const showDioceseAdmin = await isDioceseAdmin(clerkUserId);
-  const showParishAdmin = await hasActiveParishRole("instructor", clerkUserId);
+  const activeParishRole = await getActiveParishRole(clerkUserId);
+  const showParishAdmin = activeParishRole === "parish_admin" || activeParishRole === "instructor";
   const showUserButton = !isE2ESmokeMode() && Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY);
   const store = await cookies();
   const cookieParishId = store.get("active_parish_id")?.value;

--- a/src/components/__tests__/completion-modal.test.tsx
+++ b/src/components/__tests__/completion-modal.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CompletionModal } from "@/components/completion-modal";
+
+describe("CompletionModal", () => {
+  it("does not claim a certificate was issued when no certificate id is available", () => {
+    render(
+      <CompletionModal
+        courseComplete
+        courseTitle="Safe Environment"
+        lessonTitle="Final quiz"
+        nextLesson={null}
+        score={100}
+      />,
+    );
+
+    expect(screen.getByText("Course Complete!")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "You have finished all lessons in Safe Environment. Your certificate is being prepared and will be available soon.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/certificate has been issued/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "View & Download Certificate" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/course-sidebar-client.test.tsx
+++ b/src/components/__tests__/course-sidebar-client.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CourseSidebarClient } from "@/components/course-sidebar-client";
+import type { CourseModuleWithProgress } from "@/lib/repositories/courses";
+
+const modules: CourseModuleWithProgress[] = [
+  {
+    id: "module-1",
+    title: "Module one",
+    sort_order: 1,
+    lessons: [
+      {
+        id: "lesson-1",
+        title: "First lesson",
+        sort_order: 1,
+        content_type: "VIDEO",
+        thumbnailUrl: null,
+        status: "completed",
+        bestScore: 100,
+      },
+      {
+        id: "lesson-2",
+        title: "Second lesson",
+        sort_order: 2,
+        content_type: "DOCUMENT",
+        thumbnailUrl: null,
+        status: "not_started",
+        bestScore: 0,
+      },
+    ],
+  },
+];
+
+describe("CourseSidebarClient", () => {
+  it("closes the mobile outline when a lesson is selected", async () => {
+    render(
+      <CourseSidebarClient
+        courseTitle="Course title"
+        courseId="course-1"
+        modules={modules}
+        currentLessonId="lesson-1"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open course outline" }));
+
+    const sheet = await screen.findByRole("dialog");
+    fireEvent.click(within(sheet).getByRole("link", { name: /Second lesson/ }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/__tests__/diocese-admin-nav.test.tsx
+++ b/src/components/__tests__/diocese-admin-nav.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DioceseAdminNav } from "@/components/diocese-admin-nav";
+
+const usePathname = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => usePathname(),
+}));
+
+describe("DioceseAdminNav", () => {
+  beforeEach(() => {
+    usePathname.mockReset();
+  });
+
+  it("marks a matching descendant route active", () => {
+    usePathname.mockReturnValue("/app/admin/users/123");
+
+    render(<DioceseAdminNav />);
+
+    expect(screen.getByRole("link", { name: "Users" }).className).toContain("bg-primary");
+    expect(screen.getByRole("link", { name: "Overview" }).className).not.toContain("bg-primary");
+  });
+
+  it("does not mark sibling prefixes active", () => {
+    usePathname.mockReturnValue("/app/admin/usersettings");
+
+    render(<DioceseAdminNav />);
+
+    expect(screen.getByRole("link", { name: "Users" }).className).not.toContain("bg-primary");
+  });
+});

--- a/src/components/__tests__/parish-admin-nav.test.tsx
+++ b/src/components/__tests__/parish-admin-nav.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ParishAdminNav } from "@/components/parish-admin-nav";
+
+const usePathname = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => usePathname(),
+}));
+
+describe("ParishAdminNav", () => {
+  beforeEach(() => {
+    usePathname.mockReset();
+  });
+
+  it("marks an exact section route active", () => {
+    usePathname.mockReturnValue("/app/parish-admin/courses");
+
+    render(<ParishAdminNav />);
+
+    expect(screen.getByRole("link", { name: "Course Adoption" }).className).toContain(
+      "bg-primary",
+    );
+    expect(screen.getByRole("link", { name: "Overview" }).className).not.toContain("bg-primary");
+  });
+
+  it("marks a matching descendant route active", () => {
+    usePathname.mockReturnValue("/app/parish-admin/people/123");
+
+    render(<ParishAdminNav />);
+
+    expect(screen.getByRole("link", { name: "People" }).className).toContain("bg-primary");
+    expect(screen.getByRole("link", { name: "Overview" }).className).not.toContain("bg-primary");
+  });
+
+  it("does not mark sibling prefixes active", () => {
+    usePathname.mockReturnValue("/app/parish-admin/courses-archive");
+
+    render(<ParishAdminNav />);
+
+    expect(screen.getByRole("link", { name: "Course Adoption" }).className).not.toContain(
+      "bg-primary",
+    );
+  });
+});

--- a/src/components/__tests__/parish-participation-manager.test.tsx
+++ b/src/components/__tests__/parish-participation-manager.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ParishParticipationManager } from "@/components/parish-participation-manager";
+import type {
+  ParishAdminCohortRow,
+  ParishAdminCourseRow,
+  ParishAdminMemberRow,
+  ParishAdminParticipationRow,
+} from "@/lib/repositories/parish-admin";
+
+const courses: ParishAdminCourseRow[] = [
+  {
+    id: "course-1",
+    title: "Foundations",
+    description: null,
+    published: true,
+    scope: "DIOCESE",
+  },
+];
+
+const cohorts: ParishAdminCohortRow[] = [
+  {
+    id: "cohort-1",
+    name: "Spring Cohort",
+    facilitator_clerk_user_id: null,
+    cadence: "weekly",
+    next_session_at: null,
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+  },
+];
+
+const members: ParishAdminMemberRow[] = [
+  {
+    clerk_user_id: "user_123",
+    role: "student",
+    email: "learner@example.com",
+    display_name: "Learner One",
+  },
+];
+
+const participationRows: ParishAdminParticipationRow[] = [
+  {
+    enrollment_id: "enrollment-1",
+    clerk_user_id: "user_123",
+    course_id: "course-1",
+    cohort_id: "cohort-1",
+    enrolled_at: "2026-03-05T23:30:00.000Z",
+    completed_lessons: 1,
+    started_lessons: 1,
+    total_lessons: 4,
+    progress_percent: 25,
+    last_activity_at: "2026-02-01T01:30:00.000Z",
+    status: "active",
+  },
+];
+
+describe("ParishParticipationManager", () => {
+  it("renders participation dates with a deterministic UTC format", () => {
+    render(
+      <ParishParticipationManager
+        canLogCommunications={false}
+        cohorts={cohorts}
+        courses={courses}
+        members={members}
+        participationRows={participationRows}
+      />,
+    );
+
+    expect(screen.getByText("2/1/2026")).toBeInTheDocument();
+    expect(screen.getByText("3/5/2026")).toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/theme-toggle.test.tsx
+++ b/src/components/__tests__/theme-toggle.test.tsx
@@ -4,16 +4,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ThemeToggle } from "@/components/theme-toggle";
 
 describe("ThemeToggle", () => {
+  let systemThemeListener: (() => void) | undefined;
+  let systemThemeMatches = false;
+
   beforeEach(() => {
+    systemThemeListener = undefined;
+    systemThemeMatches = false;
+
     Object.defineProperty(window, "matchMedia", {
       writable: true,
       value: vi.fn().mockImplementation((query: string) => ({
-        matches: false,
+        matches: systemThemeMatches,
         media: query,
         onchange: null,
         addListener: vi.fn(),
         removeListener: vi.fn(),
-        addEventListener: vi.fn(),
+        addEventListener: vi.fn((_event: string, listener: () => void) => {
+          systemThemeListener = listener;
+        }),
         removeEventListener: vi.fn(),
         dispatchEvent: vi.fn(),
       })),
@@ -56,6 +64,25 @@ describe("ThemeToggle", () => {
     await waitFor(() => {
       expect(document.documentElement.dataset.theme).toBe("light");
     });
+  });
+
+  it("continues following system theme when no theme is saved", async () => {
+    systemThemeMatches = true;
+
+    render(<ThemeToggle />);
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.theme).toBe("dark");
+    });
+    expect(localStorage.getItem("wd-lms-theme")).toBeNull();
+
+    systemThemeMatches = false;
+    systemThemeListener?.();
+
+    await waitFor(() => {
+      expect(document.documentElement.dataset.theme).toBe("light");
+    });
+    expect(localStorage.getItem("wd-lms-theme")).toBeNull();
   });
 
   it("toggles from dark to light", async () => {

--- a/src/components/completion-modal.tsx
+++ b/src/components/completion-modal.tsx
@@ -58,7 +58,10 @@ export function CompletionModal({
             <div className="mb-3 text-4xl">🎉</div>
             <p className="mb-2 font-bold text-primary">Course Complete!</p>
             <p className="mb-4 text-sm text-muted-foreground">
-              You have finished all lessons in {courseTitle}. A certificate has been issued.
+              You have finished all lessons in {courseTitle}.{" "}
+              {certificateId
+                ? "A certificate has been issued."
+                : "Your certificate is being prepared and will be available soon."}
             </p>
             {certificateId && (
               <Button asChild>

--- a/src/components/course-sidebar-client.tsx
+++ b/src/components/course-sidebar-client.tsx
@@ -57,6 +57,7 @@ export function CourseSidebarClient({
               courseId={courseId}
               modules={modules}
               currentLessonId={currentLessonId}
+              onLessonSelect={() => setMobileOpen(false)}
               showHeader={false}
             />
           </div>

--- a/src/components/course-sidebar.tsx
+++ b/src/components/course-sidebar.tsx
@@ -11,6 +11,7 @@ interface CourseSidebarProps {
   modules: CourseModuleWithProgress[];
   currentLessonId: string;
   showHeader?: boolean;
+  onLessonSelect?: () => void;
 }
 
 function lessonTypeIcon(contentType: CourseLesson["content_type"], isActive: boolean) {
@@ -21,7 +22,14 @@ function lessonTypeIcon(contentType: CourseLesson["content_type"], isActive: boo
   return <span className={`text-[12px] ${color}`}>▶</span>;
 }
 
-export function CourseSidebar({ courseTitle, courseId, modules, currentLessonId, showHeader = true }: CourseSidebarProps) {
+export function CourseSidebar({
+  courseTitle,
+  courseId,
+  modules,
+  currentLessonId,
+  showHeader = true,
+  onLessonSelect,
+}: CourseSidebarProps) {
   const allLessons = modules.flatMap((m) => m.lessons);
   const completedCount = allLessons.filter((l) => l.status === "completed").length;
   const progressPercent = allLessons.length > 0
@@ -68,6 +76,7 @@ export function CourseSidebar({ courseTitle, courseId, modules, currentLessonId,
                   }`}
                   href={`/app/lessons/${lesson.id}`}
                   key={lesson.id}
+                  onClick={onLessonSelect}
                 >
                   {/* Completion icon */}
                   <div

--- a/src/components/diocese-admin-nav.tsx
+++ b/src/components/diocese-admin-nav.tsx
@@ -23,7 +23,7 @@ export function DioceseAdminNav() {
       {routes.map((route) => {
         const isActive = route.exact
           ? pathname === route.href
-          : pathname.startsWith(route.href);
+          : pathname === route.href || pathname.startsWith(`${route.href}/`);
 
         return (
           <Link

--- a/src/components/parish-admin-nav.tsx
+++ b/src/components/parish-admin-nav.tsx
@@ -22,7 +22,9 @@ export function ParishAdminNav() {
   return (
     <nav aria-label="Parish admin sections" className="flex flex-wrap gap-1.5">
       {tabs.map((tab) => {
-        const isActive = tab.exact ? pathname === tab.href : pathname.startsWith(tab.href);
+        const isActive = tab.exact
+          ? pathname === tab.href
+          : pathname === tab.href || pathname.startsWith(`${tab.href}/`);
 
         return (
           <Link

--- a/src/components/parish-communications-manager.tsx
+++ b/src/components/parish-communications-manager.tsx
@@ -46,6 +46,14 @@ interface SendDetailsResponse {
   }>;
 }
 
+async function parseJsonResponse(response: Response) {
+  try {
+    return (await response.json()) as { error?: string; deliveryNote?: string };
+  } catch {
+    return null;
+  }
+}
+
 function isAudienceType(value: string | null): value is AudienceType {
   return value === "all_members" || value === "stalled_learners" || value === "cohort" || value === "course";
 }
@@ -188,17 +196,19 @@ export function ParishCommunicationsManager({
           body,
         }),
       });
-      const data = await response.json();
+      const data = await parseJsonResponse(response);
 
       if (!response.ok) {
-        setMessage(data.error ?? "Failed to log message.");
+        setMessage(data?.error ?? "Failed to log message.");
         return;
       }
 
-      setMessage(data.deliveryNote ?? "Message logged.");
+      setMessage(data?.deliveryNote ?? "Message logged.");
       setSubject("");
       setBody("");
       router.refresh();
+    } catch {
+      setMessage("Failed to log message.");
     } finally {
       setSubmitting(false);
     }
@@ -216,17 +226,26 @@ export function ParishCommunicationsManager({
     }
 
     setDetailsLoadingSendId(sendId);
-    const response = await fetch(`/api/parish-admin/communications/${sendId}`);
-    const data = await response.json();
-    setDetailsLoadingSendId(null);
+    try {
+      const response = await fetch(`/api/parish-admin/communications/${sendId}`);
+      const data = await parseJsonResponse(response);
 
-    if (!response.ok) {
-      setMessage(data.error ?? "Failed to load send details.");
-      return;
+      if (!response.ok) {
+        setMessage(data?.error ?? "Failed to load send details.");
+        return;
+      }
+      if (!data) {
+        setMessage("Failed to load send details.");
+        return;
+      }
+
+      setDetailsBySendId((prev) => ({ ...prev, [sendId]: data as SendDetailsResponse }));
+      setExpandedSendId(sendId);
+    } catch {
+      setMessage("Failed to load send details.");
+    } finally {
+      setDetailsLoadingSendId(null);
     }
-
-    setDetailsBySendId((prev) => ({ ...prev, [sendId]: data as SendDetailsResponse }));
-    setExpandedSendId(sendId);
   }
 
   return (

--- a/src/components/parish-participation-manager.tsx
+++ b/src/components/parish-participation-manager.tsx
@@ -24,9 +24,11 @@ const STATUS_BADGES: Record<
   completed: { label: "Completed", variant: "success" },
 };
 
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", { timeZone: "UTC" });
+
 function formatDate(value: string | null) {
   if (!value) return "No activity yet";
-  return new Date(value).toLocaleDateString();
+  return DATE_FORMATTER.format(new Date(value));
 }
 
 function toLearnerLabel(member: ParishAdminMemberRow | undefined, clerkUserId: string) {
@@ -231,7 +233,7 @@ export function ParishParticipationManager({
                 <Badge variant={STATUS_BADGES[row.status].variant}>{STATUS_BADGES[row.status].label}</Badge>
               </td>
               <td className="py-2 pr-4">{formatDate(row.last_activity_at)}</td>
-              <td className="py-2 pr-4">{new Date(row.enrolled_at).toLocaleDateString()}</td>
+              <td className="py-2 pr-4">{formatDate(row.enrolled_at)}</td>
               {canLogCommunications ? (
                 <td className="py-2 pr-4">
                   <div className="flex flex-wrap gap-2">

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -83,7 +83,6 @@ export function ThemeToggle() {
   useEffect(() => {
     if (!mounted) return;
     applyTheme(theme);
-    localStorage.setItem(THEME_KEY, theme);
   }, [mounted, theme]);
 
   const toggleTheme = () => {

--- a/src/components/ui/__tests__/button.test.tsx
+++ b/src/components/ui/__tests__/button.test.tsx
@@ -13,6 +13,7 @@ describe("Button", () => {
     expect(button.className).toContain("bg-primary");
     expect(button.className).toContain("text-primary-foreground");
     expect(button.className).toContain("h-[38px]");
+    expect(button).toHaveAttribute("type", "button");
   });
 
   it("renders configured variant and size styles", () => {

--- a/src/components/ui/__tests__/radix-primitives.test.tsx
+++ b/src/components/ui/__tests__/radix-primitives.test.tsx
@@ -76,4 +76,21 @@ describe("Radix primitives", () => {
 
     expect(screen.getByText("Sheet Title")).toBeInTheDocument();
   });
+
+  it("renders Sheet close control as a non-submit button", () => {
+    render(
+      <form>
+        <Sheet open onOpenChange={() => {}}>
+          <SheetContent>
+            <SheetTitle>Sheet Title</SheetTitle>
+          </SheetContent>
+        </Sheet>
+      </form>,
+    );
+
+    expect(screen.getByRole("button", { name: "Close" })).toHaveAttribute(
+      "type",
+      "button",
+    );
+  });
 });

--- a/src/components/ui/__tests__/radix-primitives.test.tsx
+++ b/src/components/ui/__tests__/radix-primitives.test.tsx
@@ -50,17 +50,23 @@ describe("Radix primitives", () => {
 
   it("renders Tooltip content when open", () => {
     render(
-      <TooltipProvider delayDuration={0}>
-        <Tooltip open>
-          <TooltipTrigger asChild>
-            <button type="button">Hover me</button>
-          </TooltipTrigger>
-          <TooltipContent>Helpful context</TooltipContent>
-        </Tooltip>
-      </TooltipProvider>,
+      <div data-testid="constrained-parent" className="overflow-hidden">
+        <TooltipProvider delayDuration={0}>
+          <Tooltip open>
+            <TooltipTrigger asChild>
+              <button type="button">Hover me</button>
+            </TooltipTrigger>
+            <TooltipContent>Helpful context</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>,
     );
 
-    expect(screen.getByRole("tooltip")).toHaveTextContent("Helpful context");
+    const tooltip = screen.getByRole("tooltip");
+    expect(tooltip).toHaveTextContent("Helpful context");
+    expect(screen.getByTestId("constrained-parent")).not.toContainElement(
+      tooltip,
+    );
   });
 
   it("renders Sheet content on the right side", () => {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -41,12 +41,13 @@ export interface ButtonProps
 }
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, type, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size }), className)}
         ref={ref}
+        type={asChild ? type : (type ?? "button")}
         {...props}
       />
     );

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -48,7 +48,10 @@ export function SheetContent({
         {...props}
       >
         {children}
-        <DialogPrimitive.Close className="absolute right-3 top-3 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
+        <DialogPrimitive.Close
+          type="button"
+          className="absolute right-3 top-3 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+        >
           <X className="h-4 w-4" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -11,14 +11,16 @@ export const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 6, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    className={cn(
-      "z-50 overflow-hidden rounded-md border border-border bg-card px-3 py-1.5 text-xs text-card-foreground shadow-md",
-      className,
-    )}
-    ref={ref}
-    sideOffset={sideOffset}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      className={cn(
+        "z-50 overflow-hidden rounded-md border border-border bg-card px-3 py-1.5 text-xs text-card-foreground shadow-md",
+        className,
+      )}
+      ref={ref}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;

--- a/src/lib/__tests__/authz.test.ts
+++ b/src/lib/__tests__/authz.test.ts
@@ -21,7 +21,9 @@ vi.mock("@/lib/supabase/server", () => ({
   getSupabaseAdminClient: vi.fn(),
 }));
 
-import { hasCompletedOnboarding } from "@/lib/authz";
+import { clerkClient } from "@clerk/nextjs/server";
+
+import { getUserLabel, hasCompletedOnboarding } from "@/lib/authz";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 
 function createQuery(result: unknown) {
@@ -71,5 +73,27 @@ describe("hasCompletedOnboarding", () => {
     await expect(hasCompletedOnboarding("user-1")).resolves.toBe(false);
 
     expect(from).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getUserLabel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("falls back to email when the Clerk user has no name", async () => {
+    const getUser = vi.fn(async () => ({
+      fullName: null,
+      firstName: null,
+      lastName: null,
+      primaryEmailAddress: { emailAddress: "user@example.com" },
+    }));
+    vi.mocked(clerkClient).mockResolvedValue({
+      users: { getUser },
+    } as never);
+
+    await expect(getUserLabel("clerk-user-1")).resolves.toBe("user@example.com");
+
+    expect(getUser).toHaveBeenCalledWith("clerk-user-1");
   });
 });

--- a/src/lib/authz.ts
+++ b/src/lib/authz.ts
@@ -195,10 +195,9 @@ export async function getUserLabel(clerkUserId: string) {
 
   const client = await clerkClient();
   const user = await client.users.getUser(clerkUserId);
-  return (
-    user.fullName ??
-    `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim() ??
-    user.primaryEmailAddress?.emailAddress ??
-    clerkUserId
-  );
+  const fullName = user.fullName?.trim();
+  const name = `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim();
+  const email = user.primaryEmailAddress?.emailAddress?.trim();
+
+  return fullName || name || email || clerkUserId;
 }


### PR DESCRIPTION
Fixes the second open-bug batch: navigation/visibility, HTML/accessibility primitives, and client display/resilience findings.

Changes:
- Close mobile lesson outline after lesson selection
- Show Parish Admin nav for parish_admin users
- Bound parish/diocese admin active route matching to exact paths or descendants
- Default Button and Sheet close controls to non-submit buttons
- Portal Tooltip content
- Remove nested interactive elements from certificate actions
- Preserve system theme as system preference until explicit toggle
- Fall back to Clerk email when names are blank
- Handle non-JSON/network failures in parish communications manager
- Avoid certificate-issued copy without a certificate id
- Render participation dates with deterministic UTC formatting

Validation:
- Crabbox CI passed: lint, typecheck, coverage tests
- 84 test files, 408 tests passing
- All targeted clawpatch findings revalidated fixed
- clawpatch open findings: 100 -> 85

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI, nav highlighting, and client error handling; layout role visibility is a small authorization-adjacent behavior change with tests.
> 
> **Overview**
> This PR hardens client UI behavior around navigation, accessibility, and display edge cases, with broad test coverage for the touched flows.
> 
> **Navigation and visibility:** App layout now uses `getActiveParishRole` so **Parish Admin** appears for `parish_admin` as well as `instructor`. Parish and diocese admin nav active states only match exact paths or real descendants (e.g. `/people/123`), not accidental prefix matches like `courses-archive`. The mobile course outline closes after a lesson is picked.
> 
> **Accessibility and primitives:** Certificate actions use `Button` + `asChild` links instead of nested buttons. Default `Button` and sheet close controls use `type="button"`. Tooltips render through a portal so they are not clipped by overflow parents.
> 
> **UX and resilience:** Completion copy no longer claims a certificate was issued when `certificateId` is missing. Theme follows system preference until the user toggles (no longer writing theme to `localStorage` on every apply). Participation dates use fixed UTC formatting. Parish communications fetch paths tolerate non-JSON and network failures. `getUserLabel` falls back to email when Clerk names are empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03481e7f86c0ce5259f320ed4db2d000d6fff94d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->