### PR TITLE
Redesign learner pages per WD Learning Redesign

### DIFF
--- a/src/app/app/catalog/__tests__/page.test.tsx
+++ b/src/app/app/catalog/__tests__/page.test.tsx
@@ -87,6 +87,12 @@ describe("CatalogPage enrollment confirmation", () => {
     render(await CatalogPage({ searchParams: Promise.resolve({}) }));
 
     expect(screen.getByRole("link", { name: "Open" })).toHaveAttribute("href", "/app/courses/course-1");
+    expect(document.getElementById("course-course-2")).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("link", { name: "Pending Course" }).some(
+        (link) => link.getAttribute("href") === "#course-course-2",
+      ),
+    ).toBe(true);
     expect(screen.getByText("Request sent")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Request course-3" })).toBeInTheDocument();
   });
@@ -107,5 +113,23 @@ describe("CatalogPage enrollment confirmation", () => {
     render(await CatalogPage({ searchParams: Promise.resolve({ q: "history" }) }));
 
     expect(screen.getByText("No courses match your search.")).toBeInTheDocument();
+  });
+
+  it("shows a category empty state when only the category filter removes courses", async () => {
+    vi.mocked(getCatalogCourses).mockResolvedValue([
+      {
+        id: "course-1",
+        title: "Foundations",
+        description: null,
+        thumbnailUrl: null,
+        scope: "DIOCESE",
+        lessonCount: 1,
+        enrolled: false,
+      },
+    ]);
+
+    render(await CatalogPage({ searchParams: Promise.resolve({ category: "Scripture" }) }));
+
+    expect(screen.getByText("No courses match this category.")).toBeInTheDocument();
   });
 });

