### PR TITLE
fix: upload and document security hardening

### DIFF
--- a/src/app/api/admin/uploads/documents/__tests__/route.test.ts
+++ b/src/app/api/admin/uploads/documents/__tests__/route.test.ts
@@ -32,9 +32,9 @@ describe("POST /api/admin/uploads/documents", () => {
     });
 
     const file = {
-      arrayBuffer: vi.fn().mockResolvedValue(new TextEncoder().encode("pdf").buffer),
+      arrayBuffer: vi.fn().mockResolvedValue(new TextEncoder().encode("%PDF-1.7").buffer),
       name: "reading.pdf",
-      size: 3,
+      size: 8,
       type: "application/pdf",
     };
 
@@ -67,6 +67,24 @@ describe("POST /api/admin/uploads/documents", () => {
     await expect(response.json()).resolves.toEqual({
       error: "Only PDF uploads are supported.",
     });
+    expect(uploadDocumentToR2).not.toHaveBeenCalled();
+  });
+
+  it("rejects files with pdf metadata but non-pdf bytes", async () => {
+    const file = {
+      arrayBuffer: vi.fn().mockResolvedValue(new TextEncoder().encode("not a pdf").buffer),
+      name: "payload.pdf",
+      size: 9,
+      type: "application/pdf",
+    };
+
+    const response = await POST(buildRequest(file));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "Only PDF uploads are supported.",
+    });
+    expect(uploadDocumentToR2).not.toHaveBeenCalled();
   });
 
   it("rejects oversized uploads", async () => {

--- a/src/app/api/admin/uploads/documents/__tests__/route.test.ts
+++ b/src/app/api/admin/uploads/documents/__tests__/route.test.ts
@@ -17,8 +17,17 @@ describe("POST /api/admin/uploads/documents", () => {
     vi.mocked(getDocumentUploadMaxBytes).mockReturnValue(5 * 1024 * 1024);
   });
 
-  function buildRequest(file: { arrayBuffer: () => Promise<ArrayBuffer>; name: string; size: number; type: string } | string | null) {
+  function buildRequest(
+    file: { arrayBuffer: () => Promise<ArrayBuffer>; name: string; size: number; type: string } | string | null,
+    headers?: Headers,
+  ) {
+    const requestHeaders = headers ?? new Headers();
+    if (!headers && typeof file === "object" && file !== null) {
+      requestHeaders.set("content-length", String(file.size));
+    }
+
     return {
+      headers: requestHeaders,
       formData: vi.fn().mockResolvedValue({
         get: vi.fn((key: string) => (key === "file" ? file : null)),
       }),
@@ -103,5 +112,47 @@ describe("POST /api/admin/uploads/documents", () => {
     await expect(response.json()).resolves.toEqual({
       error: "PDF exceeds the 1 MB upload limit.",
     });
+  });
+
+  it("rejects oversized content-length before parsing multipart form data", async () => {
+    vi.mocked(getDocumentUploadMaxBytes).mockReturnValue(3);
+
+    const file = {
+      arrayBuffer: vi.fn().mockResolvedValue(new TextEncoder().encode("%PDF-large").buffer),
+      name: "reading.pdf",
+      size: 9,
+      type: "application/pdf",
+    };
+    const request = buildRequest(file, new Headers({ "content-length": String(1024 * 1024 + 4) }));
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "PDF exceeds the 1 MB upload limit.",
+    });
+    expect(request.formData).not.toHaveBeenCalled();
+    expect(file.arrayBuffer).not.toHaveBeenCalled();
+    expect(uploadDocumentToR2).not.toHaveBeenCalled();
+  });
+
+  it("rejects requests without a valid content-length before parsing multipart form data", async () => {
+    const file = {
+      arrayBuffer: vi.fn().mockResolvedValue(new TextEncoder().encode("%PDF-1.7").buffer),
+      name: "reading.pdf",
+      size: 8,
+      type: "application/pdf",
+    };
+    const request = buildRequest(file, new Headers());
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(411);
+    await expect(response.json()).resolves.toEqual({
+      error: "Content-Length header is required.",
+    });
+    expect(request.formData).not.toHaveBeenCalled();
+    expect(file.arrayBuffer).not.toHaveBeenCalled();
+    expect(uploadDocumentToR2).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/admin/uploads/documents/route.ts
+++ b/src/app/api/admin/uploads/documents/route.ts
@@ -29,6 +29,10 @@ function isPdfFile(file: UploadFile) {
   return file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf");
 }
 
+function hasPdfHeader(body: Buffer) {
+  return body.subarray(0, 5).equals(Buffer.from("%PDF-"));
+}
+
 export async function POST(req: Request) {
   await requireDioceseAdmin();
 
@@ -57,8 +61,14 @@ export async function POST(req: Request) {
   }
 
   try {
+    const body = Buffer.from(await entry.arrayBuffer());
+
+    if (!hasPdfHeader(body)) {
+      return NextResponse.json({ error: "Only PDF uploads are supported." }, { status: 400 });
+    }
+
     const uploaded = await uploadDocumentToR2({
-      body: Buffer.from(await entry.arrayBuffer()),
+      body,
       contentType: "application/pdf",
       fileName: entry.name,
     });

--- a/src/app/api/admin/uploads/documents/route.ts
+++ b/src/app/api/admin/uploads/documents/route.ts
@@ -7,6 +7,8 @@ import { getDocumentUploadMaxBytes, uploadDocumentToR2 } from "@/lib/r2";
 
 export const runtime = "nodejs";
 
+const MULTIPART_OVERHEAD_ALLOWANCE_BYTES = 1024 * 1024;
+
 type UploadFile = FormDataEntryValue & {
   arrayBuffer: () => Promise<ArrayBuffer>;
   name: string;
@@ -33,8 +35,35 @@ function hasPdfHeader(body: Buffer) {
   return body.subarray(0, 5).equals(Buffer.from("%PDF-"));
 }
 
+function getRequestContentLength(req: Request) {
+  const rawValue = req.headers.get("content-length");
+  if (!rawValue) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function uploadLimitError(maxBytes: number) {
+  const maxMegabytes = Math.max(1, Math.ceil(maxBytes / (1024 * 1024)));
+  return NextResponse.json(
+    { error: `PDF exceeds the ${maxMegabytes} MB upload limit.` },
+    { status: 400 },
+  );
+}
+
 export async function POST(req: Request) {
   await requireDioceseAdmin();
+
+  const maxBytes = getDocumentUploadMaxBytes();
+  const contentLength = getRequestContentLength(req);
+  if (contentLength === null) {
+    return NextResponse.json({ error: "Content-Length header is required." }, { status: 411 });
+  }
+  if (contentLength > maxBytes + MULTIPART_OVERHEAD_ALLOWANCE_BYTES) {
+    return uploadLimitError(maxBytes);
+  }
 
   const formData = await req.formData();
   const entry = formData.get("file");
@@ -51,13 +80,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Uploaded PDF is empty." }, { status: 400 });
   }
 
-  const maxBytes = getDocumentUploadMaxBytes();
   if (entry.size > maxBytes) {
-    const maxMegabytes = Math.max(1, Math.ceil(maxBytes / (1024 * 1024)));
-    return NextResponse.json(
-      { error: `PDF exceeds the ${maxMegabytes} MB upload limit.` },
-      { status: 400 },
-    );
+    return uploadLimitError(maxBytes);
   }
 
   try {

--- a/src/app/api/admin/uploads/images/__tests__/route.test.ts
+++ b/src/app/api/admin/uploads/images/__tests__/route.test.ts
@@ -50,6 +50,11 @@ describe("POST /api/admin/uploads/images", () => {
       assetUrl: "https://cdn.example.com/module-thumbnails/key.jpg",
     });
     expect(buildImageObjectKey).toHaveBeenCalledWith("module", "thumb.jpg", "image/jpeg");
+    expect(createPresignedImageUpload).toHaveBeenCalledWith({
+      key: "module-thumbnails/key.jpg",
+      contentType: "image/jpeg",
+      contentLengthBytes: 12345,
+    });
   });
 
   it("returns 400 for unsupported content type", async () => {

--- a/src/app/api/admin/uploads/images/route.ts
+++ b/src/app/api/admin/uploads/images/route.ts
@@ -63,6 +63,7 @@ export async function POST(req: Request) {
     const upload = await createPresignedImageUpload({
       key: objectKey,
       contentType: normalizedContentType,
+      contentLengthBytes: payload.size,
     });
 
     return NextResponse.json(upload, { status: 201 });

--- a/src/app/app/lessons/[lessonId]/__tests__/page.test.tsx
+++ b/src/app/app/lessons/[lessonId]/__tests__/page.test.tsx
@@ -115,7 +115,10 @@ describe("LessonPage", () => {
 
     expect(screen.getByRole("heading", { name: "Reading lesson" })).toBeInTheDocument();
     expect(screen.getByText("Document review: Pages 2-4")).toBeInTheDocument();
-    expect(screen.getByTitle("Reading lesson document")).toHaveAttribute("src", "/docs/reading.pdf#page=2");
+    const documentFrame = screen.getByTitle("Reading lesson document");
+    expect(documentFrame).toHaveAttribute("src", "/docs/reading.pdf#page=2");
+    expect(documentFrame).toHaveAttribute("sandbox", "allow-downloads");
+    expect(documentFrame).toHaveAttribute("referrerpolicy", "no-referrer");
     expect(screen.getByText("Quiz questions: 1")).toBeInTheDocument();
   });
 

--- a/src/app/app/lessons/[lessonId]/page.tsx
+++ b/src/app/app/lessons/[lessonId]/page.tsx
@@ -139,6 +139,8 @@ export default async function LessonPage({
             <div className="mx-8 mt-6">
               <iframe
                 className="h-[720px] w-full rounded-lg border border-border"
+                referrerPolicy="no-referrer"
+                sandbox="allow-downloads"
                 src={documentViewerUrl}
                 title={`${lesson.title} document`}
               />

--- a/src/lib/storage/__tests__/r2.test.ts
+++ b/src/lib/storage/__tests__/r2.test.ts
@@ -41,6 +41,7 @@ describe("createPresignedImageUpload", () => {
       createPresignedImageUpload({
         key: "course-thumbnails/key.html",
         contentType: "text/html",
+        contentLengthBytes: 500,
       }),
     ).rejects.toThrow("Unsupported image content type: text/html");
 
@@ -53,6 +54,7 @@ describe("createPresignedImageUpload", () => {
       createPresignedImageUpload({
         key: "course-thumbnails/key.jpg",
         contentType: "image/jpeg",
+        contentLengthBytes: 12345,
       }),
     ).resolves.toEqual({
       uploadUrl: "https://upload.example.com",
@@ -65,6 +67,7 @@ describe("createPresignedImageUpload", () => {
       Bucket: "bucket",
       Key: "course-thumbnails/key.jpg",
       ContentType: "image/jpeg",
+      ContentLength: 12345,
     });
     expect(getSignedUrl).toHaveBeenCalledWith(
       expect.anything(),
@@ -73,9 +76,23 @@ describe("createPresignedImageUpload", () => {
           Bucket: "bucket",
           Key: "course-thumbnails/key.jpg",
           ContentType: "image/jpeg",
+          ContentLength: 12345,
         },
       },
       { expiresIn: 300 },
     );
+  });
+
+  it("rejects invalid upload content lengths before presigning", async () => {
+    await expect(
+      createPresignedImageUpload({
+        key: "course-thumbnails/key.jpg",
+        contentType: "image/jpeg",
+        contentLengthBytes: 0,
+      }),
+    ).rejects.toThrow("Image upload content length must be a positive integer.");
+
+    expect(getSignedUrl).not.toHaveBeenCalled();
+    expect(s3ClientMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/storage/__tests__/r2.test.ts
+++ b/src/lib/storage/__tests__/r2.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getSignedUrlMock, s3ClientMock, putObjectCommandMock } = vi.hoisted(() => ({
+  getSignedUrlMock: vi.fn(),
+  putObjectCommandMock: vi.fn(function PutObjectCommand(input: unknown) {
+    return { input };
+  }),
+  s3ClientMock: vi.fn(function S3Client(config: unknown) {
+    return { config };
+  }),
+}));
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  DeleteObjectCommand: vi.fn(),
+  PutObjectCommand: putObjectCommandMock,
+  S3Client: s3ClientMock,
+}));
+
+vi.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: getSignedUrlMock,
+}));
+
+import { createPresignedImageUpload } from "@/lib/storage/r2";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+describe("createPresignedImageUpload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.R2_ACCOUNT_ID = "account";
+    process.env.R2_ACCESS_KEY_ID = "access-key";
+    process.env.R2_SECRET_ACCESS_KEY = "secret-key";
+    process.env.R2_BUCKET = "bucket";
+    process.env.R2_PUBLIC_BASE_URL = "https://cdn.example.com";
+    delete process.env.R2_ENDPOINT;
+    delete process.env.R2_REGION;
+    getSignedUrlMock.mockResolvedValue("https://upload.example.com");
+  });
+
+  it("rejects unsupported image content types before presigning", async () => {
+    await expect(
+      createPresignedImageUpload({
+        key: "course-thumbnails/key.html",
+        contentType: "text/html",
+      }),
+    ).rejects.toThrow("Unsupported image content type: text/html");
+
+    expect(getSignedUrl).not.toHaveBeenCalled();
+    expect(s3ClientMock).not.toHaveBeenCalled();
+  });
+
+  it("presigns allowed image content types", async () => {
+    await expect(
+      createPresignedImageUpload({
+        key: "course-thumbnails/key.jpg",
+        contentType: "image/jpeg",
+      }),
+    ).resolves.toEqual({
+      uploadUrl: "https://upload.example.com",
+      expiresInSeconds: 300,
+      objectKey: "course-thumbnails/key.jpg",
+      assetUrl: "https://cdn.example.com/course-thumbnails/key.jpg",
+    });
+
+    expect(putObjectCommandMock).toHaveBeenCalledWith({
+      Bucket: "bucket",
+      Key: "course-thumbnails/key.jpg",
+      ContentType: "image/jpeg",
+    });
+    expect(getSignedUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        input: {
+          Bucket: "bucket",
+          Key: "course-thumbnails/key.jpg",
+          ContentType: "image/jpeg",
+        },
+      },
+      { expiresIn: 300 },
+    );
+  });
+});

--- a/src/lib/storage/r2.ts
+++ b/src/lib/storage/r2.ts
@@ -120,10 +120,14 @@ export function getPublicObjectUrl(key: string) {
 export async function createPresignedImageUpload(params: {
   key: string;
   contentType: string;
+  contentLengthBytes: number;
   expiresInSeconds?: number;
 }) {
   if (!isAllowedImageContentType(params.contentType)) {
     throw new Error(`Unsupported image content type: ${params.contentType}`);
+  }
+  if (!Number.isSafeInteger(params.contentLengthBytes) || params.contentLengthBytes <= 0) {
+    throw new Error("Image upload content length must be a positive integer.");
   }
 
   const config = getConfig();
@@ -136,6 +140,7 @@ export async function createPresignedImageUpload(params: {
       Bucket: config.bucket,
       Key: params.key,
       ContentType: params.contentType,
+      ContentLength: params.contentLengthBytes,
     }),
     { expiresIn: expiresInSeconds },
   );

--- a/src/lib/storage/r2.ts
+++ b/src/lib/storage/r2.ts
@@ -122,6 +122,10 @@ export async function createPresignedImageUpload(params: {
   contentType: string;
   expiresInSeconds?: number;
 }) {
+  if (!isAllowedImageContentType(params.contentType)) {
+    throw new Error(`Unsupported image content type: ${params.contentType}`);
+  }
+
   const config = getConfig();
   const client = getClient();
   const expiresInSeconds = params.expiresInSeconds ?? DEFAULT_UPLOAD_EXPIRATION_SECONDS;


### PR DESCRIPTION
## Summary
- validate presigned image upload content types before signing
- bind presigned image uploads to the declared content length
- validate uploaded PDFs by file header bytes, not filename or MIME alone
- reject missing/oversized document upload Content-Length before multipart parsing
- sandbox lesson document iframes and suppress referrers

## Clawpatch findings fixed
- fnd_sig-feat-library-6f13c34fa6-ff01_91acd6a850
- fnd_sig-feat-route-68b3066998-99e58b_ad4be2e278
- fnd_sig-feat-library-0c70e325ec-83d2_2c76414ae9
- fnd_sig-feat-library-dc343e2862-3649_89ec2bf5eb
- fnd_sig-feat-route-4c098225de-aeed51_71cb0de665
- fnd_sig-feat-library-dc343e2862-a7d0_08f3eb8848
- fnd_sig-feat-route-4c098225de-39057b_6175684adc
- fnd_sig-feat-route-25552e64ff-72dc50_edfa2e18fd

## Validation
- all 8 targeted findings revalidated fixed
- `scripts/crabbox-validate.sh ci`
- 93 test files passed, 448 tests passed
- lint/typecheck passed
- coverage thresholds passed

Note: lint still reports existing warnings unrelated to this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication-gated upload routes and object-store presigning; behavior is defensive but clients must send Content-Length for PDF uploads and matching sizes for presigned PUTs.
> 
> **Overview**
> Tightens **admin upload** and **lesson document** handling against spoofed or oversized payloads and risky embedded content.
> 
> **PDF uploads** now require a valid `Content-Length`, reject bodies over the limit (plus multipart overhead) *before* `formData()` runs, and verify the `%PDF-` header after read—not only MIME/extension. Missing `Content-Length` returns **411**.
> 
> **Presigned image uploads** bind the signed `PutObject` to declared `ContentLength` and reject disallowed types or non-positive lengths before presigning; the images API passes `contentLengthBytes` from the client payload.
> 
> **Lesson document iframes** use `sandbox="allow-downloads"` and `referrerPolicy="no-referrer"`, with tests updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56b8c6b8cfed6f4bf5758dc05e5a8a5e90e61f05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->