### PR TITLE
fix: remaining bug and concurrency findings

### DIFF
--- a/src/app/api/admin/enrollments/__tests__/route.test.ts
+++ b/src/app/api/admin/enrollments/__tests__/route.test.ts
@@ -36,15 +36,21 @@ describe("/api/admin/enrollments", () => {
     const eqUser = vi.fn(() => ({ eq: eqCourse }));
     const eqParish = vi.fn(() => ({ eq: eqUser }));
     const existingSelect = vi.fn(() => ({ eq: eqParish }));
+    const courseMaybeSingle = vi.fn(async () => ({ data: { id: "c1", scope: "DIOCESE" }, error: null }));
+    const courseEq = vi.fn(() => ({ maybeSingle: courseMaybeSingle }));
+    const courseSelect = vi.fn(() => ({ eq: courseEq }));
     const single = vi.fn(async () => ({ data: { id: "e1" }, error: null }));
     const upsertSelect = vi.fn(() => ({ single }));
     const upsert = vi.fn(() => ({ select: upsertSelect }));
+    const rpc = vi.fn();
 
     vi.mocked(getSupabaseAdminClient).mockReturnValue({
-      from: vi
-        .fn()
-        .mockReturnValueOnce({ select: existingSelect })
-        .mockReturnValueOnce({ upsert }),
+      from: vi.fn((table: string) => {
+        if (table === "enrollments") return { select: existingSelect, upsert };
+        if (table === "courses") return { select: courseSelect };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+      rpc,
     } as never);
 
     const response = await POST(
@@ -61,6 +67,7 @@ describe("/api/admin/enrollments", () => {
     expect(response.status).toBe(201);
     await expect(response.json()).resolves.toEqual({ enrollment: { id: "e1" } });
     expect(upsertSelect).toHaveBeenCalledWith("id,parish_id,clerk_user_id,course_id,created_at");
+    expect(rpc).not.toHaveBeenCalled();
     expect(notifyEnrollmentConfirmed).toHaveBeenCalledWith({
       parishId: "11111111-1111-4111-8111-111111111111",
       courseId: "22222222-2222-4222-8222-222222222222",
@@ -69,20 +76,29 @@ describe("/api/admin/enrollments", () => {
   });
 
   it("does not send enrollment confirmation for existing enrollments", async () => {
-    const maybeSingle = vi.fn(async () => ({ data: { id: "e1" }, error: null }));
+    const existingEnrollment = {
+      id: "e1",
+      parish_id: "11111111-1111-4111-8111-111111111111",
+      clerk_user_id: "user-1",
+      course_id: "22222222-2222-4222-8222-222222222222",
+      created_at: "2026-01-01",
+    };
+    const maybeSingle = vi.fn(async () => ({ data: existingEnrollment, error: null }));
     const eqCourse = vi.fn(() => ({ maybeSingle }));
     const eqUser = vi.fn(() => ({ eq: eqCourse }));
     const eqParish = vi.fn(() => ({ eq: eqUser }));
     const existingSelect = vi.fn(() => ({ eq: eqParish }));
-    const single = vi.fn(async () => ({ data: { id: "e1" }, error: null }));
-    const upsertSelect = vi.fn(() => ({ single }));
+    const upsertSelect = vi.fn();
     const upsert = vi.fn(() => ({ select: upsertSelect }));
+    const rpc = vi.fn();
 
     vi.mocked(getSupabaseAdminClient).mockReturnValue({
-      from: vi
-        .fn()
-        .mockReturnValueOnce({ select: existingSelect })
-        .mockReturnValueOnce({ upsert }),
+      from: vi.fn((table: string) => {
+        if (table === "enrollments") return { select: existingSelect, upsert };
+        if (table === "courses") return { select: vi.fn() };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+      rpc,
     } as never);
 
     const response = await POST(
@@ -97,8 +113,72 @@ describe("/api/admin/enrollments", () => {
     );
 
     expect(response.status).toBe(201);
-    await expect(response.json()).resolves.toEqual({ enrollment: { id: "e1" } });
+    await expect(response.json()).resolves.toEqual({ enrollment: existingEnrollment });
+    expect(upsert).not.toHaveBeenCalled();
+    expect(rpc).not.toHaveBeenCalled();
     expect(notifyEnrollmentConfirmed).not.toHaveBeenCalled();
+  });
+
+  it("creates parish-scoped enrollments through the atomic adoption RPC", async () => {
+    const maybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const eqCourse = vi.fn(() => ({ maybeSingle }));
+    const eqUser = vi.fn(() => ({ eq: eqCourse }));
+    const eqParish = vi.fn(() => ({ eq: eqUser }));
+    const existingSelect = vi.fn(() => ({ eq: eqParish }));
+    const courseMaybeSingle = vi.fn(async () => ({ data: { id: "c1", scope: "PARISH" }, error: null }));
+    const courseEq = vi.fn(() => ({ maybeSingle: courseMaybeSingle }));
+    const courseSelect = vi.fn(() => ({ eq: courseEq }));
+    const upsert = vi.fn();
+    const rpc = vi.fn(async () => ({
+      data: {
+        ok: true,
+        enrollment: {
+          id: "e1",
+          parish_id: "11111111-1111-4111-8111-111111111111",
+          clerk_user_id: "user-1",
+          course_id: "22222222-2222-4222-8222-222222222222",
+          created_at: "2026-01-01",
+        },
+      },
+      error: null,
+    }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "enrollments") return { select: existingSelect, upsert };
+        if (table === "courses") return { select: courseSelect };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+      rpc,
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/admin/enrollments", {
+        method: "POST",
+        body: JSON.stringify({
+          parishId: "11111111-1111-4111-8111-111111111111",
+          courseId: "22222222-2222-4222-8222-222222222222",
+          clerkUserId: "user-1",
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      enrollment: {
+        id: "e1",
+        parish_id: "11111111-1111-4111-8111-111111111111",
+        clerk_user_id: "user-1",
+        course_id: "22222222-2222-4222-8222-222222222222",
+        created_at: "2026-01-01",
+      },
+    });
+    expect(rpc).toHaveBeenCalledWith("create_parish_course_enrollment", {
+      p_parish_id: "11111111-1111-4111-8111-111111111111",
+      p_course_id: "22222222-2222-4222-8222-222222222222",
+      p_clerk_user_id: "user-1",
+    });
+    expect(upsert).not.toHaveBeenCalled();
   });
 
   it("returns 400 for invalid create payloads", async () => {

--- a/src/app/api/admin/enrollments/route.ts
+++ b/src/app/api/admin/enrollments/route.ts
@@ -17,6 +17,14 @@ const deleteEnrollmentSchema = z.object({
   courseId: z.string().uuid(),
 });
 
+type EnrollmentRow = {
+  id: string;
+  parish_id: string;
+  clerk_user_id: string;
+  course_id: string;
+  created_at: string;
+};
+
 async function parseJsonBody<T>(req: Request, schema: z.ZodSchema<T>) {
   try {
     return schema.safeParse(await req.json());
@@ -64,7 +72,7 @@ export async function POST(req: Request) {
 
   const existingEnrollmentQuery = await supabase
     .from("enrollments")
-    .select("id")
+    .select("id,parish_id,clerk_user_id,course_id,created_at")
     .eq("parish_id", payload.parishId)
     .eq("clerk_user_id", payload.clerkUserId)
     .eq("course_id", payload.courseId)
@@ -74,24 +82,70 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: existingEnrollmentQuery.error.message }, { status: 400 });
   }
 
-  const { data, error } = await supabase
-    .from("enrollments")
-    .upsert(
-      {
-        parish_id: payload.parishId,
-        clerk_user_id: payload.clerkUserId,
-        course_id: payload.courseId,
-      },
-      { onConflict: "parish_id,clerk_user_id,course_id" },
-    )
-    .select("id,parish_id,clerk_user_id,course_id,created_at")
-    .single();
+  let data = existingEnrollmentQuery.data as EnrollmentRow | null;
 
-  if (error) {
-    return NextResponse.json({ error: error.message }, { status: 400 });
-  }
+  if (!data) {
+    const { data: course, error: courseError } = await supabase
+      .from("courses")
+      .select("id,scope")
+      .eq("id", payload.courseId)
+      .maybeSingle();
 
-  if (!existingEnrollmentQuery.data) {
+    if (courseError) {
+      return NextResponse.json({ error: courseError.message }, { status: 400 });
+    }
+
+    if (!course) {
+      return NextResponse.json({ error: "Selected course is not available for enrollment." }, { status: 400 });
+    }
+
+    if (course.scope === "PARISH") {
+      const { data: result, error: rpcError } = await supabase.rpc("create_parish_course_enrollment", {
+        p_parish_id: payload.parishId,
+        p_course_id: payload.courseId,
+        p_clerk_user_id: payload.clerkUserId,
+      });
+
+      if (rpcError) {
+        return NextResponse.json({ error: rpcError.message }, { status: 400 });
+      }
+
+      const rpcResult = result as {
+        error?: string;
+        ok?: boolean;
+        enrollment?: EnrollmentRow;
+      } | null;
+
+      if (rpcResult?.error) {
+        return NextResponse.json({ error: rpcResult.error }, { status: 400 });
+      }
+
+      if (!rpcResult?.enrollment) {
+        return NextResponse.json({ error: "Failed to create enrollment." }, { status: 400 });
+      }
+
+      data = rpcResult.enrollment;
+    } else {
+      const { data: enrollment, error } = await supabase
+        .from("enrollments")
+        .upsert(
+          {
+            parish_id: payload.parishId,
+            clerk_user_id: payload.clerkUserId,
+            course_id: payload.courseId,
+          },
+          { onConflict: "parish_id,clerk_user_id,course_id" },
+        )
+        .select("id,parish_id,clerk_user_id,course_id,created_at")
+        .single();
+
+      if (error) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+
+      data = enrollment as EnrollmentRow;
+    }
+
     // Send enrollment confirmation email (non-blocking)
     notifyEnrollmentConfirmed({
       clerkUserId: payload.clerkUserId,

--- a/src/app/api/admin/users/__tests__/route.test.ts
+++ b/src/app/api/admin/users/__tests__/route.test.ts
@@ -275,4 +275,47 @@ describe("GET /api/admin/users", () => {
       users: [{ clerk_user_id: "target-user" }],
     });
   });
+
+  it("applies diocese admin exclusion before limiting user profiles", async () => {
+    const events: string[] = [];
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "user_profiles") {
+          return {
+            select: vi.fn(() =>
+              createUserProfilesQuery({
+                data: [
+                  {
+                    clerk_user_id: "older-non-admin",
+                    email: "older@example.com",
+                    display_name: "Older Non Admin",
+                    onboarding_completed_at: "2024-01-01",
+                    created_at: "2024-01-01",
+                  },
+                ],
+                events,
+              }),
+            ),
+          };
+        }
+
+        if (table === "diocese_admins") {
+          return { select: vi.fn(async () => ({ data: [{ clerk_user_id: "newest-admin" }], error: null })) };
+        }
+
+        return {
+          select: vi.fn(async () => ({ data: [], error: null })),
+        };
+      }),
+    } as never);
+
+    const response = await GET(new Request("http://localhost/api/admin/users?dioceseAdmin=no&limit=1"));
+
+    expect(response.status).toBe(200);
+    expect(events).toEqual(["not", "order", "limit"]);
+    await expect(response.json()).resolves.toMatchObject({
+      users: [{ clerk_user_id: "older-non-admin", is_diocese_admin: false }],
+    });
+  });
 });

--- a/src/lib/repositories/__tests__/course-join-requests.test.ts
+++ b/src/lib/repositories/__tests__/course-join-requests.test.ts
@@ -1,0 +1,325 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseAdminClient: vi.fn(),
+}));
+
+vi.mock("@/lib/audit-log", () => ({
+  recordAdminAuditLog: vi.fn(),
+}));
+
+import { recordAdminAuditLog } from "@/lib/audit-log";
+import {
+  approveJoinRequest,
+  createJoinRequest,
+  getParishJoinRequests,
+  getStudentPendingRequests,
+  rejectJoinRequest,
+} from "@/lib/repositories/course-join-requests";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+const request = {
+  parish_id: "11111111-1111-4111-8111-111111111111",
+  clerk_user_id: "user-1",
+  course_id: "22222222-2222-4222-8222-222222222222",
+};
+
+function mockApproveSupabase({
+  requestData = request,
+  requestError = null,
+  updatedData = { id: "request-1" },
+  updateError = null,
+  courseData = { id: request.course_id, scope: "PARISH" },
+  courseError = null,
+  rpcResult = { data: { ok: true, enrollment: { id: "enrollment-1" } }, error: null },
+  upsertResult = { error: null },
+}: {
+  requestData?: typeof request | null;
+  requestError?: Error | null;
+  updatedData?: { id: string } | null;
+  updateError?: Error | null;
+  courseData?: { id: string; scope: string } | null;
+  courseError?: Error | null;
+  rpcResult?: { data: unknown; error: Error | null };
+  upsertResult?: { error: Error | null };
+} = {}) {
+  const requestMaybeSingle = vi.fn(async () => ({ data: requestData, error: requestError }));
+  const requestStatusEq = vi.fn(() => ({ maybeSingle: requestMaybeSingle }));
+  const requestIdEq = vi.fn(() => ({ eq: requestStatusEq }));
+  const requestSelect = vi.fn(() => ({ eq: requestIdEq }));
+
+  const updateMaybeSingle = vi.fn(async () => ({ data: updatedData, error: updateError }));
+  const updateSelect = vi.fn(() => ({ maybeSingle: updateMaybeSingle }));
+  const updateStatusEq = vi.fn(() => ({ select: updateSelect }));
+  const updateIdEq = vi.fn(() => ({ eq: updateStatusEq }));
+  const update = vi.fn(() => ({ eq: updateIdEq }));
+
+  const courseMaybeSingle = vi.fn(async () => ({ data: courseData, error: courseError }));
+  const courseEq = vi.fn(() => ({ maybeSingle: courseMaybeSingle }));
+  const courseSelect = vi.fn(() => ({ eq: courseEq }));
+
+  const directEnrollmentUpsert = vi.fn(async () => upsertResult);
+  const rpc = vi.fn(async () => rpcResult);
+
+  vi.mocked(getSupabaseAdminClient).mockReturnValue({
+    from: vi.fn((table: string) => {
+      if (table === "course_join_requests") {
+        return { select: requestSelect, update };
+      }
+      if (table === "courses") {
+        return { select: courseSelect };
+      }
+      if (table === "enrollments") {
+        return { upsert: directEnrollmentUpsert };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    }),
+    rpc,
+  } as never);
+
+  return { directEnrollmentUpsert, rpc, update };
+}
+
+describe("approveJoinRequest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates parish-scoped enrollments through the atomic adoption RPC", async () => {
+    const { directEnrollmentUpsert, rpc } = mockApproveSupabase();
+
+    await approveJoinRequest({ requestId: "request-1", actorClerkUserId: "admin-1" });
+
+    expect(rpc).toHaveBeenCalledWith("create_parish_course_enrollment", {
+      p_parish_id: request.parish_id,
+      p_course_id: request.course_id,
+      p_clerk_user_id: request.clerk_user_id,
+    });
+    expect(directEnrollmentUpsert).not.toHaveBeenCalled();
+    expect(recordAdminAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "parish.join_request_approved",
+        resourceId: "request-1",
+      }),
+    );
+  });
+
+  it("keeps direct upserts for non-parish course approvals", async () => {
+    const { directEnrollmentUpsert, rpc } = mockApproveSupabase({
+      courseData: { id: request.course_id, scope: "DIOCESE" },
+    });
+
+    await approveJoinRequest({ requestId: "request-1", actorClerkUserId: "admin-1" });
+
+    expect(rpc).not.toHaveBeenCalled();
+    expect(directEnrollmentUpsert).toHaveBeenCalledWith(
+      {
+        parish_id: request.parish_id,
+        clerk_user_id: request.clerk_user_id,
+        course_id: request.course_id,
+      },
+      { onConflict: "parish_id,clerk_user_id,course_id" },
+    );
+  });
+
+  it("rolls approval back when parish enrollment RPC returns a domain error", async () => {
+    const { update } = mockApproveSupabase({
+      rpcResult: { data: { error: "Course is not adopted by this parish." }, error: null },
+    });
+
+    await expect(approveJoinRequest({ requestId: "request-1", actorClerkUserId: "admin-1" })).rejects.toThrow(
+      "Course is not adopted by this parish.",
+    );
+
+    expect(update).toHaveBeenCalledWith({ status: "APPROVED" });
+    expect(update).toHaveBeenCalledWith({ status: "PENDING" });
+    expect(recordAdminAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("rolls approval back when the course cannot be loaded", async () => {
+    const courseError = new Error("course lookup failed");
+    const { update } = mockApproveSupabase({ courseError });
+
+    await expect(approveJoinRequest({ requestId: "request-1", actorClerkUserId: "admin-1" })).rejects.toThrow(
+      "course lookup failed",
+    );
+
+    expect(update).toHaveBeenCalledWith({ status: "PENDING" });
+    expect(recordAdminAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("does not approve missing or non-pending requests", async () => {
+    const { update, rpc, directEnrollmentUpsert } = mockApproveSupabase({ requestData: null });
+
+    await expect(approveJoinRequest({ requestId: "request-1", actorClerkUserId: "admin-1" })).rejects.toThrow(
+      "Request not found or not pending",
+    );
+
+    expect(update).not.toHaveBeenCalled();
+    expect(rpc).not.toHaveBeenCalled();
+    expect(directEnrollmentUpsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("course join request repository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a join request when no enrollment or pending request exists", async () => {
+    const enrollmentMaybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const enrollmentCourseEq = vi.fn(() => ({ maybeSingle: enrollmentMaybeSingle }));
+    const enrollmentUserEq = vi.fn(() => ({ eq: enrollmentCourseEq }));
+    const enrollmentParishEq = vi.fn(() => ({ eq: enrollmentUserEq }));
+    const enrollmentSelect = vi.fn(() => ({ eq: enrollmentParishEq }));
+
+    const pendingMaybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const pendingStatusEq = vi.fn(() => ({ maybeSingle: pendingMaybeSingle }));
+    const pendingCourseEq = vi.fn(() => ({ eq: pendingStatusEq }));
+    const pendingUserEq = vi.fn(() => ({ eq: pendingCourseEq }));
+    const pendingParishEq = vi.fn(() => ({ eq: pendingUserEq }));
+    const pendingSelect = vi.fn(() => ({ eq: pendingParishEq }));
+
+    const created = {
+      id: "request-1",
+      parish_id: request.parish_id,
+      clerk_user_id: request.clerk_user_id,
+      course_id: request.course_id,
+      status: "PENDING",
+      created_at: "2026-01-01",
+      updated_at: "2026-01-02",
+    };
+    const single = vi.fn(async () => ({ data: created, error: null }));
+    const insertSelect = vi.fn(() => ({ single }));
+    const insert = vi.fn(() => ({ select: insertSelect }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "enrollments") {
+          return { select: enrollmentSelect };
+        }
+        if (table === "course_join_requests") {
+          return { select: pendingSelect, insert };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    } as never);
+
+    await expect(createJoinRequest({
+      parishId: request.parish_id,
+      clerkUserId: request.clerk_user_id,
+      courseId: request.course_id,
+    })).resolves.toEqual({
+      id: "request-1",
+      parishId: request.parish_id,
+      clerkUserId: request.clerk_user_id,
+      courseId: request.course_id,
+      status: "PENDING",
+      createdAt: "2026-01-01",
+      updatedAt: "2026-01-02",
+    });
+  });
+
+  it("rejects duplicate join requests for already-enrolled learners", async () => {
+    const maybeSingle = vi.fn(async () => ({ data: { id: "enrollment-1" }, error: null }));
+    const eqCourse = vi.fn(() => ({ maybeSingle }));
+    const eqUser = vi.fn(() => ({ eq: eqCourse }));
+    const eqParish = vi.fn(() => ({ eq: eqUser }));
+    const select = vi.fn(() => ({ eq: eqParish }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ select })),
+    } as never);
+
+    await expect(createJoinRequest({
+      parishId: request.parish_id,
+      clerkUserId: request.clerk_user_id,
+      courseId: request.course_id,
+    })).rejects.toThrow("Already enrolled in this course");
+  });
+
+  it("lists parish join requests with course titles", async () => {
+    const data = [
+      {
+        id: "request-1",
+        parish_id: request.parish_id,
+        clerk_user_id: request.clerk_user_id,
+        course_id: request.course_id,
+        status: "PENDING",
+        created_at: "2026-01-01",
+        updated_at: "2026-01-02",
+        courses: { title: "Intro Course" },
+      },
+    ];
+    const statusEq = vi.fn(() => ({ data, error: null }));
+    const order = vi.fn(() => ({ eq: statusEq }));
+    const parishEq = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ eq: parishEq }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ select })),
+    } as never);
+
+    await expect(getParishJoinRequests(request.parish_id, "PENDING")).resolves.toEqual([
+      expect.objectContaining({ id: "request-1", courseTitle: "Intro Course", status: "PENDING" }),
+    ]);
+    expect(statusEq).toHaveBeenCalledWith("status", "PENDING");
+  });
+
+  it("lists a student's pending join requests", async () => {
+    const data = [
+      {
+        id: "request-1",
+        parish_id: request.parish_id,
+        clerk_user_id: request.clerk_user_id,
+        course_id: request.course_id,
+        status: "PENDING",
+        created_at: "2026-01-01",
+        updated_at: "2026-01-02",
+      },
+    ];
+    const order = vi.fn(() => ({ data, error: null }));
+    const statusEq = vi.fn(() => ({ order }));
+    const userEq = vi.fn(() => ({ eq: statusEq }));
+    const parishEq = vi.fn(() => ({ eq: userEq }));
+    const select = vi.fn(() => ({ eq: parishEq }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ select })),
+    } as never);
+
+    await expect(getStudentPendingRequests({
+      parishId: request.parish_id,
+      clerkUserId: request.clerk_user_id,
+    })).resolves.toEqual([
+      expect.objectContaining({ id: "request-1", parishId: request.parish_id, status: "PENDING" }),
+    ]);
+  });
+
+  it("rejects a pending join request and records an audit log", async () => {
+    const requestMaybeSingle = vi.fn(async () => ({ data: request, error: null }));
+    const requestStatusEq = vi.fn(() => ({ maybeSingle: requestMaybeSingle }));
+    const requestIdEq = vi.fn(() => ({ eq: requestStatusEq }));
+    const requestSelect = vi.fn(() => ({ eq: requestIdEq }));
+
+    const updateMaybeSingle = vi.fn(async () => ({ data: { id: "request-1" }, error: null }));
+    const updateSelect = vi.fn(() => ({ maybeSingle: updateMaybeSingle }));
+    const updateStatusEq = vi.fn(() => ({ select: updateSelect }));
+    const updateIdEq = vi.fn(() => ({ eq: updateStatusEq }));
+    const update = vi.fn(() => ({ eq: updateIdEq }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn(() => ({ select: requestSelect, update })),
+    } as never);
+
+    await rejectJoinRequest({ requestId: "request-1", actorClerkUserId: "admin-1" });
+
+    expect(update).toHaveBeenCalledWith({ status: "REJECTED" });
+    expect(recordAdminAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "parish.join_request_rejected",
+        resourceId: "request-1",
+      }),
+    );
+  });
+});

