### PR TITLE
feat: add public course registration flow

### DIFF
--- a/src/app/app/catalog/__tests__/page.test.tsx
+++ b/src/app/app/catalog/__tests__/page.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/authz", () => ({
+  requireParishRole: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/catalog", () => ({
+  getCatalogCourses: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/course-join-requests", () => ({
+  getStudentPendingRequests: vi.fn(),
+}));
+
+vi.mock("@/components/course-join/request-join-button", () => ({
+  RequestJoinButton: ({ courseId }: { courseId: string }) => <button>Request {courseId}</button>,
+}));
+
+import CatalogPage from "@/app/app/catalog/page";
+import { requireParishRole } from "@/lib/authz";
+import { getCatalogCourses } from "@/lib/repositories/catalog";
+import { getStudentPendingRequests } from "@/lib/repositories/course-join-requests";
+
+describe("CatalogPage enrollment confirmation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireParishRole).mockResolvedValue({
+      parishId: "parish-1",
+      clerkUserId: "user-1",
+      role: "student",
+    });
+    vi.mocked(getCatalogCourses).mockResolvedValue([]);
+    vi.mocked(getStudentPendingRequests).mockResolvedValue([]);
+  });
+
+  it("shows a confirmation after onboarding submits a course request", async () => {
+    render(await CatalogPage({ searchParams: Promise.resolve({ enrollment: "requested" }) }));
+
+    expect(
+      screen.getByText("Your enrollment request has been submitted. A parish admin will review it shortly."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders enrolled, pending, and requestable catalog courses", async () => {
+    vi.mocked(getCatalogCourses).mockResolvedValue([
+      {
+        id: "course-1",
+        title: "Enrolled Course",
+        description: "Already started",
+        thumbnailUrl: "/course.png",
+        scope: "DIOCESE",
+        lessonCount: 1,
+        enrolled: true,
+      },
+      {
+        id: "course-2",
+        title: "Pending Course",
+        description: null,
+        thumbnailUrl: null,
+        scope: "PARISH",
+        lessonCount: 2,
+        enrolled: false,
+      },
+      {
+        id: "course-3",
+        title: "Available Course",
+        description: "Open to request",
+        thumbnailUrl: null,
+        scope: "DIOCESE",
+        lessonCount: 0,
+        enrolled: false,
+      },
+    ]);
+    vi.mocked(getStudentPendingRequests).mockResolvedValue([
+      {
+        id: "request-1",
+        parishId: "parish-1",
+        clerkUserId: "user-1",
+        courseId: "course-2",
+        status: "PENDING",
+        createdAt: "2026-01-01",
+        updatedAt: "2026-01-01",
+      },
+    ]);
+
+    render(await CatalogPage({ searchParams: Promise.resolve({}) }));
+
+    expect(screen.getByRole("link", { name: "Go to course" })).toHaveAttribute("href", "/app/courses/course-1");
+    expect(screen.getByText("Request sent")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Request course-3" })).toBeInTheDocument();
+  });
+
+  it("shows a search empty state when no visible course matches", async () => {
+    vi.mocked(getCatalogCourses).mockResolvedValue([
+      {
+        id: "course-1",
+        title: "Foundations",
+        description: null,
+        thumbnailUrl: null,
+        scope: "DIOCESE",
+        lessonCount: 1,
+        enrolled: false,
+      },
+    ]);
+
+    render(await CatalogPage({ searchParams: Promise.resolve({ q: "history" }) }));
+
+    expect(screen.getByText("No courses match your search.")).toBeInTheDocument();
+  });
+});

--- a/src/app/app/catalog/page.tsx
+++ b/src/app/app/catalog/page.tsx
@@ -1,7 +1,8 @@
 import Link from "next/link";
 
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Card, CardContent, CardDescription, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { requireParishRole } from "@/lib/authz";
 import { getCatalogCourses } from "@/lib/repositories/catalog";
@@ -89,6 +90,8 @@ export default async function CatalogPage({
 
   const rawQ = params.q;
   const query = Array.isArray(rawQ) ? rawQ[0] : (rawQ?.trim() ?? "");
+  const enrollmentStatus = Array.isArray(params.enrollment) ? params.enrollment[0] : params.enrollment;
+  const showEnrollmentConfirmation = enrollmentStatus === "requested";
 
   // Get pending join requests so we can show "Request sent" on course cards
   const pendingRequests = await getStudentPendingRequests({ parishId, clerkUserId });
@@ -123,6 +126,14 @@ export default async function CatalogPage({
           Browse available courses and track your enrolled ones.
         </p>
       </header>
+
+      {showEnrollmentConfirmation ? (
+        <Alert>
+          <AlertDescription>
+            Your enrollment request has been submitted. A parish admin will review it shortly.
+          </AlertDescription>
+        </Alert>
+      ) : null}
 
       {/* Search */}
       <form className="flex gap-2">

--- a/src/app/app/onboarding/__tests__/page.test.tsx
+++ b/src/app/app/onboarding/__tests__/page.test.tsx
@@ -1,0 +1,197 @@
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const cookieSet = vi.hoisted(() => vi.fn());
+const navigationMocks = vi.hoisted(() => ({
+  redirect: vi.fn((path: string) => {
+    throw new Error(`NEXT_REDIRECT:${path}`);
+  }),
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(async () => ({ set: cookieSet })),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: navigationMocks.redirect,
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  clerkClient: vi.fn(),
+}));
+
+vi.mock("@/lib/authz", () => ({
+  hasCompletedOnboarding: vi.fn(),
+  requireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/e2e-mode", () => ({
+  isE2ESmokeMode: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/course-join-requests", () => ({
+  createJoinRequest: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/server", () => ({
+  getSupabaseAdminClient: vi.fn(),
+}));
+
+import { clerkClient } from "@clerk/nextjs/server";
+
+import OnboardingPage from "@/app/app/onboarding/page";
+import { hasCompletedOnboarding, requireAuth } from "@/lib/authz";
+import { isE2ESmokeMode } from "@/lib/e2e-mode";
+import { createJoinRequest } from "@/lib/repositories/course-join-requests";
+import { getSupabaseAdminClient } from "@/lib/supabase/server";
+
+function findFormAction(node: React.ReactNode): ((formData: FormData) => Promise<void>) | null {
+  if (!React.isValidElement(node)) return null;
+  const element = node as React.ReactElement<{
+    action?: (formData: FormData) => Promise<void>;
+    children?: React.ReactNode;
+  }>;
+
+  if (element.type === "form" && typeof element.props.action === "function") {
+    return element.props.action;
+  }
+
+  for (const child of React.Children.toArray(element.props.children)) {
+    const action = findFormAction(child);
+    if (action) return action;
+  }
+
+  return null;
+}
+
+const courseId = "11111111-1111-4111-8111-111111111111";
+const parishId = "22222222-2222-4222-8222-222222222222";
+
+function mockSupabase() {
+  const profileMaybeSingle = vi.fn(async () => ({ data: { display_name: "Student One" }, error: null }));
+  const parishesOrder = vi.fn(async () => ({
+    data: [{ id: parishId, name: "St Mary", slug: "st-mary" }],
+    error: null,
+  }));
+  const parishMaybeSingle = vi.fn(async () => ({ data: { id: parishId }, error: null }));
+  const membershipUpsert = vi.fn(async () => ({ error: null }));
+  const profileUpsert = vi.fn(async () => ({ error: null }));
+
+  vi.mocked(getSupabaseAdminClient).mockReturnValue({
+    from: vi.fn((table: string) => {
+      if (table === "user_profiles") {
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({ maybeSingle: profileMaybeSingle })),
+          })),
+          upsert: profileUpsert,
+        };
+      }
+
+      if (table === "parishes") {
+        return {
+          select: vi.fn((columns: string) => {
+            if (columns === "id,name,slug") {
+              return {
+                eq: vi.fn(() => ({ order: parishesOrder })),
+              };
+            }
+
+            return {
+              eq: vi.fn(() => ({
+                eq: vi.fn(() => ({ maybeSingle: parishMaybeSingle })),
+              })),
+            };
+          }),
+        };
+      }
+
+      if (table === "parish_memberships") {
+        return { upsert: membershipUpsert };
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    }),
+  } as never);
+}
+
+describe("OnboardingPage enrollment intent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(requireAuth).mockResolvedValue("user-1");
+    vi.mocked(hasCompletedOnboarding).mockResolvedValue(false);
+    vi.mocked(isE2ESmokeMode).mockReturnValue(false);
+    vi.mocked(createJoinRequest).mockResolvedValue({
+      id: "request-1",
+      parishId,
+      clerkUserId: "user-1",
+      courseId,
+      status: "PENDING",
+      createdAt: "2026-01-01",
+      updatedAt: "2026-01-01",
+    });
+    vi.mocked(clerkClient).mockResolvedValue({
+      users: {
+        getUser: vi.fn(async () => ({
+          primaryEmailAddressId: "email-1",
+          primaryEmailAddress: { emailAddress: "student@example.com" },
+          emailAddresses: [{ id: "email-1", emailAddress: "student@example.com" }],
+        })),
+      },
+    } as never);
+    mockSupabase();
+  });
+
+  it("submits the intended course join request after onboarding succeeds", async () => {
+    const page = await OnboardingPage({ searchParams: Promise.resolve({ enrollCourseId: courseId }) });
+    const action = findFormAction(page);
+    expect(action).toBeTypeOf("function");
+
+    const formData = new FormData();
+    formData.set("displayName", "Student One");
+    formData.set("parishId", parishId);
+    formData.set("enrollCourseId", courseId);
+
+    await expect(action?.(formData)).rejects.toThrow("NEXT_REDIRECT:/app/catalog?enrollment=requested");
+    expect(createJoinRequest).toHaveBeenCalledWith({ parishId, clerkUserId: "user-1", courseId });
+  });
+
+  it("completes onboarding normally when no enrollment intent is present", async () => {
+    const page = await OnboardingPage({ searchParams: Promise.resolve({}) });
+    const action = findFormAction(page);
+    expect(action).toBeTypeOf("function");
+
+    const formData = new FormData();
+    formData.set("displayName", "Student One");
+    formData.set("parishId", parishId);
+
+    await expect(action?.(formData)).rejects.toThrow("NEXT_REDIRECT:/app");
+    expect(createJoinRequest).not.toHaveBeenCalled();
+  });
+
+  it("treats an existing pending request as successful enrollment intent", async () => {
+    vi.mocked(createJoinRequest).mockRejectedValue(new Error("A pending request already exists for this course"));
+    const page = await OnboardingPage({ searchParams: Promise.resolve({ enrollCourseId: courseId }) });
+    const action = findFormAction(page);
+
+    const formData = new FormData();
+    formData.set("displayName", "Student One");
+    formData.set("parishId", parishId);
+    formData.set("enrollCourseId", courseId);
+
+    await expect(action?.(formData)).rejects.toThrow("NEXT_REDIRECT:/app/catalog?enrollment=requested");
+  });
+
+  it("does not block onboarding when enrollment intent cannot be submitted", async () => {
+    vi.mocked(createJoinRequest).mockRejectedValue(new Error("course deleted"));
+    const page = await OnboardingPage({ searchParams: Promise.resolve({ enrollCourseId: courseId }) });
+    const action = findFormAction(page);
+
+    const formData = new FormData();
+    formData.set("displayName", "Student One");
+    formData.set("parishId", parishId);
+    formData.set("enrollCourseId", courseId);
+
+    await expect(action?.(formData)).rejects.toThrow("NEXT_REDIRECT:/app");
+  });
+});

