### PR TITLE
fix: close security and data-loss findings

### DIFF
--- a/src/app/api/quiz-attempt/__tests__/route.test.ts
+++ b/src/app/api/quiz-attempt/__tests__/route.test.ts
@@ -133,6 +133,41 @@ describe("POST /api/quiz-attempt", () => {
     await expect(response.json()).resolves.toEqual({ error: "Could not fetch questions" });
   });
 
+  it("does not expose raw database errors when saving attempts fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const insert = vi.fn(async () => fail("duplicate key value violates unique constraint quiz_attempts_pkey"));
+    const order = vi.fn(async () => ok([{ correct_option_index: 1 }]));
+    const eq = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ eq }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({
+      from: vi.fn((table: string) => {
+        if (table === "questions") return { select };
+        if (table === "quiz_attempts") return { insert };
+        throw new Error(`Unexpected table ${table}`);
+      }),
+    } as never);
+
+    const response = await POST(
+      new Request("http://localhost/api/quiz-attempt", {
+        method: "POST",
+        body: JSON.stringify({
+          lessonId: "22222222-2222-4222-8222-222222222222",
+          parishId: "11111111-1111-4111-8111-111111111111",
+          answers: [1],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Could not save quiz attempt" });
+    expect(consoleError).toHaveBeenCalledWith(
+      "[quiz-attempt] failed to insert quiz attempt:",
+      expect.objectContaining({ message: "duplicate key value violates unique constraint quiz_attempts_pkey" }),
+    );
+    consoleError.mockRestore();
+  });
+
   it("returns 403 when learner is not enrolled in the lesson course", async () => {
     vi.mocked(isUserEnrolledForLesson).mockResolvedValue(false);
     vi.mocked(getSupabaseAdminClient).mockReturnValue({ from: vi.fn() } as never);

--- a/src/app/api/quiz-attempt/route.ts
+++ b/src/app/api/quiz-attempt/route.ts
@@ -79,7 +79,8 @@ export async function POST(req: Request) {
   });
 
   if (error) {
-    return NextResponse.json({ error: error.message }, { status: 400 });
+    console.error("[quiz-attempt] failed to insert quiz attempt:", error);
+    return NextResponse.json({ error: "Could not save quiz attempt" }, { status: 400 });
   }
 
   // Check for course completion and issue certificate if all lessons done

--- a/src/app/app/__tests__/layout.test.tsx
+++ b/src/app/app/__tests__/layout.test.tsx
@@ -25,6 +25,10 @@ vi.mock("@/lib/authz", () => ({
   requireAuth: vi.fn(),
 }));
 
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseAdminClient: vi.fn(),
+}));
+
 import AppLayout from "@/app/app/layout";
 import { AppHeaderClient } from "@/components/app-header-client";
 import { getActiveParishRole, isDioceseAdmin, requireAuth } from "@/lib/authz";

--- a/src/components/providers/__tests__/auth-provider.test.tsx
+++ b/src/components/providers/__tests__/auth-provider.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@clerk/nextjs", () => ({
+  ClerkProvider: ({ children, publishableKey }: { children: React.ReactNode; publishableKey: string }) => (
+    <div data-publishable-key={publishableKey} data-testid="clerk-provider">
+      {children}
+    </div>
+  ),
+}));
+
+import { AuthProvider } from "@/components/providers/auth-provider";
+
+describe("AuthProvider", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("wraps children with ClerkProvider when configured", () => {
+    vi.stubEnv("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "pk_test_123");
+
+    render(
+      <AuthProvider>
+        <span>Protected app</span>
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId("clerk-provider")).toHaveAttribute("data-publishable-key", "pk_test_123");
+    expect(screen.getByText("Protected app")).toBeInTheDocument();
+  });
+
+  it("fails closed when the Clerk publishable key is missing", () => {
+    vi.stubEnv("NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", "");
+
+    expect(() =>
+      render(
+        <AuthProvider>
+          <span>Protected app</span>
+        </AuthProvider>,
+      ),
+    ).toThrow("Missing NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY");
+  });
+});

--- a/src/components/providers/auth-provider.tsx
+++ b/src/components/providers/auth-provider.tsx
@@ -4,7 +4,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const publishableKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
 
   if (!publishableKey) {
-    return <>{children}</>;
+    throw new Error("Missing NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY");
   }
 
   return <ClerkProvider publishableKey={publishableKey}>{children}</ClerkProvider>;