--- a/src/lib/repositories/course-join-requests.ts
+++ b/src/lib/repositories/course-join-requests.ts
@@ -191,6 +191,11 @@ export async function approveJoinRequest({
   if (requestError || !request) {
     throw new Error("Request not found or not pending");
   }
+  const pendingRequest = request as {
+    parish_id: string;
+    clerk_user_id: string;
+    course_id: string;
+  };
 
   // Mark request as approved first (only if still PENDING) — guard against concurrent rejection
   const { error: updateError, data: updated } = await supabase
@@ -207,16 +212,45 @@ export async function approveJoinRequest({
   }
 
   // Create enrollment (after successfully transitioning the request)
-  const { error: enrollmentError } = await supabase
-    .from("enrollments")
-    .upsert(
-      {
-        parish_id: request.parish_id,
-        clerk_user_id: request.clerk_user_id,
-        course_id: request.course_id,
-      },
-      { onConflict: "parish_id,clerk_user_id,course_id" }
-    );
+  const { data: course, error: courseError } = await supabase
+    .from("courses")
+    .select("id,scope")
+    .eq("id", pendingRequest.course_id)
+    .maybeSingle();
+
+  if (courseError) {
+    await supabase.from("course_join_requests").update({ status: "PENDING" }).eq("id", requestId);
+    throw courseError;
+  }
+
+  if (!course) {
+    await supabase.from("course_join_requests").update({ status: "PENDING" }).eq("id", requestId);
+    throw new Error("Course not found");
+  }
+
+  const enrollmentResult =
+    course.scope === "PARISH"
+      ? await supabase.rpc("create_parish_course_enrollment", {
+          p_parish_id: pendingRequest.parish_id,
+          p_course_id: pendingRequest.course_id,
+          p_clerk_user_id: pendingRequest.clerk_user_id,
+        })
+      : await supabase
+          .from("enrollments")
+          .upsert(
+            {
+              parish_id: pendingRequest.parish_id,
+              clerk_user_id: pendingRequest.clerk_user_id,
+              course_id: pendingRequest.course_id,
+            },
+            { onConflict: "parish_id,clerk_user_id,course_id" },
+          );
+
+  const rpcError =
+    course.scope === "PARISH" && enrollmentResult.data
+      ? ((enrollmentResult.data as { error?: string } | null)?.error ?? null)
+      : null;
+  const enrollmentError = enrollmentResult.error ?? (rpcError ? new Error(rpcError) : null);
 
   if (enrollmentError) {
     // Roll back the approval if enrollment creation fails
@@ -235,9 +269,9 @@ export async function approveJoinRequest({
     resourceType: "course_join_request",
     resourceId: requestId,
     details: {
-      parish_id: request.parish_id,
-      clerk_user_id: request.clerk_user_id,
-      course_id: request.course_id,
+      parish_id: pendingRequest.parish_id,
+      clerk_user_id: pendingRequest.clerk_user_id,
+      course_id: pendingRequest.course_id,
     },
   });
 }

--- a/supabase/migrations/0012_atomic_adoption_removal.sql
+++ b/supabase/migrations/0012_atomic_adoption_removal.sql
@@ -46,6 +46,7 @@ begin
     'ok', true,
     'enrollment', jsonb_build_object(
       'id', v_enrollment.id,
+      'parish_id', v_enrollment.parish_id,
       'clerk_user_id', v_enrollment.clerk_user_id,
       'course_id', v_enrollment.course_id,
       'cohort_id', v_enrollment.cohort_id,


### PR DESCRIPTION
## Summary
- Clear the final open bug findings from the bug sweep
- Serialize parish course adoption removal against all parish-scoped enrollment creation paths
- Route join-request approvals through the same atomic enrollment RPC for parish courses
- Add regression coverage for filtered admin-user limits and join-request approval paths

## Clawpatch
- Revalidated fixed: fnd_sig-feat-route-62e8a430f8-f5496f_8c3724a063
- Revalidated fixed: fnd_sig-feat-library-161e732a5a-b118_621959b34f
- Revalidated fixed: fnd_sig-feat-library-e84101b4a6-681f_0b847a18d7
- Revalidated fixed: fnd_sig-feat-route-876c73db2d-3af1a9_df6c4d1f36

## Validation
- scripts/crabbox-validate.sh ci
- 86 test files, 421 tests passed
- lint/typecheck passed; lint has existing warnings
- Clawpatch open bug findings: 0
- Clawpatch open concurrency findings: 0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes enrollment and join-approval data paths and concurrency behavior for parish courses; mitigated by existing advisory locks and rollback on failure.
> 
> **Overview**
> Parish-scoped enrollments now go through the locked **`create_parish_course_enrollment`** RPC instead of a bare `enrollments` upsert, so creation lines up with adoption removal and adoption checks. **Diocese admin enrollment POST** returns an existing row without re-upserting or re-sending confirmation; new rows branch on `courses.scope` (RPC vs upsert). **Join-request approval** uses the same RPC for `PARISH` courses, rolls the request back to `PENDING` on course lookup or enrollment failures, and keeps direct upserts for other scopes.
> 
> The RPC’s enrollment JSON now includes **`parish_id`**. Tests cover parish vs diocese enrollment paths, join-request approval/rollback, and that **`dioceseAdmin=no`** filtering runs before `limit` on admin user listing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0f055d90ae6e774dcdc2bd2383e1734821c994f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->