--- a/src/app/app/onboarding/page.tsx
+++ b/src/app/app/onboarding/page.tsx
@@ -11,24 +11,28 @@ import { Select } from "@/components/ui/select";
 import { E2E_PARISHES } from "@/lib/e2e-fixtures";
 import { hasCompletedOnboarding, requireAuth } from "@/lib/authz";
 import { isE2ESmokeMode } from "@/lib/e2e-mode";
+import { createJoinRequest } from "@/lib/repositories/course-join-requests";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 
 const schema = z.object({
   displayName: z.string().trim().min(1).max(120),
   parishId: z.string().uuid(),
+  enrollCourseId: z.string().uuid().optional(),
 });
 
 async function completeOnboarding(formData: FormData) {
   "use server";
   const userId = await requireAuth();
+  const enrollCourseId = String(formData.get("enrollCourseId") ?? "");
 
   const parsed = schema.safeParse({
     displayName: String(formData.get("displayName") ?? ""),
     parishId: String(formData.get("parishId") ?? ""),
+    enrollCourseId: enrollCourseId || undefined,
   });
 
   if (!parsed.success) {
-    redirect("/app/onboarding?error=invalid_input");
+    redirect(buildOnboardingUrl("invalid_input", enrollCourseId));
   }
 
   const store = await cookies();
@@ -62,7 +66,7 @@ async function completeOnboarding(formData: FormData) {
     .maybeSingle();
 
   if (!parish) {
-    redirect("/app/onboarding?error=invalid_parish");
+    redirect(buildOnboardingUrl("invalid_parish", parsed.data.enrollCourseId));
   }
 
   const now = new Date().toISOString();
@@ -87,7 +91,7 @@ async function completeOnboarding(formData: FormData) {
     { onConflict: "parish_id,clerk_user_id", ignoreDuplicates: true },
   );
   if (membershipError) {
-    redirect("/app/onboarding?error=membership_save_failed");
+    redirect(buildOnboardingUrl("membership_save_failed", parsed.data.enrollCourseId));
   }
 
   const { error: profileError } = await supabase.from("user_profiles").upsert(
@@ -100,7 +104,7 @@ async function completeOnboarding(formData: FormData) {
     { onConflict: "clerk_user_id" },
   );
   if (profileError) {
-    redirect("/app/onboarding?error=profile_save_failed");
+    redirect(buildOnboardingUrl("profile_save_failed", parsed.data.enrollCourseId));
   }
 
   store.set("active_parish_id", parsed.data.parishId, {
@@ -110,13 +114,52 @@ async function completeOnboarding(formData: FormData) {
     path: "/",
   });
 
+  if (parsed.data.enrollCourseId) {
+    const joinRequestCreated = await tryCreateJoinRequest({
+      parishId: parsed.data.parishId,
+      clerkUserId: userId,
+      courseId: parsed.data.enrollCourseId,
+    });
+
+    redirect(joinRequestCreated ? "/app/catalog?enrollment=requested" : "/app");
+  }
+
   redirect("/app");
+}
+
+function buildOnboardingUrl(error: string, enrollCourseId?: string | null) {
+  const params = new URLSearchParams({ error });
+  if (enrollCourseId) params.set("enrollCourseId", enrollCourseId);
+  return `/app/onboarding?${params.toString()}`;
+}
+
+async function tryCreateJoinRequest({
+  parishId,
+  clerkUserId,
+  courseId,
+}: {
+  parishId: string;
+  clerkUserId: string;
+  courseId: string;
+}) {
+  try {
+    await createJoinRequest({ parishId, clerkUserId, courseId });
+    return true;
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err.message.includes("pending request") || err.message.includes("Already enrolled"))
+    ) {
+      return true;
+    }
+    return false;
+  }
 }
 
 export default async function OnboardingPage({
   searchParams,
 }: {
-  searchParams?: Promise<{ error?: string }>;
+  searchParams?: Promise<{ error?: string; enrollCourseId?: string }>;
 }) {
   const userId = await requireAuth();
 
@@ -140,6 +183,11 @@ export default async function OnboardingPage({
   }
 
   const params = (await searchParams) ?? {};
+  const enrollCourseId =
+    params.enrollCourseId &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(params.enrollCourseId)
+      ? params.enrollCourseId
+      : null;
   const errorText =
     params.error === "invalid_input"
       ? "Please provide a display name and parish."
@@ -157,6 +205,13 @@ export default async function OnboardingPage({
       <p className="text-sm text-muted-foreground">
         Pick your parish and set your display name to continue.
       </p>
+      {enrollCourseId ? (
+        <Alert>
+          <AlertDescription>
+            Finish your profile and we will submit your course enrollment request automatically.
+          </AlertDescription>
+        </Alert>
+      ) : null}
       {errorText ? (
         <Alert variant="destructive">
           <AlertDescription>{errorText}</AlertDescription>
@@ -170,6 +225,7 @@ export default async function OnboardingPage({
       <Card>
         <CardContent className="pt-4">
           <form action={completeOnboarding} className="grid gap-3">
+            {enrollCourseId ? <input name="enrollCourseId" type="hidden" value={enrollCourseId} /> : null}
             <label className="grid gap-1 text-sm">
               Display name
               <Input

--- a/src/app/courses/[courseId]/__tests__/page.test.tsx
+++ b/src/app/courses/[courseId]/__tests__/page.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const navigationMocks = vi.hoisted(() => ({
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+  redirect: vi.fn((path: string) => {
+    throw new Error(`NEXT_REDIRECT:${path}`);
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: navigationMocks.notFound,
+  redirect: navigationMocks.redirect,
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/authz", () => ({
+  hasCompletedOnboarding: vi.fn(),
+  requireActiveParish: vi.fn(),
+}));
+
+vi.mock("@/lib/repositories/courses", () => ({
+  getPublicCoursePreview: vi.fn(),
+  isUserEnrolledInCourse: vi.fn(),
+}));
+
+import { auth } from "@clerk/nextjs/server";
+
+import PublicCoursePage from "@/app/courses/[courseId]/page";
+import { hasCompletedOnboarding, requireActiveParish } from "@/lib/authz";
+import { getPublicCoursePreview, isUserEnrolledInCourse } from "@/lib/repositories/courses";
+
+const courseId = "11111111-1111-4111-8111-111111111111";
+
+describe("PublicCoursePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({ userId: null } as Awaited<ReturnType<typeof auth>>);
+    vi.mocked(getPublicCoursePreview).mockResolvedValue({
+      course: {
+        id: courseId,
+        title: "Foundations",
+        description: "Learn the basics.",
+        published: true,
+        scope: "DIOCESE",
+        thumbnailUrl: "/course.png",
+      },
+      modules: [
+        {
+          id: "module-1",
+          title: "Getting Started",
+          sort_order: 1,
+          lessons: [{ id: "lesson-1", title: "Welcome", sort_order: 1 }],
+        },
+      ],
+      lessonCount: 1,
+    });
+  });
+
+  it("renders a public preview and register CTA for anonymous visitors", async () => {
+    render(await PublicCoursePage({ params: Promise.resolve({ courseId }) }));
+
+    expect(screen.getByRole("heading", { name: "Foundations" })).toBeInTheDocument();
+    expect(screen.getByText("Learn the basics.")).toBeInTheDocument();
+    expect(screen.getByText("Getting Started")).toBeInTheDocument();
+    expect(screen.getByText("Welcome")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Register & Enroll" })).toHaveAttribute(
+      "href",
+      `/sign-up?enrollCourseId=${courseId}`,
+    );
+  });
+
+  it("renders an empty-outline preview without a thumbnail", async () => {
+    vi.mocked(getPublicCoursePreview).mockResolvedValue({
+      course: {
+        id: courseId,
+        title: "Preview Only",
+        description: null,
+        published: true,
+        scope: "PARISH",
+        thumbnailUrl: null,
+      },
+      modules: [],
+      lessonCount: 0,
+    });
+
+    render(await PublicCoursePage({ params: Promise.resolve({ courseId }) }));
+
+    expect(screen.getByRole("heading", { name: "Preview Only" })).toBeInTheDocument();
+    expect(screen.getByText("Parish course")).toBeInTheDocument();
+    expect(screen.getByText("Course outline coming soon.")).toBeInTheDocument();
+  });
+
+  it("returns 404 when the course is not public", async () => {
+    vi.mocked(getPublicCoursePreview).mockResolvedValue(null);
+
+    await expect(PublicCoursePage({ params: Promise.resolve({ courseId }) })).rejects.toThrow("NEXT_NOT_FOUND");
+    expect(navigationMocks.notFound).toHaveBeenCalled();
+  });
+
+  it("redirects an authenticated enrolled user to the course", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: "user-1" } as Awaited<ReturnType<typeof auth>>);
+    vi.mocked(hasCompletedOnboarding).mockResolvedValue(true);
+    vi.mocked(requireActiveParish).mockResolvedValue("parish-1");
+    vi.mocked(isUserEnrolledInCourse).mockResolvedValue(true);
+
+    await expect(PublicCoursePage({ params: Promise.resolve({ courseId }) })).rejects.toThrow(
+      `NEXT_REDIRECT:/app/courses/${courseId}`,
+    );
+  });
+
+  it("redirects an authenticated unenrolled user to the catalog flow", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: "user-1" } as Awaited<ReturnType<typeof auth>>);
+    vi.mocked(hasCompletedOnboarding).mockResolvedValue(true);
+    vi.mocked(requireActiveParish).mockResolvedValue("parish-1");
+    vi.mocked(isUserEnrolledInCourse).mockResolvedValue(false);
+
+    await expect(PublicCoursePage({ params: Promise.resolve({ courseId }) })).rejects.toThrow(
+      `NEXT_REDIRECT:/app/catalog?courseId=${courseId}`,
+    );
+  });
+
+  it("preserves enrollment intent for authenticated users who still need onboarding", async () => {
+    vi.mocked(auth).mockResolvedValue({ userId: "user-1" } as Awaited<ReturnType<typeof auth>>);
+    vi.mocked(hasCompletedOnboarding).mockResolvedValue(false);
+
+    await expect(PublicCoursePage({ params: Promise.resolve({ courseId }) })).rejects.toThrow(
+      `NEXT_REDIRECT:/app/onboarding?enrollCourseId=${courseId}`,
+    );
+    expect(requireActiveParish).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/courses/[courseId]/page.tsx
+++ b/src/app/courses/[courseId]/page.tsx
@@ -1,0 +1,100 @@
+import { auth } from "@clerk/nextjs/server";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { hasCompletedOnboarding, requireActiveParish } from "@/lib/authz";
+import { getPublicCoursePreview, isUserEnrolledInCourse } from "@/lib/repositories/courses";
+
+export default async function PublicCoursePage({
+  params,
+}: {
+  params: Promise<{ courseId: string }>;
+}) {
+  const { courseId } = await params;
+  const preview = await getPublicCoursePreview(courseId);
+  if (!preview) notFound();
+
+  const { userId } = await auth();
+  if (userId) {
+    if (!(await hasCompletedOnboarding(userId))) {
+      redirect(`/app/onboarding?enrollCourseId=${encodeURIComponent(courseId)}`);
+    }
+
+    const parishId = await requireActiveParish(userId);
+    const enrolled = await isUserEnrolledInCourse({ parishId, clerkUserId: userId, courseId });
+    redirect(enrolled ? `/app/courses/${courseId}` : `/app/catalog?courseId=${encodeURIComponent(courseId)}`);
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl space-y-6 px-4 py-8">
+      <header className="flex flex-col gap-4 sm:flex-row">
+        <div className="h-32 w-32 shrink-0 overflow-hidden rounded-md border bg-muted">
+          {preview.course.thumbnailUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              alt={preview.course.title}
+              className="h-full w-full object-cover"
+              src={preview.course.thumbnailUrl}
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+              Course
+            </div>
+          )}
+        </div>
+        <div className="space-y-3">
+          <div className="space-y-1">
+            <p className="text-sm font-medium text-muted-foreground">
+              {preview.course.scope === "DIOCESE" ? "Diocese-wide course" : "Parish course"}
+            </p>
+            <h1 className="text-3xl font-semibold">{preview.course.title}</h1>
+          </div>
+          {preview.course.description ? (
+            <p className="max-w-2xl text-muted-foreground">{preview.course.description}</p>
+          ) : null}
+          <p className="text-sm text-muted-foreground">
+            {preview.modules.length} module{preview.modules.length !== 1 ? "s" : ""} ·{" "}
+            {preview.lessonCount} lesson{preview.lessonCount !== 1 ? "s" : ""}
+          </p>
+          <Button asChild>
+            <Link href={`/sign-up?enrollCourseId=${encodeURIComponent(courseId)}`}>Register & Enroll</Link>
+          </Button>
+        </div>
+      </header>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Course outline</h2>
+        {preview.modules.length > 0 ? (
+          <div className="grid gap-3">
+            {preview.modules.map((module) => (
+              <Card key={module.id}>
+                <CardHeader>
+                  <CardTitle className="text-base">{module.title}</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  {module.lessons.length > 0 ? (
+                    <ul className="space-y-2 text-sm text-muted-foreground">
+                      {module.lessons.map((lesson) => (
+                        <li key={lesson.id}>{lesson.title}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">Lessons coming soon.</p>
+                  )}
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <Card>
+            <CardContent className="py-4">
+              <p className="text-sm text-muted-foreground">Course outline coming soon.</p>
+            </CardContent>
+          </Card>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/app/courses/[courseId]/page.tsx
+++ b/src/app/courses/[courseId]/page.tsx
@@ -13,6 +13,10 @@ export default async function PublicCoursePage({
   params: Promise<{ courseId: string }>;
 }) {
   const { courseId } = await params;
+
+  // Reject non-UUID courseId before querying Supabase (prevents 500 from PostgreSQL 22P02)
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(courseId)) notFound();
+
   const preview = await getPublicCoursePreview(courseId);
   if (!preview) notFound();
 

--- a/src/app/sign-up/[[...sign-up]]/__tests__/page.test.tsx
+++ b/src/app/sign-up/[[...sign-up]]/__tests__/page.test.tsx
@@ -1,0 +1,36 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const signUpMock = vi.hoisted(() => ({
+  SignUp: vi.fn(() => <div>Sign up</div>),
+}));
+
+vi.mock("@clerk/nextjs", () => signUpMock);
+
+import SignUpPage from "@/app/sign-up/[[...sign-up]]/page";
+import { SignUp } from "@clerk/nextjs";
+
+describe("SignUpPage", () => {
+  it("preserves course enrollment intent in the Clerk redirect", async () => {
+    const courseId = "11111111-1111-4111-8111-111111111111";
+
+    render(await SignUpPage({ searchParams: Promise.resolve({ enrollCourseId: courseId }) }));
+
+    expect(SignUp).toHaveBeenCalledWith(
+      { forceRedirectUrl: `/app/onboarding?enrollCourseId=${courseId}` },
+      undefined,
+    );
+  });
+
+  it("uses the normal app redirect without enrollment intent", async () => {
+    render(await SignUpPage({ searchParams: Promise.resolve({}) }));
+
+    expect(SignUp).toHaveBeenCalledWith({ forceRedirectUrl: "/app" }, undefined);
+  });
+
+  it("ignores invalid enrollment course ids", async () => {
+    render(await SignUpPage({ searchParams: Promise.resolve({ enrollCourseId: "not-a-course" }) }));
+
+    expect(SignUp).toHaveBeenCalledWith({ forceRedirectUrl: "/app" }, undefined);
+  });
+});

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,9 +1,26 @@
 import { SignUp } from "@clerk/nextjs";
 
-export default function SignUpPage() {
+function getEnrollCourseId(params: Record<string, string | string[] | undefined>) {
+  const raw = params.enrollCourseId;
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return value && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+    ? value
+    : null;
+}
+
+export default async function SignUpPage({
+  searchParams,
+}: {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const enrollCourseId = getEnrollCourseId((await searchParams) ?? {});
+  const forceRedirectUrl = enrollCourseId
+    ? `/app/onboarding?enrollCourseId=${encodeURIComponent(enrollCourseId)}`
+    : "/app";
+
   return (
     <div className="flex min-h-screen items-center justify-center">
-      <SignUp forceRedirectUrl="/app" />
+      <SignUp forceRedirectUrl={forceRedirectUrl} />
     </div>
   );
 }

--- a/src/lib/repositories/courses.ts
+++ b/src/lib/repositories/courses.ts
@@ -18,6 +18,77 @@ export interface CourseModule {
   lessons: { id: string; title: string; sort_order: number; content_type: "VIDEO" | "DOCUMENT"; thumbnail_url: string | null }[];
 }
 
+export interface PublicCoursePreview {
+  course: VisibleCourse;
+  modules: Array<{
+    id: string;
+    title: string;
+    sort_order: number;
+    lessons: Array<{ id: string; title: string; sort_order: number }>;
+  }>;
+  lessonCount: number;
+}
+
+export async function getPublicCoursePreview(courseId: string): Promise<PublicCoursePreview | null> {
+  if (isE2ESmokeMode()) {
+    if (courseId !== E2E_COURSE.id) return null;
+    return {
+      course: E2E_COURSE,
+      modules: [
+        {
+          id: E2E_MODULE.id,
+          title: E2E_MODULE.title,
+          sort_order: E2E_MODULE.sort_order,
+          lessons: [{ id: E2E_LESSON.id, title: E2E_LESSON.title, sort_order: 1 }],
+        },
+      ],
+      lessonCount: 1,
+    };
+  }
+
+  const supabase = getSupabaseAdminClient();
+  const { data: course, error: courseError } = await supabase
+    .from("courses")
+    .select("id,title,description,published,scope,thumbnail_url")
+    .eq("id", courseId)
+    .eq("published", true)
+    .maybeSingle();
+
+  if (courseError) throw courseError;
+  if (!course) return null;
+
+  const { data: modules, error: modulesError } = await supabase
+    .from("modules")
+    .select("id,title,sort_order,lessons(id,title,sort_order)")
+    .eq("course_id", courseId)
+    .order("sort_order", { ascending: true });
+
+  if (modulesError) throw modulesError;
+
+  const previewModules = ((modules ?? []) as Array<{
+    id: string;
+    title: string;
+    sort_order: number;
+    lessons: Array<{ id: string; title: string; sort_order: number }> | null;
+  }>).map((module) => ({
+    ...module,
+    lessons: [...(module.lessons ?? [])].sort((a, b) => a.sort_order - b.sort_order),
+  }));
+
+  return {
+    course: {
+      id: course.id as string,
+      title: course.title as string,
+      description: (course.description as string | null) ?? null,
+      published: true,
+      scope: course.scope as "DIOCESE" | "PARISH",
+      thumbnailUrl: (course.thumbnail_url as string | null) ?? null,
+    },
+    modules: previewModules,
+    lessonCount: previewModules.reduce((sum, module) => sum + module.lessons.length, 0),
+  };
+}
+
 export async function listVisibleCourses(parishId: string): Promise<VisibleCourse[]> {
   if (isE2ESmokeMode()) {
     return [E2E_COURSE];


### PR DESCRIPTION
Closes #44

## Summary
- add a public `/courses/[courseId]` preview for published courses using a safe server-rendered projection
- preserve `enrollCourseId` through Clerk signup into onboarding
- auto-submit pending join requests during onboarding and show catalog confirmation
- redirect authenticated users into the existing course/catalog flow

## Validation
- focused tests: 4 files, 16 tests passed
- Crabbox CI: 100 test files, 477 tests passed
- lint/typecheck/coverage passed; existing lint warnings only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth redirects, onboarding server actions, and join-request creation with admin Supabase access; behavior is mostly additive with UUID validation and tests.
> 
> **Overview**
> Adds a **public course registration path** from marketing-style preview through signup, onboarding, and catalog confirmation.
> 
> A new **`/courses/[courseId]`** page loads a **published-only** preview via `getPublicCoursePreview` (UUID validation, 404 when not public). Anonymous users see outline + **Register & Enroll** → `/sign-up?enrollCourseId=…`. Signed-in users are routed to onboarding (if incomplete), the app course, or **`/app/catalog?courseId=…`** based on enrollment.
> 
> **`enrollCourseId`** is validated as a UUID on sign-up and onboarding. Clerk **`forceRedirectUrl`** sends new users to onboarding with that param; onboarding carries it in a hidden field, preserves it on error redirects, and after profile/parish setup calls **`createJoinRequest`** (treating duplicate pending / already enrolled as success). Success redirects to **`/app/catalog?enrollment=requested`**, which shows a confirmation **Alert**; join failures still complete onboarding to `/app`.
> 
> Focused **Vitest** coverage was added for catalog, onboarding, public course, and sign-up pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db047334e5065d14c6a01d1d4030a893d183f4df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->