--- a/src/app/app/catalog/__tests__/page.test.tsx
+++ b/src/app/app/catalog/__tests__/page.test.tsx
@@ -86,7 +86,7 @@ describe("CatalogPage enrollment confirmation", () => {
 
     render(await CatalogPage({ searchParams: Promise.resolve({}) }));
 
-    expect(screen.getByRole("link", { name: "Go to course" })).toHaveAttribute("href", "/app/courses/course-1");
+    expect(screen.getByRole("link", { name: "Open" })).toHaveAttribute("href", "/app/courses/course-1");
     expect(screen.getByText("Request sent")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Request course-3" })).toBeInTheDocument();
   });

--- a/src/app/app/catalog/page.tsx
+++ b/src/app/app/catalog/page.tsx
@@ -29,7 +29,10 @@ function CourseCard({
   const duration = placeholderDuration(course.lessonCount);
 
   return (
-    <Card className="group flex h-full flex-col overflow-hidden rounded-2xl transition-all duration-200 hover:-translate-y-0.5 hover:border-border-strong hover:shadow-md">
+    <Card
+      id={`course-${course.id}`}
+      className="group flex h-full scroll-mt-24 flex-col overflow-hidden rounded-2xl transition-all duration-200 hover:-translate-y-0.5 hover:border-border-strong hover:shadow-md"
+    >
       <Link
         aria-label={course.title}
         className="relative block aspect-video w-full"
@@ -242,7 +245,11 @@ export default async function CatalogPage({
       )}
       {allCourses.length > 0 && enrolled.length === 0 && available.length === 0 && (
         <Card className="px-6 py-12 text-center text-[14px] text-muted-foreground">
-          No courses match your search.
+          {query && category !== "All"
+            ? "No courses match your filters."
+            : query
+              ? "No courses match your search."
+              : "No courses match this category."}
         </Card>
       )}
     </div>

--- a/src/app/app/catalog/page.tsx
+++ b/src/app/app/catalog/page.tsx
@@ -1,14 +1,22 @@
 import Link from "next/link";
 
-import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Card, CardContent, CardDescription, CardTitle } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { CourseThumbnail } from "@/components/learning/emblem";
+import { ScopeBadge } from "@/components/learning/scope-badge";
+import { CategoryChip, MetaRow } from "@/components/learning/meta-row";
+import {
+  CATEGORY_LIST,
+  placeholderCategory,
+  placeholderDuration,
+} from "@/components/learning/placeholders";
+import { RequestJoinButton } from "@/components/course-join/request-join-button";
 import { requireParishRole } from "@/lib/authz";
 import { getCatalogCourses } from "@/lib/repositories/catalog";
 import { getStudentPendingRequests } from "@/lib/repositories/course-join-requests";
 import type { CatalogCourse } from "@/lib/repositories/catalog";
-import { RequestJoinButton } from "@/components/course-join/request-join-button";
 
 function CourseCard({
   course,
@@ -17,64 +25,53 @@ function CourseCard({
   course: CatalogCourse;
   hasPendingRequest: boolean;
 }) {
+  const category = placeholderCategory(course.id);
+  const duration = placeholderDuration(course.lessonCount);
+
   return (
-    <Card className="flex h-full flex-col overflow-hidden transition-colors hover:bg-secondary/50">
-      <div className="flex gap-3 p-4 pb-0">
-        {/* Thumbnail */}
-        <div className="h-28 w-28 shrink-0 overflow-hidden rounded-md border bg-muted">
-          {course.thumbnailUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              alt={course.title}
-              className="h-full w-full object-cover"
-              src={course.thumbnailUrl}
-            />
-          ) : (
-            <div className="flex h-full items-center justify-center text-muted-foreground">
-              <svg className="h-12 w-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} />
-              </svg>
-            </div>
-          )}
+    <Card className="group flex h-full flex-col overflow-hidden rounded-2xl transition-all duration-200 hover:-translate-y-0.5 hover:border-border-strong hover:shadow-md">
+      <Link
+        aria-label={course.title}
+        className="relative block aspect-video w-full"
+        href={course.enrolled ? `/app/courses/${course.id}` : `#course-${course.id}`}
+      >
+        <div className="absolute inset-0">
+          <CourseThumbnail alt={course.title} seed={course.id} thumbnailUrl={course.thumbnailUrl} />
         </div>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-start justify-between gap-2">
-            <CardTitle className="text-base">{course.title}</CardTitle>
-            <span
-              className={[
-                "shrink-0 rounded-full px-2 py-0.5 text-xs font-medium",
-                course.scope === "DIOCESE"
-                  ? "bg-primary/10 text-primary"
-                  : "bg-secondary text-secondary-foreground",
-              ].join(" ")}
-            >
-              {course.scope === "DIOCESE" ? "Diocese-wide" : "Parish"}
+        <div className="absolute left-3 top-3 z-10">
+          <ScopeBadge scope={course.scope} onMedia />
+        </div>
+      </Link>
+      <div className="flex flex-1 flex-col gap-2.5 px-5 py-4">
+        <div>
+          <CategoryChip category={category} />
+        </div>
+        <Link
+          className="line-clamp-2 font-display text-[17px] font-bold leading-snug tracking-tight hover:text-primary"
+          href={course.enrolled ? `/app/courses/${course.id}` : `#course-${course.id}`}
+        >
+          {course.title}
+        </Link>
+        {course.description && (
+          <p className="line-clamp-2 text-[13.5px] leading-snug text-muted-foreground">
+            {course.description}
+          </p>
+        )}
+        <div className="mt-auto flex items-center justify-between gap-3 pt-1">
+          <MetaRow lessons={course.lessonCount} duration={duration} />
+          {course.enrolled ? (
+            <Button asChild size="sm" variant="outline">
+              <Link href={`/app/courses/${course.id}`}>Open</Link>
+            </Button>
+          ) : hasPendingRequest ? (
+            <span className="whitespace-nowrap text-[12.5px] font-semibold text-success">
+              Request sent
             </span>
-          </div>
-          {course.description && (
-            <CardDescription className="line-clamp-2 mt-0.5">
-              {course.description}
-            </CardDescription>
+          ) : (
+            <RequestJoinButton courseId={course.id} />
           )}
         </div>
       </div>
-      <CardContent className="mt-auto space-y-3 pt-3">
-        <p className="text-xs text-muted-foreground">
-          {course.lessonCount} lesson{course.lessonCount !== 1 ? "s" : ""}
-        </p>
-        {course.enrolled ? (
-          <Button asChild className="w-full" variant="outline">
-            <Link href={`/app/courses/${course.id}`}>Go to course</Link>
-          </Button>
-        ) : hasPendingRequest ? (
-          <div className="space-y-1">
-            <p className="text-sm font-medium text-success">Request sent</p>
-            <p className="text-xs text-muted-foreground">Your parish admin will review it soon.</p>
-          </div>
-        ) : (
-          <RequestJoinButton courseId={course.id} />
-        )}
-      </CardContent>
     </Card>
   );
 }
@@ -90,40 +87,34 @@ export default async function CatalogPage({
 
   const rawQ = params.q;
   const query = Array.isArray(rawQ) ? rawQ[0] : (rawQ?.trim() ?? "");
+  const rawCat = params.category;
+  const category = Array.isArray(rawCat) ? rawCat[0] : (rawCat ?? "All");
   const enrollmentStatus = Array.isArray(params.enrollment) ? params.enrollment[0] : params.enrollment;
   const showEnrollmentConfirmation = enrollmentStatus === "requested";
 
-  // Get pending join requests so we can show "Request sent" on course cards
   const pendingRequests = await getStudentPendingRequests({ parishId, clerkUserId });
   const pendingCourseIds = new Set(pendingRequests.map((r) => r.courseId));
 
-  const enrolled = allCourses.filter((c) => c.enrolled);
-  const unenrolled = allCourses.filter((c) => !c.enrolled);
+  const matchesQuery = (c: CatalogCourse) =>
+    query.length === 0 ||
+    c.title.toLowerCase().includes(query.toLowerCase()) ||
+    (c.description?.toLowerCase().includes(query.toLowerCase()) ?? false);
 
-  const filteredEnrolled =
-    query.length > 0
-      ? enrolled.filter(
-          (c) =>
-            c.title.toLowerCase().includes(query.toLowerCase()) ||
-            (c.description?.toLowerCase().includes(query.toLowerCase()) ?? false),
-        )
-      : enrolled;
+  const matchesCategory = (c: CatalogCourse) =>
+    category === "All" || placeholderCategory(c.id) === category;
 
-  const filteredUnenrolled =
-    query.length > 0
-      ? unenrolled.filter(
-          (c) =>
-            c.title.toLowerCase().includes(query.toLowerCase()) ||
-            (c.description?.toLowerCase().includes(query.toLowerCase()) ?? false),
-        )
-      : unenrolled;
+  const filtered = allCourses.filter((c) => matchesQuery(c) && matchesCategory(c));
+  const enrolled = filtered.filter((c) => c.enrolled);
+  const available = filtered.filter((c) => !c.enrolled);
 
   return (
-    <div className="space-y-6">
-      <header className="space-y-1">
-        <h1 className="text-2xl font-semibold">Course Catalog</h1>
-        <p className="text-sm text-muted-foreground">
-          Browse available courses and track your enrolled ones.
+    <div className="space-y-9">
+      <header>
+        <h1 className="font-display text-[30px] font-bold leading-tight tracking-tight">
+          Course Catalog
+        </h1>
+        <p className="mt-1.5 text-[15px] text-muted-foreground">
+          Browse the diocese library and track the courses you&apos;re enrolled in.
         </p>
       </header>
 
@@ -135,52 +126,109 @@ export default async function CatalogPage({
         </Alert>
       ) : null}
 
-      {/* Search */}
-      <form className="flex gap-2">
-        <label className="sr-only" htmlFor="catalog-search">
-          Search courses
-        </label>
-        <Input
-          className="max-w-sm"
-          defaultValue={query}
-          id="catalog-search"
-          name="q"
-          placeholder="Search courses..."
-          type="search"
-        />
-        <Button type="submit" variant="secondary">
-          Search
-        </Button>
-        {query && (
-          <Button asChild type="button" variant="ghost">
-            <Link href="/app/catalog">Clear</Link>
+      {/* Search + categories */}
+      <div className="space-y-4">
+        <form className="flex flex-wrap gap-2.5">
+          <div className="relative w-full max-w-[460px]">
+            <svg
+              viewBox="0 0 24 24"
+              width="17"
+              height="17"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.9"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-muted-foreground"
+            >
+              <circle cx="11" cy="11" r="7" />
+              <path d="m21 21-4.3-4.3" />
+            </svg>
+            <Input
+              className="h-11 w-full rounded-[10px] pl-10 text-[14.5px]"
+              defaultValue={query}
+              id="catalog-search"
+              name="q"
+              placeholder="Search courses…"
+              type="search"
+            />
+            {category !== "All" && (
+              <input type="hidden" name="category" value={category} />
+            )}
+          </div>
+          <Button type="submit" variant="secondary">
+            Search
           </Button>
-        )}
-      </form>
+          {query && (
+            <Button asChild type="button" variant="ghost">
+              <Link
+                href={category === "All" ? "/app/catalog" : `/app/catalog?category=${encodeURIComponent(category)}`}
+              >
+                Clear
+              </Link>
+            </Button>
+          )}
+        </form>
+        <div className="flex flex-wrap gap-2.5">
+          {CATEGORY_LIST.map((c) => {
+            const isActive = category === c;
+            const href =
+              c === "All"
+                ? query
+                  ? `/app/catalog?q=${encodeURIComponent(query)}`
+                  : "/app/catalog"
+                : `/app/catalog?category=${encodeURIComponent(c)}${query ? `&q=${encodeURIComponent(query)}` : ""}`;
+            return (
+              <Link
+                key={c}
+                href={href}
+                className={
+                  "inline-flex items-center whitespace-nowrap rounded-full border px-3.5 py-1.5 text-[12px] font-semibold transition-colors " +
+                  (isActive
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border bg-card text-muted-foreground hover:border-border-strong hover:text-foreground")
+                }
+              >
+                {c}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
 
-      {/* Enrolled courses */}
-      {filteredEnrolled.length > 0 && (
+      {/* Enrolled */}
+      {enrolled.length > 0 && (
         <section>
-          <h2 className="mb-3 text-sm font-medium text-muted-foreground">
-            My enrolled courses
-          </h2>
-          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-            {filteredEnrolled.map((course) => (
-              <CourseCard course={course} hasPendingRequest={pendingCourseIds.has(course.id)} key={course.id} />
+          <SectionHead title={`My enrolled courses · ${enrolled.length}`} />
+          <div className="grid gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {enrolled.map((course) => (
+              <CourseCard
+                course={course}
+                hasPendingRequest={pendingCourseIds.has(course.id)}
+                key={course.id}
+              />
             ))}
           </div>
         </section>
       )}
 
-      {/* Available courses */}
-      {filteredUnenrolled.length > 0 && (
+      {/* Available */}
+      {available.length > 0 && (
         <section>
-          <h2 className="mb-3 text-sm font-medium text-muted-foreground">
-            {query ? `Results for "${query}"` : "All available courses"}
-          </h2>
-          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-            {filteredUnenrolled.map((course) => (
-              <CourseCard course={course} hasPendingRequest={pendingCourseIds.has(course.id)} key={course.id} />
+          <SectionHead
+            title={
+              query
+                ? `Results for "${query}" · ${available.length}`
+                : `${category === "All" ? "All courses" : category} · ${available.length}`
+            }
+          />
+          <div className="grid gap-5 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {available.map((course) => (
+              <CourseCard
+                course={course}
+                hasPendingRequest={pendingCourseIds.has(course.id)}
+                key={course.id}
+              />
             ))}
           </div>
         </section>
@@ -188,31 +236,25 @@ export default async function CatalogPage({
 
       {/* Empty states */}
       {allCourses.length === 0 && (
-        <Card>
-          <CardContent className="py-8 text-center">
-            <p className="text-sm text-muted-foreground">
-              No courses are available in the catalog yet.
-            </p>
-          </CardContent>
+        <Card className="px-6 py-12 text-center text-[14px] text-muted-foreground">
+          No courses are available in the catalog yet.
         </Card>
       )}
-      {allCourses.length > 0 &&
-        filteredEnrolled.length === 0 &&
-        filteredUnenrolled.length === 0 && (
-          <Card>
-            <CardContent className="py-8 text-center">
-              <p className="text-sm text-muted-foreground">
-                No courses match your search.
-              </p>
-            </CardContent>
-          </Card>
-        )}
+      {allCourses.length > 0 && enrolled.length === 0 && available.length === 0 && (
+        <Card className="px-6 py-12 text-center text-[14px] text-muted-foreground">
+          No courses match your search.
+        </Card>
+      )}
+    </div>
+  );
+}
 
-      <div className="flex justify-end gap-2">
-        <Button asChild variant="outline">
-          <Link href="/app/dashboard">Back to dashboard</Link>
-        </Button>
-      </div>
+function SectionHead({ title }: { title: string }) {
+  return (
+    <div className="mb-4 flex items-baseline justify-between">
+      <h2 className="whitespace-nowrap text-[13px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+        {title}
+      </h2>
     </div>
   );
 }

--- a/src/app/app/courses/[courseId]/page.tsx
+++ b/src/app/app/courses/[courseId]/page.tsx
@@ -1,21 +1,45 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
 
+import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CourseThumbnail } from "@/components/learning/emblem";
+import { ScopeBadge } from "@/components/learning/scope-badge";
+import { CategoryChip, MetaRow } from "@/components/learning/meta-row";
+import { ProgressLine } from "@/components/learning/progress-line";
+import {
+  placeholderCategory,
+  placeholderDuration,
+} from "@/components/learning/placeholders";
 import { requireParishRole } from "@/lib/authz";
-import { getCourseTreeWithProgress, isUserEnrolledInCourse } from "@/lib/repositories/courses";
+import {
+  getCourseTreeWithProgress,
+  isUserEnrolledInCourse,
+} from "@/lib/repositories/courses";
 import type { CourseLesson } from "@/lib/repositories/courses";
 
-function statusIcon(status: CourseLesson["status"]) {
-  switch (status) {
-    case "completed":
-      return <span className="mr-1.5" title="Completed">✓</span>;
-    case "in_progress":
-      return <span className="mr-1.5" title="In progress">▶</span>;
-    default:
-      return <span className="mr-1.5 text-muted-foreground" title="Not started">○</span>;
+function StatusDot({ status }: { status: CourseLesson["status"] }) {
+  if (status === "completed") {
+    return (
+      <span className="grid h-[22px] w-[22px] shrink-0 place-items-center rounded-full bg-success text-success-foreground">
+        <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+          <path d="m20 6-11 11-5-5" />
+        </svg>
+      </span>
+    );
   }
+  if (status === "in_progress") {
+    return (
+      <span className="grid h-[22px] w-[22px] shrink-0 place-items-center rounded-full bg-primary text-primary-foreground">
+        <svg viewBox="0 0 24 24" width="11" height="11" fill="currentColor" stroke="none">
+          <path d="m10 9 5 3-5 3V9Z" />
+        </svg>
+      </span>
+    );
+  }
+  return (
+    <span className="grid h-[22px] w-[22px] shrink-0 place-items-center rounded-full border-[1.5px] border-border-strong" />
+  );
 }
 
 export default async function CourseDetailPage({
@@ -36,113 +60,163 @@ export default async function CourseDetailPage({
   const allLessons = tree.modules.flatMap((m) => m.lessons);
   const completedCount = allLessons.filter((l) => l.status === "completed").length;
   const firstIncomplete = allLessons.find((l) => l.status !== "completed");
-  const progressPercent = allLessons.length > 0
-    ? Math.round((completedCount / allLessons.length) * 100)
-    : 0;
+  const progressPercent =
+    allLessons.length > 0 ? Math.round((completedCount / allLessons.length) * 100) : 0;
+
+  const category = placeholderCategory(tree.course.id);
+  const duration = placeholderDuration(allLessons.length);
+
+  const lessonNumbers = new Map<string, number>();
+  let n = 0;
+  for (const m of tree.modules) {
+    for (const l of m.lessons) {
+      n += 1;
+      lessonNumbers.set(l.id, n);
+    }
+  }
 
   return (
-    <div className="space-y-4">
-      <header className="flex items-start gap-4">
-        {/* Course thumbnail */}
-        <div className="h-28 w-28 shrink-0 overflow-hidden rounded-md border bg-muted">
-          {tree.course.thumbnailUrl ? (
-            // eslint-disable-next-line @next/next/no-img-element
-            <img
-              alt={tree.course.title}
-              className="h-full w-full object-cover"
-              src={tree.course.thumbnailUrl}
-            />
-          ) : (
-            <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-              <svg className="h-12 w-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} />
-              </svg>
-            </div>
-          )}
-        </div>
-        <div className="space-y-1">
-          <h1 className="text-2xl font-semibold">{tree.course.title}</h1>
-          <p className="text-sm text-muted-foreground">
-            {completedCount}/{allLessons.length} lessons complete ({progressPercent}%)
-          </p>
-        </div>
-      </header>
+    <div className="space-y-6">
+      <Link
+        href="/app/catalog"
+        className="inline-flex items-center text-[13px] font-semibold text-primary hover:underline"
+      >
+        ← Back to catalog
+      </Link>
 
-      {/* Resume button */}
-      {firstIncomplete && (
-        <Button asChild>
-          <Link href={`/app/lessons/${firstIncomplete.id}`}>
-            {firstIncomplete.status === "in_progress" ? "Resume" : "Start"} next lesson
-          </Link>
-        </Button>
-      )}
-
-      {/* Progress bar */}
-      {allLessons.length > 0 && (
-        <div className="h-2 w-full rounded-full bg-muted">
-          <div
-            className="h-2 rounded-full bg-primary transition-all duration-500"
-            style={{ width: `${progressPercent}%` }}
+      {/* Hero */}
+      <Card className="grid grid-cols-1 gap-6 p-6 sm:grid-cols-[200px_1fr] sm:gap-7">
+        <div className="aspect-square w-full max-w-[200px] self-start overflow-hidden rounded-[13px]">
+          <CourseThumbnail
+            alt={tree.course.title}
+            seed={tree.course.id}
+            thumbnailUrl={tree.course.thumbnailUrl ?? null}
           />
         </div>
-      )}
-
-      {tree.modules.map((module) => (
-        <Card key={module.id}>
-          <CardHeader>
-            <CardTitle className="text-base">{module.title}</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ul className="space-y-2">
-              {module.lessons.map((lesson) => (
-                <li className="flex items-center gap-3" key={lesson.id}>
-                  {/* Lesson thumbnail */}
-                  <div className="h-14 w-14 shrink-0 overflow-hidden rounded border bg-muted">
-                    {lesson.thumbnailUrl ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        alt={lesson.title}
-                        className="h-full w-full object-cover"
-                        src={lesson.thumbnailUrl}
-                      />
-                    ) : (
-                      <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-                        <svg className="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9v4a1 1 0 001.552.83l3.197-2.132a1 1 0 000-1.666z" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} />
-                          <path d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} />
-                        </svg>
-                      </div>
-                    )}
-                  </div>
-                  {statusIcon(lesson.status)}
-                  <Button
-                    asChild
-                    className="h-auto flex-1 justify-start p-0 font-medium"
-                    variant="link"
-                  >
-                    <Link href={`/app/lessons/${lesson.id}`}>{lesson.title}</Link>
-                  </Button>
-                  {lesson.bestScore > 0 && (
-                    <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-                      {lesson.bestScore}%
-                    </span>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </CardContent>
-        </Card>
-      ))}
-
-      {allLessons.length === 0 && (
-        <Card>
-          <CardContent className="py-4">
-            <p className="text-sm text-muted-foreground">
-              No lessons have been added to this course yet.
+        <div className="flex min-w-0 flex-col gap-3.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <CategoryChip category={category} />
+            <ScopeBadge scope={tree.course.scope} />
+          </div>
+          <h1 className="font-display text-[28px] font-bold leading-tight tracking-tight">
+            {tree.course.title}
+          </h1>
+          {tree.course.description && (
+            <p className="m-0 max-w-[62ch] text-[15px] leading-relaxed text-[var(--ds-color-text-secondary)]">
+              {tree.course.description}
             </p>
-          </CardContent>
-        </Card>
-      )}
+          )}
+          <MetaRow lessons={allLessons.length} duration={duration} />
+          <div className="mt-auto flex flex-wrap items-center gap-4 pt-1">
+            {firstIncomplete ? (
+              <Button asChild size="lg">
+                <Link href={`/app/lessons/${firstIncomplete.id}`}>
+                  <svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" className="mr-1">
+                    <circle cx="12" cy="12" r="9" />
+                    <path d="m10 9 5 3-5 3V9Z" fill="currentColor" stroke="none" />
+                  </svg>
+                  {progressPercent > 0 ? "Resume next lesson" : "Start course"}
+                </Link>
+              </Button>
+            ) : (
+              <span className="text-[14px] font-semibold text-success">
+                ✓ Course complete
+              </span>
+            )}
+            <ProgressLine className="min-w-[220px]" percent={progressPercent} />
+          </div>
+        </div>
+      </Card>
+
+      <div className="grid items-start gap-6 lg:grid-cols-[1fr_300px]">
+        <div className="flex flex-col" style={{ rowGap: 18 }}>
+          {tree.modules.map((module, mi) => (
+            <Card key={module.id} className="overflow-hidden rounded-2xl">
+              <div className="flex items-center justify-between gap-3 border-b border-border px-5 py-4">
+                <div className="flex items-center gap-3 font-display text-[17px] font-bold">
+                  <span className="grid h-[26px] w-[26px] place-items-center rounded-[7px] bg-brand-subtle font-sans text-[12px] font-bold text-primary">
+                    {mi + 1}
+                  </span>
+                  {module.title}
+                </div>
+                <span className="whitespace-nowrap text-[12.5px] font-medium text-muted-foreground">
+                  {module.lessons.length} lesson{module.lessons.length === 1 ? "" : "s"}
+                </span>
+              </div>
+              <ul>
+                {module.lessons.map((lesson) => (
+                    <li key={lesson.id}>
+                      <Link
+                        href={`/app/lessons/${lesson.id}`}
+                        className="flex items-center gap-4 border-b border-border px-5 py-3.5 transition-colors last:border-0 hover:bg-surface-raised"
+                      >
+                        <span className="w-[22px] shrink-0 text-[12px] text-muted-foreground">
+                          {String(lessonNumbers.get(lesson.id) ?? 0).padStart(2, "0")}
+                        </span>
+                        <div className="h-11 w-16 shrink-0 overflow-hidden rounded-lg">
+                          <CourseThumbnail
+                            alt={lesson.title}
+                            seed={`${tree.course.id}-${lesson.id}`}
+                            thumbnailUrl={lesson.thumbnailUrl}
+                          />
+                        </div>
+                        <StatusDot status={lesson.status} />
+                        <span className="min-w-0 flex-1 truncate text-[15px] font-medium">
+                          {lesson.title}
+                        </span>
+                        {lesson.bestScore > 0 && (
+                          <span className="shrink-0 text-[12px] font-semibold text-success">
+                            {lesson.bestScore}%
+                          </span>
+                        )}
+                      </Link>
+                    </li>
+                  ))}
+              </ul>
+            </Card>
+          ))}
+
+          {allLessons.length === 0 && (
+            <Card className="px-5 py-6">
+              <p className="text-sm text-muted-foreground">
+                No lessons have been added to this course yet.
+              </p>
+            </Card>
+          )}
+        </div>
+
+        <aside>
+          <Card className="sticky top-[80px] rounded-2xl p-6">
+            <h3 className="mb-3.5 font-display text-[15px] font-bold">
+              Course details
+            </h3>
+            <DetailRow label="Progress" value={`${completedCount}/${allLessons.length} (${progressPercent}%)`} />
+            <DetailRow label="Lessons" value={String(allLessons.length)} />
+            <DetailRow label="Duration" value={duration} />
+            <DetailRow label="Modules" value={String(tree.modules.length)} />
+            <DetailRow
+              label="Access"
+              value={tree.course.scope === "DIOCESE" ? "Diocese-wide" : "Parish"}
+            />
+            <Button className="mt-4 w-full" variant="outline" disabled>
+              <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" className="mr-1.5">
+                <circle cx="12" cy="9" r="6" />
+                <path d="M9 14l-1.5 7L12 19l4.5 2L15 14" />
+              </svg>
+              View certificate
+            </Button>
+          </Card>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function DetailRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-border py-2 text-[13.5px] last:border-0">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-right font-semibold">{value}</span>
     </div>
   );
 }

--- a/src/app/app/courses/[courseId]/page.tsx
+++ b/src/app/app/courses/[courseId]/page.tsx
@@ -115,7 +115,11 @@ export default async function CourseDetailPage({
                     <circle cx="12" cy="12" r="9" />
                     <path d="m10 9 5 3-5 3V9Z" fill="currentColor" stroke="none" />
                   </svg>
-                  {progressPercent > 0 ? "Resume next lesson" : "Start course"}
+                  {firstIncomplete.status === "in_progress"
+                    ? "Resume next lesson"
+                    : completedCount > 0
+                      ? "Start next lesson"
+                      : "Start course"}
                 </Link>
               </Button>
             ) : allLessons.length > 0 ? (

--- a/src/app/app/courses/[courseId]/page.tsx
+++ b/src/app/app/courses/[courseId]/page.tsx
@@ -118,11 +118,11 @@ export default async function CourseDetailPage({
                   {progressPercent > 0 ? "Resume next lesson" : "Start course"}
                 </Link>
               </Button>
-            ) : (
+            ) : allLessons.length > 0 ? (
               <span className="text-[14px] font-semibold text-success">
                 ✓ Course complete
               </span>
-            )}
+            ) : null}
             <ProgressLine className="min-w-[220px]" percent={progressPercent} />
           </div>
         </div>

--- a/src/app/app/courses/page.tsx
+++ b/src/app/app/courses/page.tsx
@@ -61,17 +61,21 @@ export default async function CoursesPage({
           const scope = scopeByCourseId.get(course.courseId) ?? "DIOCESE";
           const category = placeholderCategory(course.courseId);
           const isStarted = course.progressPercent > 0;
-          const targetHref = course.lastLessonId
-            ? `/app/lessons/${course.lastLessonId}`
+          const targetHref = course.resumeLessonId
+            ? `/app/lessons/${course.resumeLessonId}`
             : `/app/courses/${course.courseId}`;
+          const courseHref = `/app/courses/${course.courseId}`;
 
           return (
-            <Link
+            <Card
               key={course.courseId}
-              href={`/app/courses/${course.courseId}`}
-              className="group min-w-0"
+              className="flex flex-wrap items-center p-4 transition-all duration-200 hover:-translate-y-0.5 hover:border-border-strong hover:shadow-md sm:flex-nowrap"
+              style={{ gap: 18 }}
             >
-              <Card className="flex flex-wrap items-center p-4 transition-all duration-200 group-hover:-translate-y-0.5 group-hover:border-border-strong group-hover:shadow-md sm:flex-nowrap" style={{ gap: 18 }}>
+              <Link
+                href={courseHref}
+                className="flex min-w-0 flex-1 items-center gap-[18px]"
+              >
                 <div className="h-16 w-24 shrink-0 overflow-hidden rounded-[11px]">
                   <CourseThumbnail
                     alt={course.courseTitle}
@@ -93,21 +97,21 @@ export default async function CoursesPage({
                     </p>
                   )}
                 </div>
-                <div className="hidden shrink-0 items-center gap-6 sm:flex">
-                  <div className="w-[200px]">
-                    <ProgressLine percent={course.progressPercent} />
-                    <p className="mt-1.5 text-[12px] text-muted-foreground">
-                      {course.completedLessons}/{course.totalLessons} lessons
-                    </p>
-                  </div>
-                  <Button asChild size="sm" variant="default">
-                    <Link href={targetHref} onClick={(e) => e.stopPropagation()}>
-                      {isStarted ? "Resume" : "Start"}
-                    </Link>
-                  </Button>
+              </Link>
+              <div className="hidden shrink-0 items-center gap-6 sm:flex">
+                <div className="w-[200px]">
+                  <ProgressLine percent={course.progressPercent} />
+                  <p className="mt-1.5 text-[12px] text-muted-foreground">
+                    {course.completedLessons}/{course.totalLessons} lessons
+                  </p>
                 </div>
-              </Card>
-            </Link>
+                <Button asChild size="sm" variant="default">
+                  <Link href={targetHref}>
+                    {isStarted ? "Resume" : "Start"}
+                  </Link>
+                </Button>
+              </div>
+            </Card>
           );
         })}
       </div>

--- a/src/app/app/courses/page.tsx
+++ b/src/app/app/courses/page.tsx
@@ -1,9 +1,15 @@
 import Link from "next/link";
 
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CourseThumbnail } from "@/components/learning/emblem";
+import { ScopeBadge } from "@/components/learning/scope-badge";
+import { CategoryChip } from "@/components/learning/meta-row";
+import { ProgressLine } from "@/components/learning/progress-line";
+import { placeholderCategory } from "@/components/learning/placeholders";
 import { requireParishRole } from "@/lib/authz";
-import { listEnrolledVisibleCourses } from "@/lib/repositories/courses";
-import type { VisibleCourse } from "@/lib/repositories/courses";
+import { getStudentDashboardData } from "@/lib/repositories/dashboard";
+import { listVisibleCourses } from "@/lib/repositories/courses";
 
 export default async function CoursesPage({
   searchParams,
@@ -11,65 +17,99 @@ export default async function CoursesPage({
   searchParams?: Promise<{ error?: string }>;
 }) {
   const { parishId, clerkUserId } = await requireParishRole("student");
-  const courses = await listEnrolledVisibleCourses(parishId, clerkUserId);
+  const [{ progress }, visible] = await Promise.all([
+    getStudentDashboardData(parishId, clerkUserId),
+    listVisibleCourses(parishId),
+  ]);
   const params = (await searchParams) ?? {};
   const showNotEnrolledMessage = params.error === "not_enrolled";
 
+  const scopeByCourseId = new Map(visible.map((c) => [c.id, c.scope]));
+
   return (
-    <div className="space-y-4">
-      <h1 className="text-2xl font-semibold">Courses</h1>
-      <div className="grid gap-3">
-        {showNotEnrolledMessage ? (
-          <Card>
-            <CardContent className="pt-4">
-              <p className="text-sm text-muted-foreground">
-                You must be enrolled in a course before accessing lessons.
-              </p>
-            </CardContent>
-          </Card>
-        ) : null}
-        {courses.length === 0 ? (
-          <Card>
-            <CardContent className="pt-4">
-              <p className="text-sm text-muted-foreground">
-                You are not enrolled in any courses yet. Ask your parish admin to enroll you.
-              </p>
-            </CardContent>
-          </Card>
-        ) : null}
-        {(courses as VisibleCourse[]).map((course) => (
-          <Link key={course.id} href={`/app/courses/${course.id}`}>
-            <Card className="transition-colors hover:bg-secondary overflow-hidden">
-              <CardContent className="flex items-center gap-3 py-3 sm:py-4">
-                {/* Thumbnail */}
-                <div className="h-16 w-16 sm:h-20 sm:w-20 shrink-0 overflow-hidden rounded-md border bg-muted">
-                  {course.thumbnailUrl ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      alt={course.title}
-                      className="h-full w-full object-cover"
-                      src={course.thumbnailUrl}
-                    />
-                  ) : (
-                    <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-                      <svg className="h-7 w-7 sm:h-9 sm:w-9" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} />
-                      </svg>
-                    </div>
-                  )}
+    <div className="space-y-9">
+      <header>
+        <h1 className="font-display text-[30px] font-bold leading-tight tracking-tight">
+          My Courses
+        </h1>
+        <p className="mt-1.5 text-[15px] text-muted-foreground">
+          Everything you&apos;re enrolled in, with your progress at a glance.
+        </p>
+      </header>
+
+      {showNotEnrolledMessage && (
+        <Card className="px-5 py-4">
+          <p className="text-sm text-muted-foreground">
+            You must be enrolled in a course before accessing lessons.
+          </p>
+        </Card>
+      )}
+
+      {progress.length === 0 && !showNotEnrolledMessage && (
+        <Card className="px-6 py-12 text-center">
+          <p className="text-[15px] font-medium">
+            You are not enrolled in any courses yet.
+          </p>
+          <p className="mt-1.5 text-[13.5px] text-muted-foreground">
+            Ask your parish admin to enroll you to get started.
+          </p>
+        </Card>
+      )}
+
+      <div className="flex flex-col" style={{ rowGap: 18 }}>
+        {progress.map((course) => {
+          const scope = scopeByCourseId.get(course.courseId) ?? "DIOCESE";
+          const category = placeholderCategory(course.courseId);
+          const isStarted = course.progressPercent > 0;
+          const targetHref = course.lastLessonId
+            ? `/app/lessons/${course.lastLessonId}`
+            : `/app/courses/${course.courseId}`;
+
+          return (
+            <Link
+              key={course.courseId}
+              href={`/app/courses/${course.courseId}`}
+              className="group min-w-0"
+            >
+              <Card className="flex flex-wrap items-center p-4 transition-all duration-200 group-hover:-translate-y-0.5 group-hover:border-border-strong group-hover:shadow-md sm:flex-nowrap" style={{ gap: 18 }}>
+                <div className="h-16 w-24 shrink-0 overflow-hidden rounded-[11px]">
+                  <CourseThumbnail
+                    alt={course.courseTitle}
+                    seed={course.courseId}
+                    thumbnailUrl={course.thumbnailUrl}
+                  />
                 </div>
                 <div className="min-w-0 flex-1">
-                  <p className="truncate text-sm sm:text-base font-medium">{course.title}</p>
-                  {course.description && (
-                    <p className="hidden sm:block truncate text-xs sm:text-sm text-muted-foreground">
-                      {course.description}
+                  <div className="mb-1 flex flex-wrap items-center gap-2">
+                    <CategoryChip category={category} />
+                    <ScopeBadge scope={scope} />
+                  </div>
+                  <p className="font-display text-[16.5px] font-bold leading-snug">
+                    {course.courseTitle}
+                  </p>
+                  {course.courseDescription && (
+                    <p className="mt-1 line-clamp-1 text-[13px] text-muted-foreground">
+                      {course.courseDescription}
                     </p>
                   )}
                 </div>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
+                <div className="hidden shrink-0 items-center gap-6 sm:flex">
+                  <div className="w-[200px]">
+                    <ProgressLine percent={course.progressPercent} />
+                    <p className="mt-1.5 text-[12px] text-muted-foreground">
+                      {course.completedLessons}/{course.totalLessons} lessons
+                    </p>
+                  </div>
+                  <Button asChild size="sm" variant="default">
+                    <Link href={targetHref} onClick={(e) => e.stopPropagation()}>
+                      {isStarted ? "Resume" : "Start"}
+                    </Link>
+                  </Button>
+                </div>
+              </Card>
+            </Link>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/app/app/courses/page.tsx
+++ b/src/app/app/courses/page.tsx
@@ -60,7 +60,8 @@ export default async function CoursesPage({
         {progress.map((course) => {
           const scope = scopeByCourseId.get(course.courseId) ?? "DIOCESE";
           const category = placeholderCategory(course.courseId);
-          const isStarted = course.progressPercent > 0;
+          const isStarted =
+            course.progressPercent > 0 || course.lastActivityAt !== null;
           const targetHref = course.resumeLessonId
             ? `/app/lessons/${course.resumeLessonId}`
             : `/app/courses/${course.courseId}`;
@@ -98,7 +99,7 @@ export default async function CoursesPage({
                   )}
                 </div>
               </Link>
-              <div className="hidden shrink-0 items-center gap-6 sm:flex">
+              <div className="flex w-full shrink-0 items-center justify-between gap-4 sm:w-auto sm:justify-start sm:gap-6">
                 <div className="w-[200px]">
                   <ProgressLine percent={course.progressPercent} />
                   <p className="mt-1.5 text-[12px] text-muted-foreground">

--- a/src/app/app/dashboard/page.tsx
+++ b/src/app/app/dashboard/page.tsx
@@ -33,17 +33,18 @@ export default async function DashboardPage() {
     clerkUserId,
   );
 
-  const inProgress = progress
-    .filter((c) => c.lastLessonId)
+  const resumableCourses = progress
+    .filter((c) => c.resumeLessonId && c.progressPercent < 100)
     .sort(
       (a, b) =>
         new Date(b.lastActivityAt ?? 0).getTime() -
         new Date(a.lastActivityAt ?? 0).getTime(),
     );
+  const activeResumeCourses = resumableCourses.filter((c) => c.lastActivityAt);
 
   const totalCompleted = progress.reduce((sum, c) => sum + c.completedLessons, 0);
   const totalLessons = progress.reduce((sum, c) => sum + c.totalLessons, 0);
-  const top = inProgress[0];
+  const continueCourse = resumableCourses[0];
 
   if (progress.length === 0) {
     return (
@@ -76,17 +77,17 @@ export default async function DashboardPage() {
       </header>
 
       {/* Continue learning hero */}
-      {top && (
+      {continueCourse && (
         <Card className="grid overflow-hidden rounded-2xl grid-cols-1 sm:grid-cols-[280px_1fr]">
           <Link
-            aria-label={`Resume ${top.lastLessonTitle ?? top.courseTitle}`}
+            aria-label={`Resume ${continueCourse.resumeLessonTitle ?? continueCourse.courseTitle}`}
             className="relative block min-h-[180px] sm:min-h-[220px]"
-            href={`/app/lessons/${top.lastLessonId}`}
+            href={`/app/lessons/${continueCourse.resumeLessonId}`}
           >
             <CourseThumbnail
-              alt={top.courseTitle}
-              seed={top.courseId}
-              thumbnailUrl={top.thumbnailUrl}
+              alt={continueCourse.courseTitle}
+              seed={continueCourse.courseId}
+              thumbnailUrl={continueCourse.thumbnailUrl}
               className="absolute inset-0"
             />
           </Link>
@@ -100,18 +101,18 @@ export default async function DashboardPage() {
             </div>
             <Link
               className="font-display text-[26px] font-bold leading-tight tracking-tight hover:text-primary"
-              href={`/app/lessons/${top.lastLessonId}`}
+              href={`/app/lessons/${continueCourse.resumeLessonId}`}
             >
-              {top.lastLessonTitle ?? "Resume next lesson"}
+              {continueCourse.resumeLessonTitle ?? "Resume next lesson"}
             </Link>
             <p className="m-0 text-[14.5px] text-muted-foreground">
-              {top.courseTitle}
+              {continueCourse.courseTitle}
             </p>
-            <ProgressLine className="max-w-[360px]" percent={top.progressPercent} />
+            <ProgressLine className="max-w-[360px]" percent={continueCourse.progressPercent} />
             <div className="mt-1 flex flex-wrap items-center gap-4">
               <Link
                 className="inline-flex items-center gap-2 rounded-[9px] bg-primary px-5 py-2.5 text-[15px] font-semibold text-primary-foreground transition-colors hover:bg-[var(--ds-color-brand-hover)]"
-                href={`/app/lessons/${top.lastLessonId}`}
+                href={`/app/lessons/${continueCourse.resumeLessonId}`}
               >
                 Resume lesson
                 <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -119,7 +120,7 @@ export default async function DashboardPage() {
                 </svg>
               </Link>
               <span className="text-[13px] text-muted-foreground">
-                {top.completedLessons}/{top.totalLessons} lessons complete
+                {continueCourse.completedLessons}/{continueCourse.totalLessons} lessons complete
               </span>
             </div>
           </div>
@@ -174,13 +175,13 @@ export default async function DashboardPage() {
       </div>
 
       {/* Pick up where you left off */}
-      {inProgress.length > 0 && (
+      {activeResumeCourses.length > 0 && (
         <section>
           <SectionHead title="Pick up where you left off" />
           <div className="grid gap-4 grid-cols-1 lg:grid-cols-3">
-            {inProgress.slice(0, 3).map((course) => (
+            {activeResumeCourses.slice(0, 3).map((course) => (
               <Link
-                href={`/app/lessons/${course.lastLessonId}`}
+                href={`/app/lessons/${course.resumeLessonId}`}
                 key={`resume-${course.courseId}`}
                 className="group min-w-0"
               >
@@ -194,7 +195,7 @@ export default async function DashboardPage() {
                   </div>
                   <div className="min-w-0 flex-1">
                     <p className="line-clamp-1 text-[14.5px] font-semibold leading-tight">
-                      {course.lastLessonTitle ?? "Resume"}
+                      {course.resumeLessonTitle ?? "Resume"}
                     </p>
                     <p className="mt-0.5 truncate text-[12.5px] text-muted-foreground">
                       {course.courseTitle}

--- a/src/app/app/dashboard/page.tsx
+++ b/src/app/app/dashboard/page.tsx
@@ -1,45 +1,13 @@
 import Link from "next/link";
 
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
+import { CourseThumbnail } from "@/components/learning/emblem";
+import { ProgressLine, ProgressRing } from "@/components/learning/progress-line";
+import { MetaRow } from "@/components/learning/meta-row";
+import { placeholderDuration } from "@/components/learning/placeholders";
 import { requireParishRole } from "@/lib/authz";
 import { getStudentDashboardData } from "@/lib/repositories/dashboard";
 import type { LessonActivity } from "@/lib/repositories/dashboard";
-
-function ProgressRing({ percent }: { percent: number }) {
-  const radius = 28;
-  const circumference = 2 * Math.PI * radius;
-  const offset = circumference - (percent / 100) * circumference;
-
-  return (
-    <div className="relative inline-flex items-center justify-center">
-      <svg className="h-16 w-16 -rotate-90" viewBox="0 0 64 64">
-        <circle
-          className="text-muted stroke-current"
-          cx="32"
-          cy="32"
-          fill="none"
-          r={radius}
-          stroke="currentColor"
-          strokeWidth="5"
-        />
-        <circle
-          className="text-primary stroke-current transition-all duration-500 ease-out"
-          cx="32"
-          cy="32"
-          fill="none"
-          r={radius}
-          stroke="currentColor"
-          strokeDasharray={circumference}
-          strokeDashoffset={offset}
-          strokeLinecap="round"
-          strokeWidth="5"
-        />
-      </svg>
-      <span className="absolute text-sm font-semibold">{percent}%</span>
-    </div>
-  );
-}
 
 function formatDate(value: string) {
   const date = new Date(value);
@@ -53,13 +21,9 @@ function formatDate(value: string) {
   return date.toLocaleDateString();
 }
 
-function activityIcon(
-  entry: LessonActivity,
-): { icon: string; label: string } {
-  if (entry.score !== null) {
-    return { icon: "📝", label: `Quiz: ${entry.score}%` };
-  }
-  return { icon: "✅", label: "Lesson completed" };
+function activityLabel(entry: LessonActivity) {
+  if (entry.score !== null) return { label: `Quiz: ${entry.score}%`, kind: "quiz" as const };
+  return { label: "Lesson completed", kind: "lesson" as const };
 }
 
 export default async function DashboardPage() {
@@ -77,84 +41,168 @@ export default async function DashboardPage() {
         new Date(a.lastActivityAt ?? 0).getTime(),
     );
 
-  const totalCompleted = progress.reduce(
-    (sum, c) => sum + c.completedLessons,
-    0,
-  );
+  const totalCompleted = progress.reduce((sum, c) => sum + c.completedLessons, 0);
   const totalLessons = progress.reduce((sum, c) => sum + c.totalLessons, 0);
+  const top = inProgress[0];
 
   if (progress.length === 0) {
     return (
       <div className="space-y-6">
-        <h1 className="text-2xl font-semibold">Dashboard</h1>
-        <Card>
-          <CardContent className="flex flex-col items-center gap-4 py-12">
-            <p className="text-lg font-medium">
-              You are not enrolled in any courses yet.
-            </p>
-            <p className="text-sm text-muted-foreground">
-              Ask your parish admin to enroll you to get started.
-            </p>
-          </CardContent>
+        <h1 className="font-display text-[30px] font-bold tracking-tight">
+          Dashboard
+        </h1>
+        <Card className="px-6 py-12 text-center">
+          <p className="text-lg font-medium">
+            You are not enrolled in any courses yet.
+          </p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Ask your parish admin to enroll you to get started.
+          </p>
         </Card>
       </div>
     );
   }
 
   return (
-    <div className="space-y-6">
-      <header className="space-y-1">
-        <h1 className="text-2xl font-semibold">Dashboard</h1>
-        <p className="text-sm text-muted-foreground">
+    <div className="space-y-9">
+      <header>
+        <h1 className="font-display text-[30px] font-bold leading-tight tracking-tight">
+          Welcome back
+        </h1>
+        <p className="mt-1.5 text-[15px] text-muted-foreground">
           {totalCompleted} of {totalLessons} lessons completed across{" "}
           {progress.length} course{progress.length !== 1 ? "s" : ""}
         </p>
       </header>
 
-      {/* Continue where you left off */}
+      {/* Continue learning hero */}
+      {top && (
+        <Card className="grid overflow-hidden rounded-2xl grid-cols-1 sm:grid-cols-[280px_1fr]">
+          <Link
+            aria-label={`Resume ${top.lastLessonTitle ?? top.courseTitle}`}
+            className="relative block min-h-[180px] sm:min-h-[220px]"
+            href={`/app/lessons/${top.lastLessonId}`}
+          >
+            <CourseThumbnail
+              alt={top.courseTitle}
+              seed={top.courseId}
+              thumbnailUrl={top.thumbnailUrl}
+              className="absolute inset-0"
+            />
+          </Link>
+          <div className="flex flex-col justify-center gap-3.5 px-7 py-7">
+            <div className="inline-flex items-center gap-2 whitespace-nowrap text-[12px] font-bold uppercase tracking-widest text-gold">
+              <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="12" cy="12" r="9" />
+                <path d="m10 9 5 3-5 3V9Z" fill="currentColor" stroke="none" />
+              </svg>
+              Continue learning
+            </div>
+            <Link
+              className="font-display text-[26px] font-bold leading-tight tracking-tight hover:text-primary"
+              href={`/app/lessons/${top.lastLessonId}`}
+            >
+              {top.lastLessonTitle ?? "Resume next lesson"}
+            </Link>
+            <p className="m-0 text-[14.5px] text-muted-foreground">
+              {top.courseTitle}
+            </p>
+            <ProgressLine className="max-w-[360px]" percent={top.progressPercent} />
+            <div className="mt-1 flex flex-wrap items-center gap-4">
+              <Link
+                className="inline-flex items-center gap-2 rounded-[9px] bg-primary px-5 py-2.5 text-[15px] font-semibold text-primary-foreground transition-colors hover:bg-[var(--ds-color-brand-hover)]"
+                href={`/app/lessons/${top.lastLessonId}`}
+              >
+                Resume lesson
+                <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M5 12h14M13 6l6 6-6 6" />
+                </svg>
+              </Link>
+              <span className="text-[13px] text-muted-foreground">
+                {top.completedLessons}/{top.totalLessons} lessons complete
+              </span>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {/* Stat strip */}
+      <div className="flex flex-wrap gap-3.5">
+        <Stat
+          icon={
+            <svg viewBox="0 0 24 24" width="21" height="21" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m12 3 9 5-9 5-9-5 9-5Z" />
+              <path d="m3 13 9 5 9-5" />
+            </svg>
+          }
+          tone="brand"
+          num={totalCompleted}
+          label="Lessons completed"
+        />
+        <Stat
+          icon={
+            <svg viewBox="0 0 24 24" width="21" height="21" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M4 5a2 2 0 0 1 2-2h12v16H6a2 2 0 0 0-2 2V5Z" />
+              <path d="M18 17H6a2 2 0 0 0-2 2" />
+            </svg>
+          }
+          tone="gold"
+          num={progress.length}
+          label={`Active course${progress.length === 1 ? "" : "s"}`}
+        />
+        <Stat
+          icon={
+            <svg viewBox="0 0 24 24" width="21" height="21" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M12 3c1 3 4 4 4 8a4 4 0 0 1-8 0c0-1 .5-2 1-2.5C9 10 9 12 10 12c0-2 1-3 2-3 0-2-1-4 0-6Z" />
+            </svg>
+          }
+          tone="ok"
+          num={Math.max(0, totalLessons - totalCompleted)}
+          label="Lessons remaining"
+        />
+        <Stat
+          icon={
+            <svg viewBox="0 0 24 24" width="21" height="21" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="12" cy="9" r="6" />
+              <path d="M9 14l-1.5 7L12 19l4.5 2L15 14" />
+            </svg>
+          }
+          tone="gold"
+          num={progress.filter((c) => c.progressPercent === 100).length}
+          label="Courses complete"
+        />
+      </div>
+
+      {/* Pick up where you left off */}
       {inProgress.length > 0 && (
         <section>
-          <h2 className="mb-3 text-sm font-medium text-muted-foreground">
-            Continue where you left off
-          </h2>
-          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          <SectionHead title="Pick up where you left off" />
+          <div className="grid gap-4 grid-cols-1 lg:grid-cols-3">
             {inProgress.slice(0, 3).map((course) => (
               <Link
                 href={`/app/lessons/${course.lastLessonId}`}
                 key={`resume-${course.courseId}`}
-                className="min-w-0"
+                className="group min-w-0"
               >
-                <Card className="h-full overflow-hidden transition-colors hover:bg-secondary">
-                  <CardContent className="flex items-center gap-3 py-3">
-                    {/* Course thumbnail */}
-                    <div className="h-16 w-16 shrink-0 overflow-hidden rounded-md border bg-muted">
-                      {course.thumbnailUrl ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img
-                          alt={course.courseTitle}
-                          className="h-full w-full object-cover"
-                          src={course.thumbnailUrl}
-                        />
-                      ) : (
-                        <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-                          <svg className="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} />
-                          </svg>
-                        </div>
-                      )}
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <p className="truncate text-sm font-medium">
-                        {course.lastLessonTitle ?? "Resume"}
-                      </p>
-                      <p className="truncate text-xs text-muted-foreground">
-                        {course.courseTitle}
-                      </p>
-                    </div>
-                    <span className="shrink-0 text-xs font-medium text-primary">
-                      Resume →
-                    </span>
-                  </CardContent>
+                <Card className="flex items-center gap-3.5 p-3.5 transition-all duration-200 group-hover:-translate-y-0.5 group-hover:border-border-strong group-hover:shadow-md">
+                  <div className="h-[60px] w-[60px] shrink-0 overflow-hidden rounded-[10px]">
+                    <CourseThumbnail
+                      alt={course.courseTitle}
+                      seed={course.courseId}
+                      thumbnailUrl={course.thumbnailUrl}
+                    />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="line-clamp-1 text-[14.5px] font-semibold leading-tight">
+                      {course.lastLessonTitle ?? "Resume"}
+                    </p>
+                    <p className="mt-0.5 truncate text-[12.5px] text-muted-foreground">
+                      {course.courseTitle}
+                    </p>
+                  </div>
+                  <span className="shrink-0 whitespace-nowrap text-[13px] font-semibold text-primary">
+                    Resume →
+                  </span>
                 </Card>
               </Link>
             ))}
@@ -162,59 +210,43 @@ export default async function DashboardPage() {
         </section>
       )}
 
-      {/* Course progress */}
+      {/* Your courses */}
       <section>
-        <div className="mb-3 flex items-center justify-between">
-          <h2 className="text-sm font-medium text-muted-foreground">
-            Your courses
-          </h2>
-          <Link
-            className="text-xs font-medium text-primary hover:underline"
-            href="/app/courses"
-          >
-            View all
-          </Link>
-        </div>
-        <div className="grid gap-3 sm:grid-cols-1 lg:grid-cols-2">
+        <SectionHead
+          title="Your courses"
+          link={{ href: "/app/courses", label: "View all" }}
+        />
+        <div className="grid gap-5 grid-cols-1 lg:grid-cols-2">
           {progress.map((course) => (
             <Link
               href={`/app/courses/${course.courseId}`}
               key={course.courseId}
-              className="min-w-0"
+              className="group min-w-0"
             >
-              <Card className="h-full overflow-hidden transition-colors hover:bg-secondary">
-                <CardContent className="flex items-center gap-4 py-4">
-                  {/* Thumbnail */}
-                  <div className="h-20 w-20 shrink-0 overflow-hidden rounded-md border bg-muted">
-                    {course.thumbnailUrl ? (
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img
-                        alt={course.courseTitle}
-                        className="h-full w-full object-cover"
-                        src={course.thumbnailUrl}
-                      />
-                    ) : (
-                      <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-                        <svg className="h-10 w-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} />
-                        </svg>
-                      </div>
-                    )}
-                  </div>
-                  <ProgressRing percent={course.progressPercent} />
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate font-medium">{course.courseTitle}</p>
-                    {course.courseDescription && (
-                      <p className="truncate text-xs text-muted-foreground">
-                        {course.courseDescription}
-                      </p>
-                    )}
-                    <p className="mt-1 text-xs text-muted-foreground">
-                      {course.completedLessons}/{course.totalLessons} lessons
-                      complete
+              <Card className="flex items-center gap-4 p-4 transition-all duration-200 group-hover:-translate-y-0.5 group-hover:border-border-strong group-hover:shadow-md">
+                <div className="h-[88px] w-[88px] shrink-0 overflow-hidden rounded-xl">
+                  <CourseThumbnail
+                    alt={course.courseTitle}
+                    seed={course.courseId}
+                    thumbnailUrl={course.thumbnailUrl}
+                  />
+                </div>
+                <ProgressRing percent={course.progressPercent} />
+                <div className="min-w-0 flex-1">
+                  <p className="font-display text-[16px] font-bold leading-tight">
+                    {course.courseTitle}
+                  </p>
+                  {course.courseDescription && (
+                    <p className="mt-1 line-clamp-1 text-[13px] text-muted-foreground">
+                      {course.courseDescription}
                     </p>
-                  </div>
-                </CardContent>
+                  )}
+                  <MetaRow
+                    className="mt-2.5"
+                    lessons={course.totalLessons}
+                    duration={placeholderDuration(course.totalLessons)}
+                  />
+                </div>
               </Card>
             </Link>
           ))}
@@ -224,44 +256,106 @@ export default async function DashboardPage() {
       {/* Recent activity */}
       {recentActivity.length > 0 && (
         <section>
-          <h2 className="mb-3 text-sm font-medium text-muted-foreground">
-            Recent activity
-          </h2>
-          <Card>
-            <CardContent className="py-2">
-              <ul className="divide-y divide-border">
-                {recentActivity.map((entry, index) => {
-                  const { icon, label } = activityIcon(entry);
-                  return (
-                    <li
-                      className="flex items-center gap-3 py-2.5"
-                      key={`${entry.lessonId}-${entry.activityAt}-${index}`}
+          <SectionHead title="Recent activity" />
+          <Card className="px-5 py-1">
+            <ul>
+              {recentActivity.map((entry, index) => {
+                const { label, kind } = activityLabel(entry);
+                return (
+                  <li
+                    className="flex items-center gap-3.5 border-b border-border py-3.5 last:border-0"
+                    key={`${entry.lessonId}-${entry.activityAt}-${index}`}
+                  >
+                    <div
+                      className={
+                        "grid h-[22px] w-[22px] shrink-0 place-items-center rounded-full " +
+                        (kind === "quiz"
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-success text-success-foreground")
+                      }
                     >
-                      <span className="text-lg">{icon}</span>
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm font-medium">
-                          {entry.lessonTitle}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {entry.courseTitle} · {label}
-                        </p>
-                      </div>
-                      <span className="shrink-0 text-xs text-muted-foreground">
-                        {formatDate(entry.activityAt)}
-                      </span>
-                    </li>
-                  );
-                })}
-              </ul>
-            </CardContent>
+                      {kind === "quiz" ? (
+                        <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <circle cx="12" cy="9" r="6" />
+                          <path d="M9 14l-1.5 7L12 19l4.5 2L15 14" />
+                        </svg>
+                      ) : (
+                        <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="m20 6-11 11-5-5" />
+                        </svg>
+                      )}
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-[14.5px] font-semibold">
+                        {entry.lessonTitle}
+                      </p>
+                      <p className="text-[12.5px] text-muted-foreground">
+                        {entry.courseTitle} · {label}
+                      </p>
+                    </div>
+                    <span className="shrink-0 text-[12.5px] text-muted-foreground">
+                      {formatDate(entry.activityAt)}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
           </Card>
         </section>
       )}
+    </div>
+  );
+}
 
-      <div className="flex justify-end">
-        <Button asChild variant="outline">
-          <Link href="/app/courses">View all courses</Link>
-        </Button>
+function SectionHead({
+  title,
+  link,
+}: {
+  title: string;
+  link?: { href: string; label: string };
+}) {
+  return (
+    <div className="mb-4 flex items-baseline justify-between">
+      <h2 className="whitespace-nowrap text-[13px] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+        {title}
+      </h2>
+      {link && (
+        <Link
+          className="whitespace-nowrap text-[13px] font-semibold text-primary hover:underline"
+          href={link.href}
+        >
+          {link.label}
+        </Link>
+      )}
+    </div>
+  );
+}
+
+function Stat({
+  icon,
+  tone,
+  num,
+  label,
+}: {
+  icon: React.ReactNode;
+  tone: "brand" | "gold" | "ok";
+  num: number;
+  label: string;
+}) {
+  const toneClass =
+    tone === "brand"
+      ? "bg-brand-subtle text-primary"
+      : tone === "gold"
+        ? "bg-gold-subtle text-gold"
+        : "bg-success-subtle text-success";
+  return (
+    <div className="flex min-w-[160px] flex-1 items-center gap-3.5 rounded-[13px] border border-border bg-card px-5 py-4">
+      <div className={"grid h-[42px] w-[42px] shrink-0 place-items-center rounded-[11px] " + toneClass}>
+        {icon}
+      </div>
+      <div>
+        <div className="font-display text-[22px] font-bold leading-none">{num}</div>
+        <div className="mt-1 text-[12.5px] text-muted-foreground">{label}</div>
       </div>
     </div>
   );

--- a/src/app/app/layout.tsx
+++ b/src/app/app/layout.tsx
@@ -71,7 +71,7 @@ export default async function AppLayout({
         showUserButton={showUserButton}
         activeParishId={activeParishId}
       />
-      <main className="mx-auto max-w-6xl px-6 py-7">{children}</main>
+      <main className="mx-auto max-w-[1240px] px-7 py-9">{children}</main>
       <HelpPanel />
     </div>
   );

--- a/src/components/app-header-client.tsx
+++ b/src/components/app-header-client.tsx
@@ -32,7 +32,7 @@ export function AppHeaderClient({
 
   return (
     <header className="sticky top-0 z-50 border-b border-nav-border bg-nav-bg shadow-sm transition-colors duration-250">
-      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 h-[52px]">
+      <div className="mx-auto flex max-w-[1240px] items-center justify-between px-7 h-[52px]">
         {/* Logo */}
         <div className="flex items-center gap-2">
           <div className="flex h-[26px] w-[26px] items-center justify-center rounded-[5px] bg-primary">

--- a/src/components/learning/emblem.tsx
+++ b/src/components/learning/emblem.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type EmblemKind = "rays" | "cross" | "book" | "candle";
+
+interface Palette {
+  a: string;
+  b: string;
+  glow: string;
+  glyph: EmblemKind;
+}
+
+const PALETTES: Palette[] = [
+  { a: "oklch(34% 0.13 18)", b: "oklch(18% 0.07 25)", glow: "oklch(62% 0.15 70)", glyph: "rays" },
+  { a: "oklch(30% 0.05 250)", b: "oklch(17% 0.04 260)", glow: "oklch(58% 0.12 75)", glyph: "cross" },
+  { a: "oklch(40% 0.09 55)", b: "oklch(22% 0.06 45)", glow: "oklch(66% 0.13 78)", glyph: "book" },
+  { a: "oklch(33% 0.1 28)", b: "oklch(19% 0.06 30)", glow: "oklch(60% 0.14 68)", glyph: "candle" },
+];
+
+function paletteFor(seed: string): Palette {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0;
+  return PALETTES[h % PALETTES.length];
+}
+
+function Glyph({ kind }: { kind: EmblemKind }) {
+  const stroke = "oklch(82% 0.11 78)";
+  if (kind === "cross") {
+    return (
+      <svg viewBox="0 0 40 40" className="emblem-glyph">
+        <rect x="17" y="6" width="6" height="28" rx="1.5" fill={stroke} />
+        <rect x="9" y="14" width="22" height="6" rx="1.5" fill={stroke} />
+      </svg>
+    );
+  }
+  if (kind === "book") {
+    return (
+      <svg viewBox="0 0 40 40" className="emblem-glyph" fill="none" stroke={stroke} strokeWidth="2.2" strokeLinejoin="round">
+        <path d="M20 11c-3-2-7-2-10-1v19c3-1 7-1 10 1 3-2 7-2 10-1V10c-3-1-7-1-10 1Z" />
+        <path d="M20 11v18" />
+      </svg>
+    );
+  }
+  if (kind === "candle") {
+    return (
+      <svg viewBox="0 0 40 40" className="emblem-glyph">
+        <rect x="17" y="16" width="6" height="18" rx="1.5" fill={stroke} />
+        <path d="M20 6c2 3 3 4 3 6a3 3 0 0 1-6 0c0-2 1-3 3-6Z" fill={stroke} />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 40 40" className="emblem-glyph">
+      <circle cx="20" cy="20" r="6" fill={stroke} />
+      {Array.from({ length: 12 }).map((_, i) => {
+        const a = (i * 30 * Math.PI) / 180;
+        const x1 = 20 + 10 * Math.cos(a);
+        const y1 = 20 + 10 * Math.sin(a);
+        const x2 = 20 + 15 * Math.cos(a);
+        const y2 = 20 + 15 * Math.sin(a);
+        return <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke={stroke} strokeWidth="2" strokeLinecap="round" />;
+      })}
+    </svg>
+  );
+}
+
+export function Emblem({
+  seed,
+  className,
+}: {
+  seed: string;
+  className?: string;
+}) {
+  const p = paletteFor(seed);
+  const style: React.CSSProperties = {
+    background: `radial-gradient(120% 90% at 50% 18%, ${p.glow} 0%, transparent 55%), linear-gradient(160deg, ${p.a} 0%, ${p.b} 100%)`,
+  };
+  return (
+    <div className={cn("relative grid h-full w-full place-items-center overflow-hidden", className)} style={style}>
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-[9%] rounded-full"
+        style={{
+          border: "1.5px solid oklch(78% 0.11 75 / 0.32)",
+          WebkitMask: "radial-gradient(circle, transparent 62%, #000 63%)",
+          mask: "radial-gradient(circle, transparent 62%, #000 63%)",
+        }}
+      />
+      <Glyph kind={p.glyph} />
+    </div>
+  );
+}
+
+export function CourseThumbnail({
+  seed,
+  thumbnailUrl,
+  alt,
+  className,
+}: {
+  seed: string;
+  thumbnailUrl?: string | null;
+  alt: string;
+  className?: string;
+}) {
+  if (thumbnailUrl) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        alt={alt}
+        src={thumbnailUrl}
+        className={cn("h-full w-full object-cover", className)}
+      />
+    );
+  }
+  return <Emblem seed={seed} className={className} />;
+}

--- a/src/components/learning/emblem.tsx
+++ b/src/components/learning/emblem.tsx
@@ -17,6 +17,7 @@ const PALETTES: Palette[] = [
   { a: "oklch(40% 0.09 55)", b: "oklch(22% 0.06 45)", glow: "oklch(66% 0.13 78)", glyph: "book" },
   { a: "oklch(33% 0.1 28)", b: "oklch(19% 0.06 30)", glow: "oklch(60% 0.14 68)", glyph: "candle" },
 ];
+const GLYPH_CLASS_NAME = "emblem-glyph h-auto max-h-[62%] max-w-[62%]";
 
 function paletteFor(seed: string): Palette {
   let h = 0;
@@ -28,7 +29,7 @@ function Glyph({ kind }: { kind: EmblemKind }) {
   const stroke = "oklch(82% 0.11 78)";
   if (kind === "cross") {
     return (
-      <svg viewBox="0 0 40 40" className="emblem-glyph">
+      <svg viewBox="0 0 40 40" width="48" height="48" className={GLYPH_CLASS_NAME}>
         <rect x="17" y="6" width="6" height="28" rx="1.5" fill={stroke} />
         <rect x="9" y="14" width="22" height="6" rx="1.5" fill={stroke} />
       </svg>
@@ -36,7 +37,7 @@ function Glyph({ kind }: { kind: EmblemKind }) {
   }
   if (kind === "book") {
     return (
-      <svg viewBox="0 0 40 40" className="emblem-glyph" fill="none" stroke={stroke} strokeWidth="2.2" strokeLinejoin="round">
+      <svg viewBox="0 0 40 40" width="48" height="48" className={GLYPH_CLASS_NAME} fill="none" stroke={stroke} strokeWidth="2.2" strokeLinejoin="round">
         <path d="M20 11c-3-2-7-2-10-1v19c3-1 7-1 10 1 3-2 7-2 10-1V10c-3-1-7-1-10 1Z" />
         <path d="M20 11v18" />
       </svg>
@@ -44,14 +45,14 @@ function Glyph({ kind }: { kind: EmblemKind }) {
   }
   if (kind === "candle") {
     return (
-      <svg viewBox="0 0 40 40" className="emblem-glyph">
+      <svg viewBox="0 0 40 40" width="48" height="48" className={GLYPH_CLASS_NAME}>
         <rect x="17" y="16" width="6" height="18" rx="1.5" fill={stroke} />
         <path d="M20 6c2 3 3 4 3 6a3 3 0 0 1-6 0c0-2 1-3 3-6Z" fill={stroke} />
       </svg>
     );
   }
   return (
-    <svg viewBox="0 0 40 40" className="emblem-glyph">
+    <svg viewBox="0 0 40 40" width="48" height="48" className={GLYPH_CLASS_NAME}>
       <circle cx="20" cy="20" r="6" fill={stroke} />
       {Array.from({ length: 12 }).map((_, i) => {
         const a = (i * 30 * Math.PI) / 180;

--- a/src/components/learning/meta-row.tsx
+++ b/src/components/learning/meta-row.tsx
@@ -1,0 +1,54 @@
+import { cn } from "@/lib/utils";
+
+interface MetaRowProps {
+  lessons: number;
+  duration?: string | null;
+  instructor?: string | null;
+  className?: string;
+}
+
+export function MetaRow({ lessons, duration, instructor, className }: MetaRowProps) {
+  return (
+    <div className={cn("flex flex-wrap items-center gap-3.5 text-[12.5px] text-muted-foreground", className)}>
+      <span className="inline-flex items-center gap-1.5">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" className="opacity-85">
+          <path d="m12 3 9 5-9 5-9-5 9-5Z" />
+          <path d="m3 13 9 5 9-5" />
+        </svg>
+        {lessons} lesson{lessons === 1 ? "" : "s"}
+      </span>
+      {duration && (
+        <>
+          <span className="h-[3px] w-[3px] rounded-full bg-muted-foreground/50" />
+          <span className="inline-flex items-center gap-1.5">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" className="opacity-85">
+              <circle cx="12" cy="12" r="9" />
+              <path d="M12 7v5l3 2" />
+            </svg>
+            {duration}
+          </span>
+        </>
+      )}
+      {instructor && (
+        <>
+          <span className="h-[3px] w-[3px] rounded-full bg-muted-foreground/50" />
+          <span className="inline-flex items-center gap-1.5">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round" className="opacity-85">
+              <circle cx="12" cy="8" r="4" />
+              <path d="M4 20a8 8 0 0 1 16 0" />
+            </svg>
+            {instructor}
+          </span>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function CategoryChip({ category }: { category: string }) {
+  return (
+    <span className="inline-flex items-center rounded-full border border-border bg-card px-2.5 py-[3px] text-[11px] font-semibold text-muted-foreground">
+      {category}
+    </span>
+  );
+}

--- a/src/components/learning/placeholders.ts
+++ b/src/components/learning/placeholders.ts
@@ -1,0 +1,24 @@
+/**
+ * Hard-coded placeholders for fields not yet in the schema.
+ * Tracked for backfill in GH issue (instructor, duration, category, streak, certificates).
+ */
+
+const CATEGORIES = ["Scripture", "Catechesis", "Leadership", "Seasonal"] as const;
+
+function hashSeed(seed: string): number {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+export function placeholderCategory(courseId: string): string {
+  return CATEGORIES[hashSeed(courseId) % CATEGORIES.length];
+}
+
+export function placeholderDuration(lessonCount: number): string {
+  if (lessonCount <= 0) return "—";
+  const hours = Math.max(1, Math.round(lessonCount * 0.25));
+  return `≈${hours}h`;
+}
+
+export const CATEGORY_LIST: readonly string[] = ["All", ...CATEGORIES];

--- a/src/components/learning/progress-line.tsx
+++ b/src/components/learning/progress-line.tsx
@@ -1,0 +1,76 @@
+import { cn } from "@/lib/utils";
+
+export function ProgressLine({
+  percent,
+  showPercent = true,
+  className,
+}: {
+  percent: number;
+  showPercent?: boolean;
+  className?: string;
+}) {
+  const clamped = Math.min(100, Math.max(0, percent));
+  return (
+    <div className={cn("flex items-center gap-2.5 text-[12.5px] text-muted-foreground", className)}>
+      <div className="h-[7px] flex-1 overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full transition-[width] duration-500 ease-out"
+          style={{
+            width: `${clamped}%`,
+            background: "linear-gradient(90deg, var(--ds-color-brand-primary), var(--ds-color-brand-muted))",
+          }}
+        />
+      </div>
+      {showPercent && (
+        <span className="min-w-[34px] text-right font-semibold text-foreground/70">
+          {clamped}%
+        </span>
+      )}
+    </div>
+  );
+}
+
+export function ProgressRing({
+  percent,
+  size = 56,
+}: {
+  percent: number;
+  size?: number;
+}) {
+  const r = (size - 10) / 2;
+  const c = 2 * Math.PI * r;
+  const clamped = Math.min(100, Math.max(0, percent));
+  const off = c - (clamped / 100) * c;
+  return (
+    <div
+      className="relative grid shrink-0 place-items-center"
+      style={{ width: size, height: size }}
+    >
+      <svg width={size} height={size} style={{ transform: "rotate(-90deg)" }}>
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke="var(--ds-color-bg-muted)"
+          strokeWidth="5"
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={r}
+          fill="none"
+          stroke="var(--ds-color-brand-primary)"
+          strokeWidth="5"
+          strokeDasharray={c}
+          strokeDashoffset={off}
+          strokeLinecap="round"
+          style={{ transition: "stroke-dashoffset 0.6s ease" }}
+        />
+      </svg>
+      <span className="absolute font-display text-[14px] font-bold">
+        {clamped}%
+      </span>
+    </div>
+  );
+}

--- a/src/components/learning/scope-badge.tsx
+++ b/src/components/learning/scope-badge.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils";
+
+export function ScopeBadge({
+  scope,
+  onMedia = false,
+  className,
+}: {
+  scope: "DIOCESE" | "PARISH";
+  onMedia?: boolean;
+  className?: string;
+}) {
+  const isD = scope === "DIOCESE";
+  const base =
+    "inline-flex items-center whitespace-nowrap rounded-full px-2.5 py-[3px] text-[11.5px] font-semibold tracking-wide";
+  const palette = isD
+    ? onMedia
+      ? "bg-[oklch(96%_0.04_14_/_0.92)] text-[oklch(38%_0.175_14)] backdrop-blur-sm shadow-sm"
+      : "bg-tag-diocese-bg text-tag-diocese-text"
+    : onMedia
+      ? "bg-[oklch(100%_0_0_/_0.85)] text-[oklch(30%_0.03_245)] backdrop-blur-sm shadow-sm"
+      : "bg-tag-parish-bg text-tag-parish-text";
+
+  return (
+    <span className={cn(base, palette, className)}>
+      {isD ? "Diocese-wide" : "Parish"}
+    </span>
+  );
+}

--- a/src/lib/repositories/__tests__/dashboard.test.ts
+++ b/src/lib/repositories/__tests__/dashboard.test.ts
@@ -150,4 +150,62 @@ describe("getStudentDashboardData", () => {
     expect(modulesInSpy).toHaveBeenCalledWith("course_id", ["course-visible"]);
     expect(from).not.toHaveBeenCalledWith("courses");
   });
+
+  it("uses the first incomplete lesson as the resume target", async () => {
+    const from = vi.fn((table: string) => {
+      if (table === "enrollments") {
+        return enrollmentsMock([
+          {
+            course_id: "course-visible",
+            courses: {
+              id: "course-visible",
+              title: "Visible Course",
+              description: null,
+              thumbnail_url: null,
+            },
+          },
+        ]);
+      }
+      if (table === "modules") {
+        return modulesMock([
+          {
+            course_id: "course-visible",
+            lessons: [
+              { id: "lesson-complete", title: "Complete Lesson" },
+              { id: "lesson-next", title: "Next Lesson" },
+            ],
+          },
+        ]);
+      }
+      if (table === "video_progress") {
+        return videoProgressMock([
+          {
+            lesson_id: "lesson-complete",
+            completed: true,
+            last_position_seconds: 120,
+            updated_at: new Date().toISOString(),
+          },
+        ]);
+      }
+      if (table === "quiz_attempts") {
+        return quizAttemptsMock([]);
+      }
+      throw new Error(`Unexpected table ${table}`);
+    });
+    const rpc = vi.fn(async () => ({
+      data: [{ id: "course-visible" }],
+      error: null,
+    }));
+
+    vi.mocked(getSupabaseAdminClient).mockReturnValue({ from, rpc } as never);
+
+    const result = await getStudentDashboardData("parish-1", "user-1");
+
+    expect(result.progress[0]).toMatchObject({
+      completedLessons: 1,
+      progressPercent: 50,
+      resumeLessonId: "lesson-next",
+      resumeLessonTitle: "Next Lesson",
+    });
+  });
 });

--- a/src/lib/repositories/dashboard.ts
+++ b/src/lib/repositories/dashboard.ts
@@ -105,23 +105,26 @@ export async function getStudentDashboardData(
   const courseIds = enrolledCourses.map((c) => c.courseId);
   const { data: modulesData, error: modError } = await supabase
     .from("modules")
-    .select("id, course_id, lessons(id, title)")
+    .select("id, course_id, lessons(id, title, sort_order)")
     .in("course_id", courseIds)
     .order("sort_order", { ascending: true });
 
   if (modError) throw modError;
 
-  // Flatten lessons per course
+  // Flatten lessons per course in curriculum order
   const lessonsByCourse = new Map<string, Array<{ id: string; title: string }>>();
   for (const mod of (modulesData ?? []) as Array<{
     course_id: string;
-    lessons: Array<{ id: string; title: string }>;
+    lessons: Array<{ id: string; title: string; sort_order: number }>;
   }>) {
     if (!lessonsByCourse.has(mod.course_id)) {
       lessonsByCourse.set(mod.course_id, []);
     }
-    for (const lesson of mod.lessons ?? []) {
-      lessonsByCourse.get(mod.course_id)!.push(lesson);
+    const sortedLessons = [...(mod.lessons ?? [])].sort(
+      (a, b) => a.sort_order - b.sort_order,
+    );
+    for (const lesson of sortedLessons) {
+      lessonsByCourse.get(mod.course_id)!.push({ id: lesson.id, title: lesson.title });
     }
   }
 

--- a/src/lib/repositories/dashboard.ts
+++ b/src/lib/repositories/dashboard.ts
@@ -1,4 +1,4 @@
-import { E2E_COURSE } from "@/lib/e2e-fixtures";
+import { E2E_COURSE, E2E_LESSON } from "@/lib/e2e-fixtures";
 import { isE2ESmokeMode } from "@/lib/e2e-mode";
 import { getSupabaseAdminClient } from "@/lib/supabase/server";
 
@@ -12,6 +12,8 @@ export interface DashboardCourseProgress {
   progressPercent: number;
   lastLessonId: string | null;
   lastLessonTitle: string | null;
+  resumeLessonId: string | null;
+  resumeLessonTitle: string | null;
   lastPositionSeconds: number;
   lastActivityAt: string | null;
 }
@@ -48,6 +50,8 @@ export async function getStudentDashboardData(
           progressPercent: 0,
           lastLessonId: null,
           lastLessonTitle: null,
+          resumeLessonId: E2E_LESSON.id,
+          resumeLessonTitle: E2E_LESSON.title,
           lastPositionSeconds: 0,
           lastActivityAt: null,
         },
@@ -134,6 +138,8 @@ export async function getStudentDashboardData(
       progressPercent: 0,
       lastLessonId: null,
       lastLessonTitle: null,
+      resumeLessonId: null,
+      resumeLessonTitle: null,
       lastPositionSeconds: 0,
       lastActivityAt: null,
     };
@@ -182,6 +188,15 @@ export async function getStudentDashboardData(
           course.lastLessonTitle = lesson.title;
           course.lastPositionSeconds = p.last_position_seconds;
         }
+      }
+    }
+
+    for (const lesson of lessons) {
+      const p = progressByLesson.get(lesson.id);
+      if (!p?.completed) {
+        course.resumeLessonId = lesson.id;
+        course.resumeLessonTitle = lesson.title;
+        break;
       }
     }
 


### PR DESCRIPTION
## Summary
Implements the four-page learner redesign (Dashboard, Catalog, My Courses, Course Detail) from the Claude Design handoff. Built on the existing design tokens — no token changes required.

- **Dashboard** — Continue-Learning hero (16:9 art + lesson title + inline progress), stat strip, "Pick up where you left off" cards, courses grid with progress ring, redesigned recent-activity list.
- **Catalog** — image-led hero cards (16:9 art with floating scope badge), search + category chips filter, 3-up grid.
- **My Courses** — dense rows with badges, inline progress, and Resume/Start button. Pulls per-course progress from `getStudentDashboardData`.
- **Course Detail** — hero with 1:1 thumbnail, resume action + inline progress, module cards with numbered lesson rows + status dots + thumbnails, sticky "Course details" sidebar.
- **Layout** — widens header + main from `max-w-6xl` to `max-w-[1240px]`.
- **Shared components** in `src/components/learning/`: `Emblem`/`CourseThumbnail` (deterministic gradient + glyph fallback when `thumbnailUrl` is null), `ScopeBadge`, `ProgressLine` + `ProgressRing`, `MetaRow` + `CategoryChip`, `placeholders.ts`.

Fields not in the schema yet (`category`, `duration`, `instructor`, day streak, certificate count) are filled by helpers in `placeholders.ts`. Schema work tracked in #54 — when those columns land, swap the helper calls for real data and delete the file.

## Test plan
- [x] `npx tsc --noEmit` — no new errors (pre-existing unrelated failures only)
- [x] `npx vitest run` — 473/473 unit tests pass; the one failing file is the pre-existing `@react-pdf/renderer` missing-dep issue on `certificates/[certId]/pdf`
- [x] `npx eslint` on changed files — clean
- [ ] Smoke test `/app/dashboard`, `/app/catalog`, `/app/courses`, `/app/courses/[id]` in light + dark
- [ ] Verify emblem fallback renders for courses without `thumbnailUrl`
- [ ] Confirm category-filter chips on `/app/catalog` round-trip via URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly presentation and navigation; the main behavioral change is resume targeting via dashboard data, covered by new unit tests.
> 
> **Overview**
> Redesigns the student **Dashboard**, **Catalog**, **My Courses**, and **Course detail** experiences to match the WD Learning handoff: wider app shell (`max-w-[1240px]`), shared `src/components/learning/*` UI (emblem thumbnails, scope badges, progress bars/rings, meta rows), and placeholder **category** / **duration** until schema work lands.
> 
> **Catalog** gains URL-driven **search + category chips**, image-led cards, and clearer empty states; tests cover category filtering and updated CTAs (`Open` vs in-page anchors for non-enrolled courses).
> 
> **My Courses** now lists enrolled courses with per-row progress and **Resume/Start** deep links; data comes from `getStudentDashboardData` plus visible-course scope, not the old enrolled-only list.
> 
> **Dashboard** adds a continue-learning hero, stat strip, and resume cards keyed off new **`resumeLessonId` / `resumeLessonTitle`** (first incomplete lesson in curriculum order, with `sort_order` respected in the repository).
> 
> **Course detail** is a hero + module lesson list with status dots and a sticky details sidebar (certificate button disabled for now).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e3eae71510043f11c19a561bd72fd99ae2e1b91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->