--- a/src/lib/__tests__/csv.test.ts
+++ b/src/lib/__tests__/csv.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { csvValue } from "@/lib/csv";
+
+describe("csvValue", () => {
+  it("quotes and escapes ordinary cells", () => {
+    expect(csvValue('St. "A"')).toBe('"St. ""A"""');
+  });
+
+  it.each(["=", "+", "-", "@", "\t", "\r", "\n"])("neutralizes spreadsheet formula prefix %s", (prefix) => {
+    expect(csvValue(`${prefix}danger`)).toBe(`"'${prefix}danger"`);
+  });
+});

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -1,5 +1,5 @@
 export function csvValue(value: string | number | null | undefined) {
   const text = String(value ?? "");
-  const safeText = /^[=+\-@\t\r]/.test(text) ? `'${text}` : text;
+  const safeText = /^[=+\-@\t\r\n]/.test(text) ? `'${text}` : text;
   return `"${safeText.replaceAll('"', '""')}"`;
 }

--- a/src/lib/supabase/__tests__/server-only.test.ts
+++ b/src/lib/supabase/__tests__/server-only.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+describe("Supabase server helpers", () => {
+  it("marks the admin client module as server-only", () => {
+    const source = readFileSync(join(process.cwd(), "src/lib/supabase/server.ts"), "utf8");
+
+    expect(source).toMatch(/^import "server-only";/);
+  });
+});

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,3 +1,5 @@
+import "server-only";
+
 import { createClient, SupabaseClient } from "@supabase/supabase-js";
 
 type GenericTable = {


### PR DESCRIPTION
## Summary
- fail closed when the Clerk publishable key is missing
- guard the Supabase admin client module with `server-only`
- return a generic client-safe quiz attempt persistence error while logging server detail
- neutralize CSV formula prefixes, including newline-prefixed cells
- keep the existing quiz option-index data-loss fix covered and revalidated
- update layout tests to mock the server-only Supabase module in Vitest

## Clawpatch findings fixed
- fnd_sig-feat-library-856e541ac3-1dbb_27dfd75a78
- fnd_sig-feat-library-cb6d1a7274-d92c_338daacdae
- fnd_sig-feat-library-fd97feb5a0-80a3_30e6ba755b
- fnd_sig-feat-route-3d7f4f726d-2b0942_cad7d39a40
- fnd_sig-feat-route-a6a1e1e0e6-9a0405_25fcfa2bfa
- fnd_sig-feat-ui-flow-4173c29982-4367_e6b1baf9b2
- fnd_sig-feat-ui-flow-8746472132-cf7e_a57dba1eee

## Result
- open security findings: 6 -> 0
- open data-loss findings: 1 -> 0
- total open clawpatch findings: 65 -> 58

## Validation
- all 7 targeted findings revalidated fixed
- focused local Vitest run for touched suites: 7 files, 29 tests passed
- `scripts/crabbox-validate.sh typecheck`
- `scripts/crabbox-validate.sh ci`
- 96 test files passed, 460 tests passed
- lint/typecheck/coverage passed

Note: lint still reports existing warnings unrelated to this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches root auth wiring and quiz persistence error handling; behavior is stricter (app won't boot without Clerk key) but reduces information disclosure and client exposure of server credentials.
> 
> **Overview**
> Hardens several security-sensitive paths and adds regression tests.
> 
> **Auth:** `AuthProvider` now **throws** if `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is missing instead of rendering children without Clerk—misconfigured deploys fail closed at the root layout.
> 
> **Quiz API:** Failed `quiz_attempts` inserts return a generic **"Could not save quiz attempt"** message; raw Supabase/DB text is logged server-side only.
> 
> **Supabase admin:** `src/lib/supabase/server.ts` imports **`server-only`** so the service-role client cannot be bundled into client code; app layout tests mock this module for Vitest.
> 
> **CSV export:** `csvValue` also neutralizes cells starting with **newline** (`\n`), alongside existing formula-prefix guards; dedicated tests cover quoting and prefixes.
> 
> **Tests:** New coverage for auth provider behavior, CSV safety, quiz-attempt error sanitization, and the server-only import assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f77f74ffd724c033d25e5d928b2b30b5c1d5fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->