### PR TITLE
fix: address high and medium review comments

### DIFF
--- a/src/app/api/admin/enrollments/__tests__/route.test.ts
+++ b/src/app/api/admin/enrollments/__tests__/route.test.ts
@@ -75,7 +75,7 @@ describe("/api/admin/enrollments", () => {
     });
   });
 
-  it("does not send enrollment confirmation for existing enrollments", async () => {
+  it("returns 200 without sending enrollment confirmation for existing enrollments", async () => {
     const existingEnrollment = {
       id: "e1",
       parish_id: "11111111-1111-4111-8111-111111111111",
@@ -112,7 +112,7 @@ describe("/api/admin/enrollments", () => {
       }),
     );
 
-    expect(response.status).toBe(201);
+    expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ enrollment: existingEnrollment });
     expect(upsert).not.toHaveBeenCalled();
     expect(rpc).not.toHaveBeenCalled();

--- a/src/app/api/admin/enrollments/route.ts
+++ b/src/app/api/admin/enrollments/route.ts
@@ -83,6 +83,7 @@ export async function POST(req: Request) {
   }
 
   let data = existingEnrollmentQuery.data as EnrollmentRow | null;
+  const created = !data;
 
   if (!data) {
     const { data: course, error: courseError } = await supabase
@@ -154,7 +155,7 @@ export async function POST(req: Request) {
     }).catch((err) => console.error("[notifications] diocese enrollment confirmed email failed:", err));
   }
 
-  return NextResponse.json({ enrollment: data }, { status: 201 });
+  return NextResponse.json({ enrollment: data }, { status: created ? 201 : 200 });
 }
 
 export async function DELETE(req: Request) {

--- a/src/app/api/certificates/[certId]/pdf/__tests__/route.test.tsx
+++ b/src/app/api/certificates/[certId]/pdf/__tests__/route.test.tsx
@@ -46,7 +46,7 @@ function certificateQuery() {
   return {
     select: vi.fn(() => ({
       eq: vi.fn(() => ({
-        single: vi.fn(async () => ({ data: cert, error: null })),
+        maybeSingle: vi.fn(async () => ({ data: cert, error: null })),
       })),
     })),
   };
@@ -65,7 +65,7 @@ describe("GET /api/certificates/:certId/pdf", () => {
         return {
           select: vi.fn(() => ({
             eq: vi.fn(() => ({
-              single: vi.fn(async () => ({ data: null, error: { message: "db down" } })),
+              maybeSingle: vi.fn(async () => ({ data: null, error: { message: "db down" } })),
             })),
           })),
         };
@@ -81,6 +81,32 @@ describe("GET /api/certificates/:certId/pdf", () => {
 
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({ error: "Could not load certificate" });
+    expect(getCertificatePdfData).not.toHaveBeenCalled();
+    expect(renderToBuffer).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 without rendering when the certificate does not exist", async () => {
+    const from = vi.fn((table: string) => {
+      if (table === "certificates") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              maybeSingle: vi.fn(async () => ({ data: null, error: null })),
+            })),
+          })),
+        };
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from } as never);
+
+    const response = await GET(new Request("http://localhost/api/certificates/missing/pdf"), {
+      params: Promise.resolve({ certId: "missing" }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({ error: "Certificate not found" });
     expect(getCertificatePdfData).not.toHaveBeenCalled();
     expect(renderToBuffer).not.toHaveBeenCalled();
   });

--- a/src/app/api/certificates/[certId]/pdf/route.tsx
+++ b/src/app/api/certificates/[certId]/pdf/route.tsx
@@ -19,7 +19,7 @@ export async function GET(
     .from("certificates")
     .select("id, clerk_user_id, course_id, issued_at")
     .eq("id", certId)
-    .single();
+    .maybeSingle();
 
   if (certError) {
     return NextResponse.json({ error: "Could not load certificate" }, { status: 500 });

--- a/src/app/app/lessons/[lessonId]/__tests__/page.test.tsx
+++ b/src/app/app/lessons/[lessonId]/__tests__/page.test.tsx
@@ -117,7 +117,7 @@ describe("LessonPage", () => {
     expect(screen.getByText("Document review: Pages 2-4")).toBeInTheDocument();
     const documentFrame = screen.getByTitle("Reading lesson document");
     expect(documentFrame).toHaveAttribute("src", "/docs/reading.pdf#page=2");
-    expect(documentFrame).toHaveAttribute("sandbox", "allow-downloads");
+    expect(documentFrame).toHaveAttribute("sandbox", "allow-downloads allow-scripts allow-same-origin");
     expect(documentFrame).toHaveAttribute("referrerpolicy", "no-referrer");
     expect(screen.getByText("Quiz questions: 1")).toBeInTheDocument();
   });

--- a/src/app/app/lessons/[lessonId]/page.tsx
+++ b/src/app/app/lessons/[lessonId]/page.tsx
@@ -140,7 +140,7 @@ export default async function LessonPage({
               <iframe
                 className="h-[720px] w-full rounded-lg border border-border"
                 referrerPolicy="no-referrer"
-                sandbox="allow-downloads"
+                sandbox="allow-downloads allow-scripts allow-same-origin"
                 src={documentViewerUrl}
                 title={`${lesson.title} document`}
               />


### PR DESCRIPTION
## Summary
- return 200 for idempotent admin enrollment creates when enrollment already exists
- use maybeSingle for certificate PDF ownership lookup so missing certs return 404 instead of 500
- expand the lesson document iframe sandbox to keep browser PDF viewers working while preserving download support

## Review comments addressed
- PR #49 high: https://github.com/mattash/wd-learning-system/pull/49#discussion_r3326980714
- PR #41 medium: https://github.com/mattash/wd-learning-system/pull/41#discussion_r3325546333
- PR #41 medium: https://github.com/mattash/wd-learning-system/pull/41#discussion_r3325546324

## Validation
- npm run test -- src/app/api/admin/enrollments/__tests__/route.test.ts src/app/api/certificates/[certId]/pdf/__tests__/route.test.tsx src/app/app/lessons/[lessonId]/__tests__/page.test.tsx
- scripts/crabbox-validate.sh ci

Crabbox: lint/typecheck/coverage passed; 93 test files, 449 tests passed. Existing lint warnings only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enrollment status codes and certificate lookup behavior are API contract changes; the iframe sandbox relaxes isolation for document lessons (scripts + same-origin) while still omitting top navigation and most permissions.
> 
> **Overview**
> Addresses review feedback on **admin enrollments**, **certificate PDFs**, and **document lesson viewers**.
> 
> **Admin enrollments:** When a diocese admin POSTs an enrollment that already exists, the API now returns **200** with the existing row instead of **201**, and still skips upsert/RPC and confirmation email. New enrollments remain **201**.
> 
> **Certificate PDF:** Ownership lookup uses **`maybeSingle()`** instead of **`single()`**, so a missing certificate id returns **404** (`Certificate not found`) rather than being treated as a DB error (**500**). Real query failures still return **500**.
> 
> **Document lessons:** The lesson PDF **iframe** `sandbox` adds **`allow-scripts`** and **`allow-same-origin`** (keeping **`allow-downloads`**) so in-browser PDF viewers work; tests updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e589021daaea819f320200564b147cbd376c0de5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->